### PR TITLE
Added PolymodAssets.getPath() and PolymodAssets.list()

### DIFF
--- a/polymod/backends/IBackend.hx
+++ b/polymod/backends/IBackend.hx
@@ -40,5 +40,8 @@ interface IBackend
     public function getBytes(id:String):Bytes;
     public function getText(id:String):String;
 
+    public function getPath(id:String):String;
+    public function list(type:PolymodAssetType=null):Array<String>;
+
     public function stripAssetsPrefix(id:String):String;
 }

--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -122,6 +122,16 @@ class LimeBackend implements IBackend
         return modLibrary.getText(id);
     }
 
+    public function getPath(id:String):String
+    {
+        return modLibrary.getPath(id);
+    }
+
+    public function list(type:PolymodAssetType=null):Array<String>
+    {
+        return modLibrary.list(type);
+    }
+
     public function clearCache()
     {
         if (defaultAssetLibrary != null)

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -136,6 +136,9 @@ class PolymodAssetLibrary
     public function exists (id:String):Bool { return backend.exists(id); }
     public function getText (id:String):String { return backend.getText(id); }
     public function getBytes (id:String):Bytes { return backend.getBytes(id); }
+    public function getPath(id:String):String { return backend.getPath(id); }
+
+    public function list(type:PolymodAssetType=null):Array<String> { return backend.list(type); }
 
     public function listModFiles (type:PolymodAssetType=null):Array<String>
     {

--- a/polymod/backends/PolymodAssets.hx
+++ b/polymod/backends/PolymodAssets.hx
@@ -126,6 +126,9 @@ class PolymodAssets
     public static function exists(id:String):Bool { return library.exists(id); }
     public static function getBytes(id:String):Bytes { return library.getBytes(id); }
     public static function getText(id:String):String { return library.getText(id); }
+    public static function getPath(id:String):String { return library.getPath(id); }
+
+    public static function list(type:PolymodAssetType=null):Array<String> { return library.list(type); }
 
     /**PRIVATE STATIC**/
 

--- a/polymod/backends/StubBackend.hx
+++ b/polymod/backends/StubBackend.hx
@@ -41,5 +41,8 @@ class StubBackend implements IBackend
     public function getBytes(id:String):Bytes { return null; }
     public function getText(id:String):String { return null; }
 
+    public function getPath(id:String):String { return null; }
+    public function list(type:PolymodAssetType=null):Array<String> { return []; }
+
     public function stripAssetsPrefix(id:String):String { return id; }
 }


### PR DESCRIPTION
Only implemented in Lime/OpenFL. Other backends will get null and an empty array respectively.