### PR TITLE
Adds mod support for OpenFL HTML5 apps using Node/Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# OpenFL With Node for Polymod
+A fork of larsiusprime's Polymod code that adds modding support for OpenFL applications wrapped with Electron (or, really, using Node).
+
+To use this, you need to do the following:
+- Enable the Node file system by including the compiler flag "nodefs" in your project (if you do this in the project.xml, best to add this flag before including the polymod library).
+- Specify Framework.OPENFL_WITH_NODE as your framework.
+
+Doing so will enable your mods for unembedded assets.
+
+If you want to also allow mods for assets that are embedded (loaded when the application initially starts up), you should listen for the OpenFLWithNodeBackend.FINISHED_PRELOADING_ASSETS event to be dispatched from OpenFLWithNodeBackend.dispatcher first before fully firing up your app.
+
 # Polymod
 An atomic modding framework for Haxe games/apps.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A fork of larsiusprime's Polymod code that adds modding support for OpenFL appli
 
 To use this, you need to do the following:
 - Enable the Node file system by including the compiler flag "nodefs" in your project (if you do this in the project.xml, best to add this flag before including the polymod library).
-- Specify Framework.OPENFL_WITH_NODE as your framework.
+- Specify Framework.OPENFL_WITH_NODE as your framework with you call PolyMod.init(...).
 
 Doing so will enable your mods for unembedded assets.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A fork of larsiusprime's Polymod code that adds modding support for OpenFL appli
 
 To use this, you need to do the following:
 - Enable the Node file system by including the compiler flag `nodefs` in your project (if you do this in the project.xml, best to add this flag before including the polymod library).
-- Specify `Framework.OPENFL_WITH_NODE` as your framework with you call PolyMod.init(...).
+- Specify `Framework.OPENFL_WITH_NODE` as your framework with you call `PolyMod.init(...)`.
 
 Doing so will enable your mods for unembedded assets.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A fork of larsiusprime's Polymod code that adds modding support for OpenFL HTML5
 To use this, you need to do the following:
 - Enable the Node file system by including the compiler flag `nodefs` in your project (if you do this in the project.xml, best to add this flag before including the polymod library).
 - Specify `Framework.OPENFL_WITH_NODE` as your framework with you call `PolyMod.init(...)`.
+- In your Electron app's main JavaScript file, make sure to add `nodeIntegration: true` and `contextIsolation: false` in the `webPreferences` like so:
+```const win = new BrowserWindow({
+  width: 1600,
+  height: 900,
+  useContentSize: true,
+  webPreferences: {
+    nodeIntegration: true, // required for file system access
+    contextIsolation: false // required for file system access
+  }
+})```
 
 Doing so will enable your mods for unembedded assets.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ To use this, you need to do the following:
     nodeIntegration: true, // required for file system access
     contextIsolation: false // required for file system access
   }
-})```
+})
+```
 
 Doing so will enable your mods for unembedded assets.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OpenFL With Node for Polymod
-A fork of larsiusprime's Polymod code that adds modding support for OpenFL applications wrapped with Electron (or, really, using Node).
+A fork of larsiusprime's Polymod code that adds modding support for OpenFL HTML5 applications wrapped with Electron (or, really, just using Node).
 
 To use this, you need to do the following:
 - Enable the Node file system by including the compiler flag `nodefs` in your project (if you do this in the project.xml, best to add this flag before including the polymod library).

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 A fork of larsiusprime's Polymod code that adds modding support for OpenFL applications wrapped with Electron (or, really, using Node).
 
 To use this, you need to do the following:
-- Enable the Node file system by including the compiler flag "nodefs" in your project (if you do this in the project.xml, best to add this flag before including the polymod library).
-- Specify Framework.OPENFL_WITH_NODE as your framework with you call PolyMod.init(...).
+- Enable the Node file system by including the compiler flag `nodefs` in your project (if you do this in the project.xml, best to add this flag before including the polymod library).
+- Specify `Framework.OPENFL_WITH_NODE` as your framework with you call PolyMod.init(...).
 
 Doing so will enable your mods for unembedded assets.
 
-If you want to also allow mods for assets that are embedded (loaded when the application initially starts up), you should listen for the OpenFLWithNodeBackend.FINISHED_PRELOADING_ASSETS event to be dispatched from OpenFLWithNodeBackend.dispatcher first before fully firing up your app.
+If you want to also allow mods for assets that are embedded (loaded when the application initially starts up), you should listen for the `OpenFLWithNodeBackend.FINISHED_PRELOADING_ASSETS` event to be dispatched from `OpenFLWithNodeBackend.dispatcher` first before fully firing up your app.
 
 # Polymod
 An atomic modding framework for Haxe games/apps.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ To use this, you need to do the following:
 - Enable the Node file system by including the compiler flag `nodefs` in your project (if you do this in the project.xml, best to add this flag before including the polymod library).
 - Specify `Framework.OPENFL_WITH_NODE` as your framework with you call `PolyMod.init(...)`.
 - In your Electron app's main JavaScript file, make sure to add `nodeIntegration: true` and `contextIsolation: false` in the `webPreferences` like so:
-```const win = new BrowserWindow({
+```JavaScript
+const win = new BrowserWindow({
   width: 1600,
   height: 900,
   useContentSize: true,

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -96,7 +96,7 @@ enum Framework
     NME;
     LIME;
     OPENFL;
-	OPENFL_WITH_NODE;
+    OPENFL_WITH_NODE;
     HEAPS;
     KHA;
     CUSTOM;

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -96,6 +96,7 @@ enum Framework
     NME;
     LIME;
     OPENFL;
+	OPENFL_WITH_NODE;
     HEAPS;
     KHA;
     CUSTOM;

--- a/polymod/backends/OpenFLWithNodeBackend.hx
+++ b/polymod/backends/OpenFLWithNodeBackend.hx
@@ -1,0 +1,325 @@
+package polymod.backends;
+import lime.graphics.Image;
+import lime.media.AudioBuffer;
+import lime.text.Font;
+import lime.utils.AssetType;
+import lime.utils.Assets;
+import openfl.events.Event;
+import openfl.events.EventDispatcher;
+import polymod.backends.LimeBackend.LimeModLibrary;
+
+/**
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * This class is so mods can be loaded by OpenFL applications running in Electron/Node.
+ * IMPORTANT:
+ * In order for this to work, you need to configure the BrowserWindow's webPreference
+ * for your node application to have 'nodeIntegration' to 'true' and 'contextIsolation' set to 'false'
+ * Otherwise, you will not get access to the file system
+ * 
+ * For example:
+ * const { app, BrowserWindow } = require('electron')
+ * function createWindow () {
+ *  const win = new BrowserWindow({
+ *    width: 1600,
+ *    height: 900,
+ *	// frame: false,
+ *	useContentSize: true,
+ *    webPreferences: { // !!! THE IMPORTANT PART
+ *	    nodeIntegration: true, // required for file system access
+ *      contextIsolation: false // required for file system access
+ *    }
+ *  })
+ *}
+ * 
+ */
+
+/**
+ * @author Tamar Curry
+ */
+#if (!openfl || nme)
+class OpenFLWithNodeBackend extends StubBackend
+{
+	/**
+	 * Event that is dispatched when all assets are finished preloading.
+	 */
+	public static inline var FINISHED_PRELOADING_ASSETS:String = "OpenFLWithNodeBackend.finishedPreloadingAssets";
+	private static var _dispatcher:EventDispatcher;
+	
+	public static var dispatcher(get, null):EventDispatcher;
+	
+	// -----------------------------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------------------------
+    public function new()
+    {
+        super();
+        Polymod.error(FAILED_CREATE_BACKEND,"OpenFLWithNodeBackend requires the openfl library, did you forget to install it?"); 
+    }
+	
+	// -----------------------------------------------------------------------------------------------
+	private static function get_dispatcher():EventDispatcher
+	{
+		if ( _dispatcher == null ) {
+			_dispatcher = new EventDispatcher();
+		}
+		return _dispatcher;
+	}
+}
+#else
+#if !nme
+class OpenFLWithNodeBackend extends OpenFLBackend
+{
+	/**
+	 * Event that is dispatched when all assets are finished preloading.
+	 */
+	public static inline var FINISHED_PRELOADING_ASSETS:String = "OpenFLWithNodeBackend.finishedPreloadingAssets";
+	private static var _dispatcher:EventDispatcher;
+	
+	public static var dispatcher(get, null):EventDispatcher;
+	
+	// -----------------------------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------------------------
+	public function new() 
+	{
+		super();
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	override public function init()
+    {
+        fallback = Assets.getLibrary("default");
+        modLibrary = new OpenFLNodeModLibrary(this);
+        Assets.registerLibrary("default", modLibrary);
+    }
+	
+	// -----------------------------------------------------------------------------------------------
+	private static function get_dispatcher():EventDispatcher
+	{
+		if ( _dispatcher == null ) {
+			_dispatcher = new EventDispatcher();
+		}
+		return _dispatcher;
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * 
+ */
+class OpenFLNodeModLibrary extends LimeModLibrary
+{
+	private var _imagePreloadCount:Int;
+	private var _audioPreloadCount:Int;
+	private var _textPreloadCount:Int;
+	private var _fontPreloadCount:Int;
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Constructor
+	 * @param	backend
+	 */
+	public function new(backend:OpenFLWithNodeBackend)
+    {
+		super(backend);
+		preloadAssets();
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Checks to see what assets were preloaded and if there are any corresponding mod assets to load in their place.
+	 */
+	private function preloadAssets():Void
+	{
+		var imagesToPreload:Array<String> = [];
+		var audioToPreload:Array<String> = [];
+		var textToPreload:Array<String> = [];
+		var fontsToPreload:Array<String> = [];
+		
+		// if any embedded assets have been loaded already, attempt to load any replacements
+		if ( hasFallback ) {
+			for ( s in fallback.cachedImages.keys() )
+			{
+				if ( p.check(s) ) {
+					imagesToPreload.push(s);
+				}
+			}
+			
+			for ( s in fallback.cachedAudioBuffers.keys() )
+			{
+				if ( p.check(s) ) {
+					audioToPreload.push(s);
+				}
+			}
+			
+			for ( s in fallback.cachedText.keys() )
+			{
+				if ( p.check(s) ) {
+					textToPreload.push(s);
+				}
+			}
+			
+			for ( s in fallback.cachedFonts.keys() )
+			{
+				if ( p.check(s) ) {
+					fontsToPreload.push(s);
+				}
+			}
+		}
+		
+		_imagePreloadCount 	= imagesToPreload.length;
+		_audioPreloadCount 	= audioToPreload.length;
+		_textPreloadCount 	= textToPreload.length;
+		_fontPreloadCount 	= fontsToPreload.length;
+		
+		for ( s in imagesToPreload ) {
+			loadImage(s).onComplete( onImagePreloaded );
+		}
+		
+		for ( s in audioToPreload ) {
+			loadAudioBuffer(s).onComplete( onAudioPreloaded );
+		}
+		
+		for ( s in textToPreload ) {
+			loadText(s).onComplete( onTextPreloaded );
+		}
+		
+		for ( s in fontsToPreload ) {
+			loadFont(s).onComplete( onFontPreloaded );
+		}
+		
+		checkIfPreloadFinished();
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Callback for images that are preloading.
+	 * @param	x
+	 */
+	private function onImagePreloaded(x:Image):Void
+	{
+		--_imagePreloadCount;
+		checkIfPreloadFinished();
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Callback for audio that is preloading.
+	 * @param	x
+	 */
+	private function onAudioPreloaded(x:AudioBuffer):Void
+	{
+		--_audioPreloadCount;
+		checkIfPreloadFinished();
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Callback for text that is preloading.
+	 * @param	x
+	 */
+	private function onTextPreloaded(x:String):Void
+	{
+		--_textPreloadCount;
+		checkIfPreloadFinished();
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Callback for font that is preloading.
+	 * @param	x
+	 */
+	private function onFontPreloaded(x:Font):Void
+	{
+		--_fontPreloadCount;
+		checkIfPreloadFinished();
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Check if all assets are finished preloading.
+	 * If so, dispatch OpenFLWithNodeBackend.FINISHED_PRELOADING_ASSETS
+	 */
+	private function checkIfPreloadFinished():Void
+	{
+		var isFinished:Bool = true;
+		isFinished = isFinished && _imagePreloadCount <= 0;
+		isFinished = isFinished && _audioPreloadCount <= 0;
+		isFinished = isFinished && _textPreloadCount <= 0;
+		isFinished = isFinished && _fontPreloadCount <= 0;
+		
+		if ( isFinished ) {
+			OpenFLWithNodeBackend.dispatcher.dispatchEvent( new Event(OpenFLWithNodeBackend.FINISHED_PRELOADING_ASSETS) );
+		}
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+    public override function isLocal (id:String, type:String):Bool
+    {
+		// because images and other assets are loaded asynchronously in HTML5 even if set the data directly,
+		// we need to modify the isLocal call to check the cached assets
+        if (p.check(id))
+		{
+			return checkIfAssetIsCached(id, type);
+		}
+        else if (hasFallback)
+		{
+            return fallback.isLocal(id, type);
+		}
+        return false;
+    }
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Checks if the specified asset has already been loaded.
+	 * Copied from the origina isLocal function in lime.utils.AssetLibrary
+	 * @param	id
+	 * @param	type
+	 * @return
+	 */
+	private function checkIfAssetIsCached(id:String, type:String):Bool
+	{
+		if (classTypes.exists(id))
+		{
+			return true;
+		}
+
+		var requestedType = type != null ? cast(type, AssetType) : null;
+
+		return switch (requestedType)
+		{
+			case IMAGE:
+				cachedImages.exists(id);
+
+			case MUSIC, SOUND:
+				cachedAudioBuffers.exists(id);
+
+			case FONT:
+				cachedFonts.exists(id);
+
+			default: cachedBytes.exists(id) || cachedText.exists(id);
+		}
+	}
+}
+#end
+#end

--- a/polymod/backends/OpenFLWithNodeBackend.hx
+++ b/polymod/backends/OpenFLWithNodeBackend.hx
@@ -105,9 +105,11 @@ class OpenFLWithNodeBackend extends OpenFLBackend
 	// -----------------------------------------------------------------------------------------------
 	override public function init()
     {
-        fallback = Assets.getLibrary("default");
-        modLibrary = new OpenFLNodeModLibrary(this);
+        fallback = LimeBackend.getDefaultAssetLibrary();
+        var ml:OpenFLNodeModLibrary = new OpenFLNodeModLibrary(this);
+        modLibrary = ml;
         Assets.registerLibrary("default", modLibrary);
+		ml.preloadAssets();
     }
 	
 	// -----------------------------------------------------------------------------------------------
@@ -142,14 +144,13 @@ class OpenFLNodeModLibrary extends LimeModLibrary
 	public function new(backend:OpenFLWithNodeBackend)
     {
 		super(backend);
-		preloadAssets();
 	}
 	
 	// -----------------------------------------------------------------------------------------------
 	/**
 	 * Checks to see what assets were preloaded and if there are any corresponding mod assets to load in their place.
 	 */
-	private function preloadAssets():Void
+	public function preloadAssets():Void
 	{
 		var imagesToPreload:Array<String> = [];
 		var audioToPreload:Array<String> = [];
@@ -160,28 +161,28 @@ class OpenFLNodeModLibrary extends LimeModLibrary
 		if ( hasFallback ) {
 			for ( s in fallback.cachedImages.keys() )
 			{
-				if ( p.check(s) ) {
+				if ( p.check(s) && p.exists(s) ) {
 					imagesToPreload.push(s);
 				}
 			}
 			
 			for ( s in fallback.cachedAudioBuffers.keys() )
 			{
-				if ( p.check(s) ) {
+				if ( p.check(s) && p.exists(s) ) {
 					audioToPreload.push(s);
 				}
 			}
 			
 			for ( s in fallback.cachedText.keys() )
 			{
-				if ( p.check(s) ) {
+				if ( p.check(s) && p.exists(s) ) {
 					textToPreload.push(s);
 				}
 			}
 			
 			for ( s in fallback.cachedFonts.keys() )
 			{
-				if ( p.check(s) ) {
+				if ( p.check(s) && p.exists(s) ) {
 					fontsToPreload.push(s);
 				}
 			}

--- a/polymod/backends/PolymodAssets.hx
+++ b/polymod/backends/PolymodAssets.hx
@@ -84,7 +84,7 @@ class PolymodAssets
         {
             case NME: new polymod.backends.NMEBackend();
             case OPENFL: new polymod.backends.OpenFLBackend();
-			case OPENFL_WITH_NODE: new polymod.backends.OpenFLWithNodeBackend();
+            case OPENFL_WITH_NODE: new polymod.backends.OpenFLWithNodeBackend();
             case LIME: new polymod.backends.LimeBackend();
             case HEAPS: new polymod.backends.HEAPSBackend();
             //case KHA: new polymod.backends.KhaBackend();

--- a/polymod/backends/PolymodAssets.hx
+++ b/polymod/backends/PolymodAssets.hx
@@ -84,6 +84,7 @@ class PolymodAssets
         {
             case NME: new polymod.backends.NMEBackend();
             case OPENFL: new polymod.backends.OpenFLBackend();
+			case OPENFL_WITH_NODE: new polymod.backends.OpenFLWithNodeBackend();
             case LIME: new polymod.backends.LimeBackend();
             case HEAPS: new polymod.backends.HEAPSBackend();
             //case KHA: new polymod.backends.KhaBackend();

--- a/polymod/fs/NodeFileSystem.hx
+++ b/polymod/fs/NodeFileSystem.hx
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2018 Level Up Labs, LLC
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * 
+ */
+ 
+package polymod.fs;
+import haxe.io.Bytes;
+import haxe.io.UInt8Array;
+import js.Browser;
+import js.html.ScriptElement;
+import js.Lib;
+
+class NodeFileSystem
+{
+	// hack to make sure NodeUtils.initNodeFunctions is called
+	private static var _jsCodeInjected:Bool = injectJSCode();
+	
+	// -----------------------------------------------------------------------------------------------
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Injects JS code needed to interact with Node's file system into the head element of the HTML document.
+	 * @return
+	 */
+	private static function injectJSCode():Bool
+	{
+		// array for adding JS text
+		var jsCode:Array<String> = [];
+		
+		// get the node file system
+		jsCode.push("let _nodefs = require('fs')");
+		
+		// utility function for getting directory contents
+		jsCode.push("function getDirectoryContents(path, recursive, dirContents=null)");
+		jsCode.push("{");
+		jsCode.push("	if ( dirContents == null ) {");
+		jsCode.push("		dirContents = [];");
+		jsCode.push("	}");
+		jsCode.push("	if ( isDirectory(path) ) {");
+		jsCode.push("		if ( path.charAt(path.length - 1) != '/' ) {");
+		jsCode.push("			path += '/';");
+		jsCode.push("		}");
+		jsCode.push("		var entries = _nodefs.readdirSync(path, { withFileTypes:true } );");
+		jsCode.push("		for ( var i = 0; i < entries.length; ++i ) {");
+		jsCode.push("			var entryPath = path + entries[i].name;");
+		jsCode.push("			dirContents.push( entryPath );");
+		jsCode.push("			if ( entries[i].isDirectory() && recursive ) {");
+		jsCode.push("				getDirectoryContents( entryPath, true, dirContents );");
+		jsCode.push("			}");
+		jsCode.push("		}");
+		jsCode.push("	}");
+		jsCode.push("	return dirContents;");
+		jsCode.push("}");
+		
+		// functions needed by Polymod
+		jsCode.push("function exists(path) { return _nodefs.existsSync(path); }");
+		jsCode.push("function getStats(path) { return exists(path) ? _nodefs.statSync(path) : null; }");
+		jsCode.push("function isDirectory(path) { var stats = getStats(path); return stats != null && stats.isDirectory(); }");
+		jsCode.push("function getFileContent(path) { return exists(path) ? _nodefs.readFileSync(path, {encoding:'utf8', flag:'r'}) : ''; }");
+		jsCode.push("function getFileBytes(path) { return exists(path) ? Uint8Array.from( _nodefs.readFileSync(path) ) : null; }");
+		jsCode.push("function readDirectory(path) { return getDirectoryContents(path, false, []) }");
+		jsCode.push("function readDirectoryRecursive(path) { return getDirectoryContents(path, true, []) }");
+		
+		// create the script element
+		var scriptElement:ScriptElement = Browser.document.createScriptElement();
+		scriptElement.type = "text/javascript";
+		scriptElement.text = jsCode.join("\n");
+		
+		// inject into the head tag
+		Browser.document.head.appendChild(scriptElement);
+		
+		return true;
+	}
+	
+	
+	// -----------------------------------------------------------------------------------------------
+	/**
+	 * Pulled and modified from OpenFL's ExternalInterface implementation
+	 * @param	functionName
+	 * @param	arg
+	 * @return
+	 */
+	private static function callFunc(functionName:String, arg:Dynamic = null):Dynamic
+	{
+		if (!~/^\(.+\)$/.match(functionName))
+		{
+			var thisArg = functionName.split(".").slice(0, -1).join(".");
+			if (thisArg.length > 0)
+			{
+				functionName += '.bind(${thisArg})';
+			}
+		}
+		
+		var fn:Dynamic = Lib.eval(functionName);
+		
+		return fn(arg);
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+    public static inline function exists( path: String ):Bool {
+        return callFunc("exists", path);
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+    public static inline function isDirectory( path: String ):Bool {
+        return callFunc("isDirectory", path);
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+    public static inline function readDirectory( path: String ):Array<String> {
+        return callFunc("readDirectory", path);
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+    public static inline function getFileContent( path: String ):String {
+        return callFunc("getFileContent", path);
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+	public static inline function getFileBytes( path: String ):Bytes {
+		var intArr:UInt8Array = callFunc("getFileBytes", path);
+		return intArr != null ? intArr.view.buffer : null;
+	}
+	
+	// -----------------------------------------------------------------------------------------------
+    public static inline function readDirectoryRecursive( path: String ):Array<String> {
+		var arr:Array<String> = callFunc("readDirectoryRecursive", path);
+		
+		for ( i in 0...arr.length ) {
+			arr[i] = StringTools.replace(arr[i], path, "");
+			if ( arr[i].charAt(0) == "/") {
+				arr[i] = arr[i].substr(1);
+			}
+		}
+		
+        return arr;
+	}
+}

--- a/polymod/fs/NodeFileSystem.hx
+++ b/polymod/fs/NodeFileSystem.hx
@@ -30,7 +30,7 @@ import js.Lib;
 
 class NodeFileSystem
 {
-	// hack to make sure NodeUtils.initNodeFunctions is called
+	// hack to make sure NodeUtils.injectJSCode is called
 	private static var _jsCodeInjected:Bool = injectJSCode();
 	
 	// -----------------------------------------------------------------------------------------------

--- a/polymod/fs/NodeFileSystem.hx
+++ b/polymod/fs/NodeFileSystem.hx
@@ -60,9 +60,11 @@ class NodeFileSystem
 		jsCode.push("		var entries = _nodefs.readdirSync(path, { withFileTypes:true } );");
 		jsCode.push("		for ( var i = 0; i < entries.length; ++i ) {");
 		jsCode.push("			var entryPath = path + entries[i].name;");
-		jsCode.push("			dirContents.push( entryPath );");
 		jsCode.push("			if ( entries[i].isDirectory() && recursive ) {");
 		jsCode.push("				getDirectoryContents( entryPath, true, dirContents );");
+		jsCode.push("			}");
+		jsCode.push("			else {");
+		jsCode.push("				dirContents.push( entryPath );");
 		jsCode.push("			}");
 		jsCode.push("		}");
 		jsCode.push("	}");
@@ -114,6 +116,17 @@ class NodeFileSystem
 	}
 	
 	// -----------------------------------------------------------------------------------------------
+	public static function santizePaths( path:String, directories:Array<String> ):Void
+	{
+		for ( i in 0...directories.length ) {
+			directories[i] = StringTools.replace(directories[i], path, "");
+			if ( directories[i].charAt(0) == "/") {
+				directories[i] = directories[i].substr(1);
+			}
+		}
+	}
+	
+	// -----------------------------------------------------------------------------------------------
     public static inline function exists( path: String ):Bool {
         return callFunc("exists", path);
 	}
@@ -125,7 +138,9 @@ class NodeFileSystem
 	
 	// -----------------------------------------------------------------------------------------------
     public static inline function readDirectory( path: String ):Array<String> {
-        return callFunc("readDirectory", path);
+        var arr:Array<String> = callFunc("readDirectory", path);
+		santizePaths(path, arr);
+        return arr;
 	}
 	
 	// -----------------------------------------------------------------------------------------------
@@ -142,14 +157,7 @@ class NodeFileSystem
 	// -----------------------------------------------------------------------------------------------
     public static inline function readDirectoryRecursive( path: String ):Array<String> {
 		var arr:Array<String> = callFunc("readDirectoryRecursive", path);
-		
-		for ( i in 0...arr.length ) {
-			arr[i] = StringTools.replace(arr[i], path, "");
-			if ( arr[i].charAt(0) == "/") {
-				arr[i] = arr[i].substr(1);
-			}
-		}
-		
+		santizePaths(path, arr);
         return arr;
 	}
 }


### PR DESCRIPTION
Uses the Node file system to add mod support for HTML5 apps made in OpenFL.

The actual Node file system code itself in NodeFileSystem.hx isn't dependent on OpenFL or Lime.

It requires a "nodefs" compiler flag to run, and in Electron it needs "nodeIntegration: true" and "contextIsolation: false" in the BrowserWindow's webPreferences. Then specify Framework.OPENFL_WITH_NODE when initializing Polymod in the Haxe code.