### PR TITLE
[FIX] Call arguments are now only evaluted once

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -663,8 +663,15 @@ class PolymodInterpEx extends Interp
 						if (name != null && _scriptEnumDescriptors.exists(name))
 						{
 							return new PolymodEnum(_scriptEnumDescriptors.get(name), f, args);
+						} 
+						else 
+						{
+							var obj = expr(e);
+							if( obj == null ) errorEx(EInvalidAccess(f));
+							return fcall(obj,f,args);
 						}
 					default:
+						return call(null,expr(e),args);
 				}
 				case ESwitch(e, cases, def):
 					var val:Dynamic = expr(e);


### PR DESCRIPTION
## Linked Issues

Fixes #231 (Fixes only the function arguments being evaluated twice)

## Description

I forgot that `hscript.Interp.expr(ECall)` evaluates the function parameters as well, so now we handle ECall directly in the overriden function, instead of falling back to `super.expr()`;