### PR TITLE
fix get_className output

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -567,7 +567,7 @@ class PolymodScriptClass
 		var name = "";
 		if (_c.pkg != null)
 		{
-			name += _c.pkg.join(".");
+			name += _c.pkg.join(".") + ".";
 		}
 		name += _c.name;
 		return name;


### PR DESCRIPTION
```haxe
// current output
"examplepackage.examplesubpackageExampleClass"

// fixed output
"examplepackage.examplesubpackage.ExampleClass"
```