### PR TITLE
[FEATURE] The `using` keyword

### DIFF
--- a/polymod/hscript/_internal/PolymodClassDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodClassDeclEx.hx
@@ -18,6 +18,7 @@ typedef PolymodClassDeclEx =
 	@:optional var pkg:Array<String>;
 
 	@:optional var staticFields:Array<FieldDecl>;
+	@:optional var usings:Map<String, PolymodClassImport>;
 }
 
 /**

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -859,6 +859,7 @@ class PolymodScriptClass
 	private var _cachedSuperFunctionDecls:Map<String, Dynamic> = [];
 	private var _cachedFunctionDecls:Map<String, FunctionDecl> = [];
 	private var _cachedVarDecls:Map<String, VarDecl> = [];
+	private var _cachedUsingFunctions:Map<String, Dynamic> = [];
 
 	private function buildCaches()
 	{
@@ -866,6 +867,24 @@ class PolymodScriptClass
 		_cachedSuperFunctionDecls.clear();
 		_cachedFunctionDecls.clear();
 		_cachedVarDecls.clear();
+		_cachedUsingFunctions.clear();
+
+		for (n => u in _c.usings)
+		{
+			var fields = Type.getClassFields(u.cls);
+			if (fields.length == 0) continue;
+
+			for (fld in fields)
+			{
+				var func:Dynamic = function(params:Array<Dynamic>)
+				{
+					var prop:Dynamic = Reflect.getProperty(u.cls, fld);
+					return Reflect.callMethod(u.cls, prop, params);
+				}
+					
+				_cachedUsingFunctions.set(fld, func);
+			}
+		}
 
 		for (f in _c.fields)
 		{


### PR DESCRIPTION
Reopening of https://github.com/larsiusprime/polymod/pull/196 due to messy commit history. View that PR for more information.
Now it additionally caches functions of every `using` on init.

Still requires https://github.com/FunkinCrew/hscript/pull/7 to be merged alongside this.