### PR TITLE
Remove the errors of polymod

### DIFF
--- a/polymod/format/XMLMerge.hx
+++ b/polymod/format/XMLMerge.hx
@@ -22,8 +22,7 @@
  */
  
  package polymod.format;
-
-import haxe.xml.Fast;
+import haxe.xml.Access;
 import haxe.xml.Printer;
 import polymod.util.Util;
 
@@ -186,7 +185,7 @@ class XMLMerge
 			map = mergeMapsDestructively(map, subMap);
 			var sig = getNodeSignature(el);
 		
-			var f:haxe.xml.Fast = new haxe.xml.Fast(el);
+			var f:haxe.xml.Access = new haxe.xml.Access(el);
 			if(f.hasNode.merge)
 			{
 				if(map.exists(sig) == false)


### PR DESCRIPTION
This PR removes the "XMLMerge.hx:189: characters 10-23 : Warning : This typedef is deprecated in favor of haxe.xml.Access" typedef.
(It's a minor change but I guess it's good so you don't have that error lol)