### PR TITLE
[CRITICAL BUG FIX] Resolve null object reference.

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -221,7 +221,7 @@ class Polymod
             }
         }
 
-        PolymodAssets.init({
+        library = PolymodAssets.init({
             framework:params.framework,
             dirs:dirs,
             parseRules:params.parseRules,
@@ -231,7 +231,10 @@ class Polymod
             frameworkParams:params.frameworkParams
         });
 
-        
+        if (library == null) {
+          return null;
+        }
+
         if(PolymodAssets.exists(("_polymod_pack.txt")))
         {
             initModPack(params);

--- a/polymod/backends/HEAPSBackend.hx
+++ b/polymod/backends/HEAPSBackend.hx
@@ -88,11 +88,12 @@ class HEAPSBackend implements IBackend
     
     public function new (){}
 
-    public function init()
+    public function init(?params:FrameworkParams):Bool
     {
         fallback = getDefaultLoader();
         modLoader = new HEAPSModLoader(this);
         Res.loader = modLoader;
+        return true;
     }
 
     public function destroy()

--- a/polymod/backends/IBackend.hx
+++ b/polymod/backends/IBackend.hx
@@ -32,7 +32,7 @@ interface IBackend
 {
     public var polymodLibrary:PolymodAssetLibrary;
 
-    public function init(?params:FrameworkParams):Void;
+    public function init(?params:FrameworkParams):Bool;
     public function destroy():Void;
 
     public function clearCache():Void;

--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -111,7 +111,7 @@ class LimeBackend implements IBackend
     
     public function new (){}
 
-    public function init(?params:FrameworkParams)
+    public function init(?params:FrameworkParams):Bool
     {
         //Get all the default asset libraries:
         var defaultLibraries = getDefaultAssetLibraries();
@@ -128,14 +128,14 @@ class LimeBackend implements IBackend
             }
         }
 
-        if(hasMoreThanDefault && params.assetLibraryPaths == null)
+        if(hasMoreThanDefault && (params == null || params.assetLibraryPaths == null))
         {
             Polymod.error(
                 PolymodErrorCode.LIME_MISSING_ASSET_LIBRARY_INFO, 
                 "Your Lime/OpenFL configuration is using custom asset libraries, but you have not provided any frameworkParams in Polymod.init() that tells Polymod which asset libraries to expect and what their mod sub-directory prefixes should be.",
                 PolymodErrorOrigin.INIT
             );
-            return;
+            return false;
         }
 
         //Wrap each asset library in `LimeModLibrary`, register it with Lime, and store it here
@@ -151,7 +151,7 @@ class LimeBackend implements IBackend
                         "Your Lime/OpenFL configuration is using custom asset libraries, and you provided frameworkParams in Polymod.init(), but we couldn't find a match for this asset library: ("+key+")",
                         PolymodErrorOrigin.INIT
                     );
-                    return;
+                    return false;
                 }
                 else
                 {
@@ -174,6 +174,8 @@ class LimeBackend implements IBackend
         {
             Assets.registerLibrary(key, modLibraries.get(key));
         }
+
+        return true;
     }
 
     public function destroy()

--- a/polymod/backends/NMEBackend.hx
+++ b/polymod/backends/NMEBackend.hx
@@ -64,7 +64,7 @@ class NMEBackend implements IBackend
 
     public function new (){}
 
-    public function init(?params:FrameworkParams)
+    public function init(?params:FrameworkParams):Bool
     {
         restoreDefaultAssets();
 
@@ -130,6 +130,8 @@ class NMEBackend implements IBackend
                 }
             }
         }
+
+        return true;
     }
 
     public function destroy()

--- a/polymod/backends/PolymodAssets.hx
+++ b/polymod/backends/PolymodAssets.hx
@@ -124,9 +124,12 @@ class PolymodAssets
             extensionMap:params.extensionMap
         });
 
-        backend.init(params.frameworkParams);
-
-        return library;
+        if (backend.init(params.frameworkParams)) {
+          // Initialization successful.
+          return library;
+        } else {
+          return null;
+        }
     }
 
     public static function exists(id:String):Bool { return library.exists(id); }

--- a/polymod/backends/StubBackend.hx
+++ b/polymod/backends/StubBackend.hx
@@ -33,7 +33,7 @@ class StubBackend implements IBackend
     public var polymodLibrary:PolymodAssetLibrary;
     public function new() {}
 
-    public function init(?params:FrameworkParams):Void {}
+    public function init(?params:FrameworkParams):Bool { return false; }
     public function destroy():Void {}
 
     public function clearCache():Void {}


### PR DESCRIPTION
Until this is merged, people building Friday Night Funkin' (vanilla), Kade Engine, or most mods from source will experience a Null Object Reference crash upon entering the title screen.

This bug is caused by the fact that Polymod now checks for an `assetLibraryPaths` attribute in the `frameworkParams` the user passes to the init function. However, if `frameworkParams` itself is completely unspecified, attempting to access `frameworkParams.assetLibraryPaths` will throw a Null Object Reference and crash the program.

# FNF Mod Developers: Read This

Until this change is deployed, you can run the following in your command line before rebuilding the game to apply the fix:

```
haxelib remove polymod
haxelib git polymod https://github.com/MasterEric/polymod
```