### PR TITLE
[BUGFIX] Prevent `final`s from being set from other Classes

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -3,4 +3,5 @@
   <!-- These values are added to the project XML when you include this library. -->
   <haxelib name="thx.semver" />
   <!-- <haxelib name="hscript" /> This library is now OPTIONAL. -->
+  <haxeflag name="--macro" value="polymod.hscript._internal.PolymodFinalMacro.locateAllFinals()" />
 </project>

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -1,0 +1,76 @@
+package polymod.hscript._internal;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+
+class PolymodFinalMacro
+{
+  public static function getAllFinals():Map<String, Array<String>>
+  {
+    return Reflect.callMethod(null, Reflect.field(Type.resolveClass("polymod.hscript._internal.PolymodFinals"), "getAllFinals"), []);
+  }
+
+  public static macro function locateAllFinals():Void
+  {
+    Context.onAfterTyping((types) ->
+    {
+      if (calledBefore)
+        return;
+
+      var allFinals:Map<String,Array<String>> = [];
+
+      for (type in types)
+      {
+        switch (type)
+        {
+          case TClassDecl(t):
+            var classType:ClassType = t.get();
+            var className:String = t.toString();
+            if (classType.isInterface) continue;
+
+            allFinals.set(className, []);
+            for (field in classType.statics.get())
+            {
+              if (!field.isFinal) continue;
+              allFinals[className].push(field.name);
+            }
+
+          default:
+            continue;
+        }
+      }
+
+      Context.defineModule('polymod.hscript._internal.PolymodFinalMacro', [
+        {
+          pack: ['polymod', 'hscript', '_internal'],
+          name: 'PolymodFinals',
+          kind: TypeDefKind.TDClass(null, [], false, false, false),
+          fields: [
+            {
+              name: 'getAllFinals',
+              access: [Access.APublic, Access.AStatic],
+              kind: FieldType.FFun(
+                {
+                  args: [],
+                  ret: (macro :Map<String, Array<String>>),
+                  expr: macro
+                  {
+                    return $v{allFinals};
+                  }
+                }),
+              pos: Context.currentPos()
+            }
+          ],
+          pos: Context.currentPos()
+        }
+      ]);
+
+      calledBefore = true;
+    });
+  }
+
+  #if macro
+  static var calledBefore:Bool = false;
+  #end
+}

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -204,6 +204,27 @@ class PolymodInterpEx extends Interp
 								}
 							}
 						}
+						else
+						{
+							@:privateAccess
+							{
+								// Check if we are setting a final. If so, throw an error.
+								if (_proxy != null && _proxy._c != null)
+								{
+									for (imp in _proxy._c.imports)
+									{
+										if (imp.name != id0) continue;
+										var finals = PolymodFinalMacro.getAllFinals().get(imp.fullPath);
+										for (fin in finals)
+										{
+											if (fin != id) continue;
+											errorEx(EInvalidAccess(fin));
+											return null;
+										}
+									}
+								}
+							}
+						}
 					default:
 						// Do nothing
 				}


### PR DESCRIPTION
This uses a fun little macro (code inspired by lemz ty goat) to put all static finals of classes in a map and then interp does the logic with blacklisting em and shit

Fixes https://github.com/FunkinCrew/Funkin/issues/2474