### PR TITLE
Fixed error not using correct Mod Metadata File

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -529,7 +529,12 @@ class ModMetadata
 		}
 		catch (msg:Dynamic)
 		{
-			Polymod.error(PARSE_MOD_API_VERSION, 'Error parsing api version: (${Std.string(msg)}) ${PolymodConfig.modMetadataFile} was : $str');
+			Polymod.error(PARSE_MOD_API_VERSION, "Error parsing api version: ("
+				+ Std.string(msg)
+				+ ") "
+				+ PolymodConfig.modMetadataFile
+				+ " was : "
+				+ str);
 			return null;
 		}
 		try
@@ -538,7 +543,12 @@ class ModMetadata
 		}
 		catch (msg:Dynamic)
 		{
-			Polymod.error(PARSE_MOD_VERSION, 'Error parsing mod version: (${Std.string(msg)}) ${PolymodConfig.modMetadataFile} was : $str');
+			Polymod.error(PARSE_MOD_VERSION, "Error parsing api version: ("
+				+ Std.string(msg)
+				+ ") "
+				+ PolymodConfig.modMetadataFile
+				+ " was : "
+				+ str);
 			return null;
 		}
 		m.license = JsonHelp.str(json, "license");

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -538,7 +538,7 @@ class ModMetadata
 		}
 		catch (msg:Dynamic)
 		{
-			Polymod.error(PARSE_MOD_API_VERSION, 'Error parsing mod version: (${Std.string(msg)}) ${PolymodConfig.modMetadataFile} was : $str');
+			Polymod.error(PARSE_MOD_VERSION, 'Error parsing mod version: (${Std.string(msg)}) ${PolymodConfig.modMetadataFile} was : $str');
 			return null;
 		}
 		m.license = JsonHelp.str(json, "license");

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -529,7 +529,7 @@ class ModMetadata
 		}
 		catch (msg:Dynamic)
 		{
-			Polymod.error(PARSE_MOD_API_VERSION, "Error parsing api version: (" + Std.string(msg) + ") _polymod_meta.json was : " + str);
+			Polymod.error(PARSE_MOD_API_VERSION, 'Error parsing api version: (${Std.string(msg)}) ${PolymodConfig.modMetadataFile} was : $str');
 			return null;
 		}
 		try
@@ -538,7 +538,7 @@ class ModMetadata
 		}
 		catch (msg:Dynamic)
 		{
-			Polymod.error(PARSE_MOD_VERSION, "Error parsing mod version: (" + Std.string(msg) + ") _polymod_meta.json was : " + str);
+			Polymod.error(PARSE_MOD_API_VERSION, 'Error parsing mod version: (${Std.string(msg)}) ${PolymodConfig.modMetadataFile} was : $str');
 			return null;
 		}
 		m.license = JsonHelp.str(json, "license");


### PR DESCRIPTION
Previously the modMetadata wasn't being used for this error. This [issue ](https://github.com/larsiusprime/polymod/issues/59) should of been closed by now!