### PR TITLE
Call the 'onError' callback before and after loading a mod.

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -569,6 +569,9 @@ enum PolymodErrorType
     var MISSING_MOD:String = "missing_mod";
     var MISSING_META:String = "missing_meta";
     var MISSING_ICON:String = "missing_icon";
+    var MOD_LOAD_PREPARE:String = "mod_load_prepare";
+    var MOD_LOAD_FAILED:String = "mod_load_failed";
+    var MOD_LOAD_DONE:String = "mod_load_done";
     var VERSION_CONFLICT_MOD:String = "version_conflict_mod";
     var VERSION_CONFLICT_API:String = "version_conflict_api";
     var VERSION_PRERELEASE_API:String = "version_prerelease_api";

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -292,6 +292,8 @@ class PolymodAssetLibrary
 
     private function initMod(d:String):Void
     {
+        Polymod.error(MOD_LOAD_PREPARE, 'Preparing to load mod $d');
+      
         if (d == null) return;
         
         var all:Array<String> = null;
@@ -314,6 +316,7 @@ class PolymodAssetLibrary
         }
         catch (msg:Dynamic)
         {
+            Polymod.error(MOD_LOAD_FAILED, 'Failed to load mod $d : $msg');
             throw ("ModAssetLibrary._initMod(" + d + ") failed : " + msg);
         }
         for (f in all)
@@ -324,5 +327,6 @@ class PolymodAssetLibrary
             var assetType = getExtensionType(ext);
             type.set(f,assetType);
         }
+        Polymod.error(MOD_LOAD_DONE, 'Done loading mod $d');
     }
 }


### PR DESCRIPTION
Very tiny PR, adds a log call before loading the mod, after loading the mod, or if the mod fails to load.

Useful because I wanted to print to the log for each mod that loads and whether they succeeded or failed.