### PR TITLE
[FEATURE] Hscript Typer

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -656,6 +656,9 @@ class Polymod
 		@:privateAccess
 		polymod.hscript._internal.PolymodScriptClass.clearScriptedClasses();
 		polymod.hscript._internal.PolymodEnum.clearScriptedEnums();
+		#if hscript_typer
+		polymod.hscript._internal.PolymodTyperEx.clearAllModules();
+		#end
 		polymod.hscript.HScriptable.ScriptRunner.clearScripts();
 		#else
 		Polymod.warning(SCRIPT_HSCRIPT_NOT_INSTALLED, "Cannot register script classes, HScript is not available.");
@@ -692,6 +695,12 @@ class Polymod
 					polymod.hscript._internal.PolymodScriptClass.registerScriptClassByPath(path);
 				}
 			}
+
+			#if hscript_typer
+			// in the future typed modules might have a use
+			// but for now we just ignore the typed modules that are returned
+			var _ = polymod.hscript._internal.PolymodTyperEx.typeAllModules();
+			#end
 
 			polymod.hscript._internal.PolymodInterpEx.validateImports(); 
 		}

--- a/polymod/hscript/_internal/PolymodParserEx.hx
+++ b/polymod/hscript/_internal/PolymodParserEx.hx
@@ -2,7 +2,11 @@ package polymod.hscript._internal;
 
 #if hscript
 import hscript.Parser;
+import hscript.Expr;
 
+#if hscript_typer
+@:access(polymod.hscript._internal.PolymodTyperEx)
+#end
 class PolymodParserEx extends Parser
 {
 	#if (hscript > "2.5.0")
@@ -12,10 +16,18 @@ class PolymodParserEx extends Parser
 	#end
 	{
 		#if (hscript > "2.5.0")
-		return super.parseModule(content, origin, position);
+		var decls:Array<ModuleDecl> = super.parseModule(content, origin, position);
 		#else
-		return super.parseModule(content, origin);
+		var decls:Array<ModuleDecl> = super.parseModule(content, origin);
 		#end
+		#if hscript_typer
+		PolymodTyperEx.allModules.push({
+			decls: decls,
+			code: content,
+			origin: origin,
+		});
+		#end
+		return decls;
 	}
 }
 #end

--- a/polymod/hscript/_internal/PolymodTyperEx.hx
+++ b/polymod/hscript/_internal/PolymodTyperEx.hx
@@ -1,0 +1,100 @@
+package polymod.hscript._internal;
+
+#if hscript_typer
+import hscript.Expr;
+import hscript.typer.Typer;
+import hscript.typer.TypedExpr;
+
+class PolymodTyperEx extends Typer 
+{
+  static var allModules:Array<TyperModule> = [];
+
+  var blacklistImports:Array<String>;
+  var aliasPaths:Map<String, String>;
+  var defaultImports:Map<String, CType>;
+
+  public static function clearAllModules():Void 
+  {
+    allModules = [];
+  }
+
+  public static function typeAllModules():Array<TypedModuleDecl> 
+  {
+    return new PolymodTyperEx(new PolymodInterpEx(null, null)).typeModules(allModules);
+  }
+
+  public function new(interp:PolymodInterpEx) 
+  {
+    super(interp);
+
+    blacklistImports = [];
+    aliasPaths = new Map<String, String>();
+    for (k => imp in PolymodScriptClass.importOverrides) 
+    {
+      if (imp == null) 
+        blacklistImports.push(k);
+      else
+        aliasPaths.set(k, Type.getClassName(imp));
+    }
+    for (k => imp in PolymodScriptClass.abstractClassImpls) 
+    {
+			aliasPaths.set(k, Type.getClassName(imp));
+    }
+
+    defaultImports = new Map<String, CType>();
+    for (k => imp in PolymodScriptClass.defaultImports) 
+    {
+      defaultImports.set(k, CTPath([Type.getClassName(imp)], null));
+    }
+  }
+
+  override function resolveType(path:String):Null<Dynamic>
+  {
+    if (blacklistImports.contains(path)) moduleError('"${path}" is a blacklisted type');
+    path = aliasPaths.get(path) ?? path;
+
+    var pathSplit:Array<String> = path.split('.');
+    if (pathSplit.length == 1)
+    {
+      var imp:Null<CType> = imports.get(path) ?? defaultImports.get(path);
+      if (imp != null)
+      {
+        switch (imp)
+        {
+          case CTPath(path, null):
+            var path:String = path.join('.');
+            if (blacklistImports.contains(path)) moduleError('"${path}" is a blacklisted type');
+            path = aliasPaths.get(path) ?? path;
+            var type:Null<Dynamic> = null;
+            type ??= Type.resolveClass(path);
+            type ??= Type.resolveEnum(path);
+            type ??= scriptedTypes.get(path);
+            if (type != null) return type;
+
+          default:
+            throw 'Should not happen: ${imp}';
+        }
+      }
+
+      for (pack in everythingImports)
+      {
+        var path:String = pack.concat([path]).join('.');
+        if (blacklistImports.contains(path)) moduleError('"${path}" is a blacklisted type');
+        path = aliasPaths.get(path) ?? path;
+        var type:Null<Dynamic> = null;
+        type ??= Type.resolveClass(path);
+        type ??= Type.resolveEnum(path);
+        type ??= scriptedTypes.get(path);
+        if (type != null) return type;
+      }
+    }
+
+    var type:Null<Dynamic> = null;
+    type ??= Type.resolveClass(path);
+    type ??= Type.resolveEnum(path);
+    type ??= scriptedTypes.get(path);
+
+    return type;
+  }
+}
+#end


### PR DESCRIPTION
## Description

Uses [hscript-typer](https://lib.haxe.org/p/hscript-typer/) to type modules. Currently we don't use the returned typed modules, however the typer is still useful for catching errors in scripts before running them.

(In the future if we use the typed modules, we could potentially manage to interpret overriden operators of abstracts, without the need to explicitly call the operator functions. But this would be on the back burner for a while.)
