### PR TITLE
[FEATURE] Import Scripted Classes

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -68,6 +68,13 @@ class PolymodInterpEx extends Interp
 		if (clsRef != null) return clsRef.instantiate(args);
 
 		@:privateAccess
+		if (getClassDecl().imports != null && getClassDecl().imports.exists(cl)) 
+		{
+			var clsRef = PolymodStaticClassReference.tryBuild(getClassDecl().imports.get(cl).fullPath);
+			if (clsRef != null) return clsRef.instantiate(args);
+		}
+
+		@:privateAccess
 		if (getClassDecl()?.pkg != null)
 		{
 			@:privateAccess
@@ -232,6 +239,12 @@ class PolymodInterpEx extends Interp
 
 			for (key => imp in cls.importsToValidate) 
 			{
+				if (_scriptClassDescriptors.exists(imp.fullPath))
+				{
+					cls.imports.set(key, imp);
+					continue;
+				}
+
 				if (_scriptEnumDescriptors.exists(imp.fullPath))
 				{
 					cls.imports.set(key, imp);


### PR DESCRIPTION
## DESCRIPTION
This pr adds the ability to import scripted classes like you would do in regular haxe, meaning:
```haxe
package my.mod.game;

import game.ScriptedGame;
import my.mod.objects.ModdedPlayer;

class ModdedGame extends ScriptedGame {
  public function new() {
    var player = new ModdedPlayer();
  }
}
```

## EXPLANATION
We create another imports variable to the `PolymodClassDeclEx`, because a script might import a class that hasn't been registered yet.
After all classes have been registered and parsed, we validate the imports. If the import still can't be found we give the user an error.