### PR TITLE
Recursively deparameterize TInst and TAbstract

### DIFF
--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -575,6 +575,8 @@ class HScriptedClassMacro
 				{
 					// If so, replace it with the real type.
 					resultType = targetParams.get(ty.toString());
+					// recursive call in case result is a parameter
+					resultType = deparameterizeType(resultType, targetParams);
 				}
 				else if (params.length != 0)
 				{
@@ -624,6 +626,8 @@ class HScriptedClassMacro
 				{
 					// If so, replace it with the real type.
 					resultType = targetParams.get(ty.toString());
+					// recursive call in case result is a parameter
+					resultType = deparameterizeType(resultType, targetParams);
 				}
 				else if (params.length != 0)
 				{


### PR DESCRIPTION
Fixes the "Type not found : T" error

the issue was that `deparameterizeType` took `FlxTypedGroup.T` and returned `FlxTypedContainer.T` which,  in turn, needed to be deparameterized

I'm doing the same for TAbstract, which has no effect on my tests, but I thought I'd add it, I have no idea what you are doing with Abstract Params, I assume you're just looking for `MyScriptedClass<MyAbstract<T>>` and deparameterizing T, is that the case? do you have any other tests I should try?

Additionally, is there a way to code this that would make errors of this type more helpful? I'm looking at the fields created and they seem to have a valid pos, so no idea why the T error has no position