### PR TITLE
[FIX] Only include class in metadata if it has final fields

### DIFF
--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -42,6 +42,8 @@ class PolymodFinalMacro
               finals.push(field.name);
             }
 
+            if (finals.length == 0) continue;
+
             var entryData = [
               macro $v{classPath},
               macro $v{finals}


### PR DESCRIPTION
## Linked Issues
Closes #226 

## Description
The macro would include every single class into the metadata, making the generated C++ code massive which causes some compilers to completely hang. This mitigates the issue by making it only include classes that contains final fields.