### PR TITLE
[FIX] Fix the "most deranged context loss error of all time"

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -652,16 +652,16 @@ class PolymodInterpEx extends Interp
 					return new PolymodEnum(_scriptEnumDescriptors.get(name), f, []);
 				}
 			case ECall(e,params):
-				var args = new Array();
-				for (p in params)
-					args.push(expr(p));
-
 				switch(Tools.expr(e)) {
 					case EField(e,f):
 						var name = getIdent(e);
 						name = getClassDecl().imports.get(name)?.fullPath ?? name;
 						if (name != null && _scriptEnumDescriptors.exists(name))
 						{
+							var args = new Array();
+							for (p in params)
+								args.push(expr(p));
+							
 							return new PolymodEnum(_scriptEnumDescriptors.get(name), f, args);
 						}
 					default:

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -589,9 +589,10 @@ class PolymodScriptClass
 
 			// Polymod.debug('Calling scripted class function "${fullyQualifiedName}.${fnName}(${args})"', null);
 
+			var r:Dynamic = null;
 			try
 			{
-				return _interp.executeEx(fn.expr);
+				r = _interp.executeEx(fn.expr);
 			}
 			catch (err:PolymodExprEx.ErrorEx)
 			{
@@ -599,7 +600,6 @@ class PolymodScriptClass
 				// A script error occurred while executing the script function.
 				// Purge the function from the cache so it is not called again.
 				purgeFunction(fnName);
-				return null;
 			}
 			catch (err:hscript.Expr.Error)
 			{
@@ -607,9 +607,9 @@ class PolymodScriptClass
 				// A script error occurred while executing the script function.
 				// Purge the function from the cache so it is not called again.
 				purgeFunction(fnName);
-				return null;
 			}
 
+			// This NEEDS to run regardless of the function succeeding or not, or else the previous values might be lost.
 			for (a in fn.args)
 			{
 				if (previousValues.exists(a.name))
@@ -621,6 +621,8 @@ class PolymodScriptClass
 					_interp.variables.remove(a.name);
 				}
 			}
+
+			return r;
 		}
 		else
 		{


### PR DESCRIPTION
## Linked Issues
Fixes #231 

## Description
Fixes both bugs that are part of the linked issue: functions being called twice in certain occasions and variables being lost from being overwritten but never restored to their previous values.