### PR TITLE
Fix the extensionMap parameter.

### DIFF
--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -245,7 +245,6 @@ class PolymodAssetLibrary
     private function init()
     {
         type = new Map<String,PolymodAssetType>();
-        extensions = new Map<String,PolymodAssetType>();
         initExtensions();
         if (parseRules == null) parseRules = ParseRules.getDefault();
         if (dirs != null)


### PR DESCRIPTION
If extensions is null, we already have code to check for that and initialize it here:

https://github.com/larsiusprime/polymod/blob/bb5f0a120419ac3a7132d96aff1e6f7a36b97d67/polymod/backends/PolymodAssetLibrary.hx#L262

If extensions is not null (i.e. it was provided by the user) then re-initializing it would ignore the user's preferences.