### PR TITLE
Add ability to create parse rules for specific files

### DIFF
--- a/polymod/format/ParseRules.hx
+++ b/polymod/format/ParseRules.hx
@@ -70,6 +70,11 @@ class ParseRules
         formats.set(extension, format);
     }
 
+    public function addFile(path:String, format:BaseParseFormat) 
+    {
+        formats.set(path, format);
+    }
+
     public static function getDefault():ParseRules
     {
         var rules = new ParseRules();

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -79,7 +79,13 @@ class Util
         var extension = uExtension(id, true);
         id = stripAssetsPrefix(id);
         var mergeFile = "_merge" + sl() + id;
-        var format:BaseParseFormat = parseRules.get(extension);
+        // try the path first
+        var format:BaseParseFormat = parseRules.get(id);
+        if(format == null) 
+        {
+            // try the extension then
+            format = parseRules.get(extension);
+        }
         if(format != null)
         {
             var mergeText = getModText(mergeFile, theDir);
@@ -97,7 +103,13 @@ class Util
     {
         var extension = uExtension(id, true);
         id = stripAssetsPrefix(id);
-        var format:BaseParseFormat = parseRules.get(extension);
+        // try the path first
+        var format:BaseParseFormat = parseRules.get(id);
+        if(format == null) 
+        {
+            // try the extension then
+            format = parseRules.get(extension);
+        }
         if(format != null)
         {
             var appendText = getModText(Util.pathJoin("_append",id), theDir);


### PR DESCRIPTION
This way, you can add specific rules for specific files like:
```haxe
		var specificRule:CSVParseFormat = new CSVParseFormat(";", false);
		parseRules.addFile("data/myspecificfile.csv", specificRule);
```