### PR TITLE
[FEATURE] Abstract Statics Access

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -8,6 +8,8 @@ import polymod.hscript._internal.PolymodExprEx;
 import polymod.hscript._internal.PolymodClassDeclEx.PolymodClassImport;
 import polymod.hscript._internal.PolymodClassDeclEx.PolymodStaticClassReference;
 
+using StringTools;
+
 /**
  * Based on code by Ian Harrigan
  * @see https://github.com/ianharrigan/hscript-ex
@@ -791,6 +793,11 @@ class PolymodInterpEx extends Interp
 			// }
 			// #end
 			// return result;
+		}
+
+		var abstractKey:String = Type.getClassName(o) + '.' + f;
+		if (PolymodScriptClass.abstractClassStatics.exists(abstractKey)) {
+			return Reflect.getProperty(PolymodScriptClass.abstractClassStatics[abstractKey], abstractKey.replace('.', '_'));
 		}
 
 		// Default behavior

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -97,6 +97,23 @@ class PolymodScriptClass
 		return _abstractClassImpls;
 	}
 
+	public static var abstractClassStatics(get, never):Map<String, Class<Dynamic>>;
+	static var _abstractClassStatics:Map<String, Class<Dynamic>> = null;
+
+	static function get_abstractClassStatics():Map<String, Class<Dynamic>> {
+		if (_abstractClassStatics == null) {
+			_abstractClassStatics = new Map<String, Class<Dynamic>>();
+
+			var baseAbstractClassStatics:Map<String, Class<Dynamic>> = PolymodScriptClassMacro.listAbstractStatics();
+
+			for (key => value in baseAbstractClassStatics) {
+				_abstractClassStatics.set(key, value);
+			}
+		}
+
+		return _abstractClassStatics;
+	}
+
 	/**
 	 * Register a scripted class by retrieving the script from the given path.
 	 */

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -10,6 +10,8 @@ import polymod.util.MacroUtil;
 
 import haxe.rtti.Meta;
 
+using StringTools;
+
 /**
  * Provides a macro which, after types are generated, populates a list of classes which extend `polymod.hscript.HScriptedClass`.
  * We have to do weird shenanigans to make the data accessible at runtime though.
@@ -39,8 +41,25 @@ class PolymodScriptClassMacro {
 		return macro polymod.hscript._internal.PolymodScriptClassMacro.fetchAbstractImpls();
 	}
 
+	public static macro function listAbstractStatics():ExprOf<Map<String, Class<Dynamic>>> {
+		if (!onAfterTypingCallbackRegistered)
+		{
+			onAfterTypingCallbackRegistered = true;
+			haxe.macro.Context.onAfterTyping(onAfterTyping);
+		}
+
+		if (!onGenerateCallbackRegistered)
+		{
+		  onGenerateCallbackRegistered = true;
+		  haxe.macro.Context.onGenerate(onGenerate);
+		}
+
+		return macro polymod.hscript._internal.PolymodScriptClassMacro.fetchAbstractStatics();
+	}
+
 	#if macro
   	static var onGenerateCallbackRegistered:Bool = false;
+  	static var onAfterTypingCallbackRegistered:Bool = false;
 
   	static function onGenerate(allTypes:Array<haxe.macro.Type>) {
     	// Reset these, since onGenerate persists across multiple builds.
@@ -48,6 +67,7 @@ class PolymodScriptClassMacro {
 
     	var hscriptedClassEntries:Array<Expr> = [];
 		var abstractImplEntries:Array<Expr> = [];
+		var abstractStaticEntries:Array<Expr> = [];
 
 		for (type in allTypes) {
 		  	switch (type) {
@@ -88,6 +108,30 @@ class PolymodScriptClassMacro {
 
 					abstractImplEntries.push(macro $a{entryData});
 
+					for (field in abstractImpl.statics.get()) {
+						switch (field.type) {
+							case TAbstract(_, _):
+								//
+							case TType(_, _):
+								//
+								default:
+								continue;
+						}
+						
+						var key:String = '${abstractImplPath}.${field.name}';
+
+						if (!staticFieldToClass.exists(key)) {
+							continue;
+						}
+						
+						var staticEntryData = [
+							macro $v{key},
+							macro $v{staticFieldToClass[key]},
+						];
+
+						abstractStaticEntries.push(macro $a{staticEntryData});
+					}
+
 					// Try to apply RTTI?
 					abstractType.meta.add(':rtti', [], Context.currentPos());
 					abstractImpl.meta.add(':rtti', [], Context.currentPos());
@@ -100,6 +144,101 @@ class PolymodScriptClassMacro {
     	var polymodScriptClassClassType:ClassType = MacroUtil.getClassType('polymod.hscript._internal.PolymodScriptClassMacro');
     	polymodScriptClassClassType.meta.add('hscriptedClasses', hscriptedClassEntries, Context.currentPos());
 		polymodScriptClassClassType.meta.add('abstractImpls', abstractImplEntries, Context.currentPos());
+		polymodScriptClassClassType.meta.add('abstractStatics', abstractStaticEntries, Context.currentPos());
+	}
+
+	static var iteration:Int = 0;
+	static var staticFieldToClass:Map<String, String> = [];
+	static function onAfterTyping(types: Array<ModuleType>):Void {
+		var fields:Array<Field> = [];
+
+		for (type in types) {
+			switch (type) {
+				case TAbstract(a):
+					var abstractPath = a.toString();
+					var abstractType = a.get();
+
+					if (abstractPath != 'flixel.util.FlxColor') {
+						continue;
+					}
+					
+					if (abstractType.impl == null) {
+						continue;
+					}
+
+					var abstractImplPath = abstractType.impl.toString();
+					var abstractImplType = abstractType.impl.get();
+
+					var excludes:Array<String> = [];
+					for (field in abstractImplType.statics.get()) {
+						switch (field.type) {
+							case TFun(_, _):
+							default: 
+								continue;
+						}
+
+						// exclude anything that has a getter or setter
+						// most of the time i think variables that have them are not static
+						// hopefully that's true
+						if (field.name.startsWith('get_') || field.name.startsWith('_set')) {
+							excludes.push(field.name.replace('get_', '').replace('set_', ''));
+						}
+					}
+
+					for (field in abstractImplType.statics.get()) {
+						switch (field.type) {
+							case TFun(_, _):
+								continue;
+							default:
+						}
+
+						if (excludes.contains(field.name)) {
+							continue;
+						}
+
+						var fieldName:String = '${abstractImplPath.replace('.', '_')}_${field.name}';
+
+						fields.push({
+							pos: Context.currentPos(),
+							name: fieldName,
+							access: [Access.APublic, Access.AStatic],
+							kind: FProp('get', 'never', Context.toComplexType(field.type), null)
+						});
+
+						fields.push({
+							pos: Context.currentPos(),
+							name: 'get_${fieldName}',
+							access: [Access.APublic, Access.AStatic],
+							kind: FFun({
+								args: [],
+								ret: null,
+								expr: macro {
+									@:privateAccess
+									return ${Context.parse(abstractPath + '.' + field.name, Context.currentPos())};
+								}
+							})
+						});
+
+						staticFieldToClass.set('${abstractImplPath}.${field.name}', 'polymod.hscript._internal.AbstractStaticMembers_${iteration}');
+					}
+				default:
+					continue;
+			}
+		}
+
+		if (fields.length == 0) {
+			return;
+		}
+
+		Context.defineType({
+			pos: Context.currentPos(),
+			pack: ['polymod', 'hscript', '_internal'],
+			name: 'AbstractStaticMembers_${iteration}',
+			kind: TDClass(null, [], false, false, false),
+			fields: fields
+		});
+
+		iteration++;
 	}
 	#end
 
@@ -170,6 +309,32 @@ class PolymodScriptClassMacro {
 			return result;
 		} else {
 			throw 'No abstractImpls found in PolymodScriptClassMacro!';
+		}
+	}
+
+	public static function fetchAbstractStatics():Map<String, Class<Dynamic>> {
+		var metaData = Meta.getType(PolymodScriptClassMacro);
+
+		if (metaData.abstractStatics != null) {
+			var result:Map<String, Class<Dynamic>> = [];
+
+			// Each element is formatted as `[abstractPathImpl.fieldName, reflectClass]`.
+
+			for (element in metaData.abstractStatics) {
+				if (element.length != 2) {
+					throw 'Malformed element in abstractStatics: ' + element;
+				}
+
+				var fieldPath:String = element[0];
+				var reflectClassPath:String = element[1];
+				var reflectClass:Class<Dynamic> = cast Type.resolveClass(reflectClassPath);
+
+				result.set(fieldPath, reflectClass);
+			}
+
+			return result;
+		} else {
+			throw 'No abstractStatics found in PolymodScriptClassMacro!';
 		}
 	}
 


### PR DESCRIPTION
(Renamed the branch, which forced me to reopen the pr?)

## DESCRIPTION
This pr adds the ability to access the static members of abstracts.

## NOTE
`FlxColor` is the only thing that has been tested, so I don't know if other abstracts work.

## EXPLANATION
We loop through all existing abstracts, and get the variables. 

To filter out non static member variables, I have decided to exclude any variable that has a getter or setter. I don't like doing it this way, but I haven't found a better way yet.

Then we define a class that contains getters that return the value of the static in the abstract. The reason we do this, is because abstract static member variables aren't stored in the reflection table.
