### PR TITLE
Rework of HScript and macro logic

### DIFF
--- a/polymod/hscript/HScriptConfig.hx
+++ b/polymod/hscript/HScriptConfig.hx
@@ -23,8 +23,81 @@
  
 package polymod.hscript;
 
+import haxe.macro.Type.ClassType;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+using haxe.macro.ExprTools;
+using haxe.macro.TypeTools;
+using Lambda;
+
+/**
+ * This class provides several constants used throughout the library.
+ * Since these are needed by build macros, they can be configured only through compile defines.
+ * 
+ * Overriding in HXML:
+ * ```
+ * -D POLYMOD_SCRIPT_EXT=".hx"
+ * ```
+ * 
+ * Overriding in Lime:
+ * ```
+ * <haxedef name="POLYMOD_SCRIPT_EXT" value=".hx" />
+ * ```
+ * 
+ * Each value has a default, or you can use a compiler flag to override it.
+ * For example, 
+ */
 class HScriptConfig
 {
-    public static var rootPath:String = "data/";
-    public static var useNamespaceInPaths:Bool = true;
+	static macro function getStringDefine(key:String, defaultValue:String):haxe.macro.Expr
+	{
+		var value = Context.definedValue(key);
+		Context.info('String define: ${key} : ${defaultValue} : ${value}', Context.currentPos());
+		if (value == null)
+			value = defaultValue;
+		return macro $v{value};
+	}
+
+	static macro function getBoolDefine(key:String, defaultValue:Bool):haxe.macro.Expr
+	{
+		var value:String = Context.definedValue(key);
+		var valueBool = (value == null) ? defaultValue : (value == 'true');
+		return macro $v{valueBool};
+	}
+
+	public static var debug(default, null):Bool;
+
+	function get_debug()
+	{
+		return getBoolDefine('POLYMOD_DEBUG', false);
+	}
+
+	public static var rootPath(default, null):String;
+
+	function get_rootPath()
+	{
+		return getStringDefine('POLYMOD_ROOT_PATH', "data/");
+	}
+
+	public static var useNamespaceInPaths(default, null):Bool;
+
+	function get_useNamespaceInPaths()
+	{
+		return getBoolDefine('POLYMOD_USE_NAMESPACE', true);
+	}
+
+	public static var scriptExt(default, null):String;
+
+	function get_scriptExt()
+	{
+		return getStringDefine('POLYMOD_SCRIPT_EXT', ".txt");
+	}
+
+	public static var scriptLibrary(default, null):String;
+
+	function get_scriptLibrary()
+	{
+		return getStringDefine('POLYMOD_SCRIPT_LIBRARY', "default");
+	}
 }

--- a/polymod/hscript/HScriptMacro.hx
+++ b/polymod/hscript/HScriptMacro.hx
@@ -122,7 +122,9 @@ class HScriptMacro
             {
               
               #if POLYMOD_DEBUG trace("Polymod: Loading hscript "+$v{ pathName }); #end
-              _polymod_scripts.load($v{ pathName }, Assets.getText(polymod.hscript.HScriptConfig.rootPath+$v{ pathName }+".txt"));
+              _polymod_scripts.load($v{pathName},
+                Assets.getText(polymod.hscript.HScriptConfig.scriptLibrary + ':' + polymod.hscript.HScriptConfig.rootPath
+                + $v{pathName} + polymod.hscript.HScriptConfig.scriptExt));
             });
 
           default: Context.error("Error: The @:hscript meta is only allowed on functions", field.pos);


### PR DESCRIPTION
This PR includes the following features:

* HScriptConfig is now powered by compiler macros; it now attempts to read values from compiler flags before falling back to the defaults.
  * You can now use `-D` in HXML or `<haxedef>` in Lime to configure `POLYMOD_ROOT_PATH`, `POLYMOD_USE_NAMESPACE`, `POLYMOD_SCRIPT_EXT`, or `POLYMOD_SCRIPT_LIBRARY`.
  * Adding `POLYMOD_SCRIPT_EXT` provides a fix for #42.
  * Adding `POLYMOD_SCRIPT_LIBRARY` provides a fix for #50.
* HScriptable now evaluates `:hscript` identifiers recursively.
  * Previously, if you had a large number of functions that all needed the same set of identifiers, you had to specify them manually for each.
  * Now, `@:hscript` will check each parent class and interface of the class containing the function, look for an `@:hscript` annotation on that, and add those to the script context.

Here is a short example of the second change:
```haxe
@:hscript(Std, Math, FlxG) // ALL of these values are added to ALL scripts in the implementing classes.
interface IHook
{
}

class MainState implements HScriptable implements IHook
{
	@:hscript
	public function onStart()
	{
            // Std, Math, and FlxG are accessible here, even though we didn't define them on this function directly.
	}
}
```

Overall, these changes should drastically improve the experience of developers implementing script modding into their applications.