### PR TITLE
[BUGFIX] Fix DefineUtil bool default value not working

### DIFF
--- a/polymod/util/DefineUtil.hx
+++ b/polymod/util/DefineUtil.hx
@@ -8,7 +8,7 @@ class DefineUtil
 {
 	// Only macros should be able to use these.
 	#if macro
-	public static function getDefineStringArrayRaw(key:String, ?defaultValue:Array<String> = null):Array<String>
+	public static function getDefineStringArrayRaw(key:String, ?defaultValue:Array<String>):Array<String>
 	{
 		if (defaultValue == null)
 			defaultValue = new Array<String>();
@@ -16,30 +16,30 @@ class DefineUtil
 		return value == null ? defaultValue : value.split(',');
 	}
 
-	public static function getDefineStringRaw(key:String, ?defaultValue:String = ''):String
+	public static function getDefineStringRaw(key:String, defaultValue:String = ''):String
 	{
 		var value = Context.definedValue(key);
 		return value == null ? defaultValue : value;
 	}
 
-	public static function getDefineBoolRaw(key:String, ?defaultValue:Bool = false):Bool
+	public static function getDefineBoolRaw(key:String, defaultValue:Bool = false):Bool
 	{
 		var value:String = getDefineStringRaw(key);
-		return value == null ? defaultValue : (value == 'true');
+		return value == '' ? defaultValue : (value == 'true');
 	}
 	#end
 
-	public static macro function getDefineStringArray(key:String, ?defaultValue:Array<String> = null):haxe.macro.Expr
+	public static macro function getDefineStringArray(key:String, ?defaultValue:Array<String>):haxe.macro.Expr
 	{
 		return macro $v{getDefineStringArrayRaw(key, defaultValue)};
 	}
 
-	public static macro function getDefineString(key:String, ?defaultValue:String = ''):haxe.macro.Expr
+	public static macro function getDefineString(key:String, defaultValue:String = ''):haxe.macro.Expr
 	{
 		return macro $v{getDefineStringRaw(key, defaultValue)};
 	}
 
-	public static macro function getDefineBool(key:String, ?defaultValue:Bool = false):haxe.macro.Expr
+	public static macro function getDefineBool(key:String, defaultValue:Bool = false):haxe.macro.Expr
 	{
 		return macro $v{getDefineBoolRaw(key, defaultValue)};
 	}

--- a/polymod/util/DefineUtil.hx
+++ b/polymod/util/DefineUtil.hx
@@ -25,7 +25,7 @@ class DefineUtil
 	public static function getDefineBoolRaw(key:String, defaultValue:Bool = false):Bool
 	{
 		var value:String = getDefineStringRaw(key);
-		return value == '' ? defaultValue : (value == 'true');
+		return value == '' ? defaultValue : (value == 'true' || value == '1');
 	}
 	#end
 


### PR DESCRIPTION
This fixes `getDefineBool` always returning `false` even if a default value was set.
Also makes every function only use either default or optional arguments instead of both at once.