### PR TITLE
Fix for hscript above 2.5.0

### DIFF
--- a/polymod/hscript/_internal/PolymodParserEx.hx
+++ b/polymod/hscript/_internal/PolymodParserEx.hx
@@ -5,10 +5,17 @@ import hscript.Parser;
 
 class PolymodParserEx extends Parser
 {
+	#if (hscript > "2.5.0")
+	public override function parseModule(content:String, ?origin:String = "hscript", ?position = 0)
+	#else
 	public override function parseModule(content:String, ?origin:String = "hscript")
+	#end
 	{
-		var decls = super.parseModule(content, origin);
-		return decls;
+		#if (hscript > "2.5.0")
+		return super.parseModule(content, origin, position);
+		#else
+		return super.parseModule(content, origin);
+		#end
 	}
 }
 #end


### PR DESCRIPTION
Since [this](https://github.com/HaxeFoundation/hscript/commit/e5bef49bb6cbeb925c5b8f5d8fc40d118fda5177) commit on hscript repo, polymod fails to compile with it, this should fix it.