### PR TITLE
[FEATURE] Ability to merge scripts using `_merge`

### DIFF
--- a/polymod/format/ParseRules.hx
+++ b/polymod/format/ParseRules.hx
@@ -10,6 +10,11 @@ import polymod.util.Util;
 #if unifill
 import unifill.Unifill;
 #end
+#if hscript
+import hscript.Expr;
+import polymod.hscript._internal.Printer;
+import polymod.hscript._internal.Parser;
+#end
 import UnicodeString;
 
 class ParseRules
@@ -31,6 +36,7 @@ class ParseRules
       case JSON: new JSONParseFormat();
       case LINES: new LinesParseFormat(EndLineType.LF);
       case PLAINTEXT: new PlainTextParseFormat();
+      #if hscript case SCRIPT: new ScriptParseFormat(); #end
       default: new PlainTextParseFormat();
     }
     formats.set(extension, format);
@@ -689,6 +695,266 @@ class PlainTextParseFormat implements BaseParseFormat // <String>
   }
 }
 
+#if hscript
+class ScriptParseFormat implements BaseParseFormat // <String>
+{
+  public var format(default, null):TextFileFormat;
+
+  var parser:Parser = new Parser();
+  var printer:Printer = new Printer();
+
+  public function new()
+  {
+    format = SCRIPT;
+  }
+
+  public function parse(str:String):Array<ModuleDecl>
+  {
+    var output:Array<ModuleDecl> = [];
+    try
+    {
+      output = parser.parseModule(str);
+    }
+    catch (e:Error)
+    {
+      Polymod.error(ASSET_MERGE_FAILED, 'Script merge error: ${e.toString()}');
+      return [];
+    }
+
+    return output;
+  }
+
+  public function append(baseText:String, appendText:String, id:String):String
+  {
+    Polymod.warning(ASSET_MERGE_FAILED, '($id) Script files do not support append functionality!');
+    return baseText;
+  }
+
+  public function merge(baseText:String, mergeText:String, id:String):String
+  {
+    var baseDecls:Array<ModuleDecl> = parse(baseText);
+    var mergeDecls:Array<ModuleDecl> = parse(mergeText);
+    var output:String = baseText;
+
+    if (baseDecls.length == 0 || mergeDecls.length == 0)
+    {
+      return baseText;
+    }
+
+    for (decl in mergeDecls)
+    {
+      switch (decl)
+      {
+        case DImport(path, star, name):
+          // Simply push the import, duplicate imports are handled later.
+
+          baseDecls.push(decl);
+        case DPackage(path):
+          // If the base text doesn't have any package, add it in. Otherwise, don't replace it.
+
+          var hasPackage:Bool = false;
+          for (decl2 in baseDecls)
+          {
+            if (decl2.match(DPackage(_)))
+            {
+              hasPackage = true;
+              Polymod.warning(ASSET_MERGE_FAILED, 'Base Script already has a Package. Skipping.');
+              break;
+            }
+          }
+
+          if (!hasPackage) baseDecls.push(decl);
+        case DTypedef(c1):
+          // For Typedefs: if the base script has one with the same name, override it with @:mergeOverride metadata.
+          // Otherwise, add it regularly.
+
+          var hasTypedef:Bool = false;
+          var removeDecl:Null<ModuleDecl> = null;
+          for (decl2 in baseDecls)
+          {
+            switch (decl2)
+            {
+              case DTypedef(c2):
+                if (c2.name == c1.name)
+                {
+                  hasTypedef = true;
+
+                  if (!Type.enumEq(c2.t, c1.t))
+                  {
+                    // If the merge typedef has the @:mergeOverride metadata, override it.
+                    var metaNames:Array<String> = [for (m in c1.meta) m.name];
+                    if (metaNames.contains(":mergeOverride"))
+                    {
+                      removeDecl = decl2;
+                      hasTypedef = false;
+                      break;
+                    }
+                  }
+
+                  Polymod.warning(ASSET_MERGE_FAILED, 'Base script already has a typedef ${c1.name}. Skipping.');
+                }
+              default:
+            }
+          }
+
+          if (removeDecl != null) baseDecls.remove(removeDecl);
+          if (!hasTypedef) baseDecls.push(decl);
+        case DClass(c1):
+          // For classes, we handle things differently.
+          // If the class doesn't exist, add it.
+          // If the entire merged class has the @:mergeOverride metadata, replace the entire class.
+          // Otherwise add the missing fields with @:mergeAdd, including overriding the fields with @:mergeOverride.
+          // If a function has the @:mergeInsert metadata with an integer parameter, add the function content to the index from the parameter.
+
+          var hasClass:Bool = false;
+          var removeDecl:Null<ModuleDecl> = null;
+          for (decl2 in baseDecls)
+          {
+            switch (decl2)
+            {
+              case DClass(c2):
+                if (c1.name != c2.name) continue;
+                hasClass = true;
+
+                // Override the class if it has the @:mergeOverride metadata.
+                var metaNames:Array<String> = [for (m in c1.meta) m.name];
+                if (metaNames.contains(":mergeOverride"))
+                {
+                  removeDecl = decl2;
+                  hasClass = false;
+                  c1.meta.remove(c1.meta[metaNames.indexOf(":mergeOverride")]);
+                  break;
+                }
+
+                var fldNames:Array<String> = [for (fld in c2.fields) fld.name];
+                var removeFields:Array<FieldDecl> = [];
+                for (fld in c1.fields)
+                {
+                  var fldMetaNames:Array<String> = [for (m in fld.meta) m.name];
+
+                  // If the field has no metadata, do nothing.
+                  if (fldMetaNames.length == 0)
+                  {
+                    Polymod.warning(ASSET_MERGE_FAILED, 'Field ${fld.name} from the merge class ${c1.name} has no metadata. Skipping.');
+                    continue;
+                  }
+
+                  // If the field contains the @:mergeInsert metadata, insert the function expressions in the index.
+                  var metaInsertIndex:Int = fldMetaNames.indexOf(":mergeInsert");
+                  if (metaInsertIndex >= 0 && (fld.meta[metaInsertIndex].params?.length ?? 0) > 0)
+                  {
+                    var insertIndex:Int = switch (fld.meta[metaInsertIndex].params[0]#if hscriptPos .e #end)
+                    {
+                      case EConst(c):
+                        switch (c)
+                        {
+                          case CInt(v): v;
+                          default: 0;
+                        }
+                      default: 0;
+                    }
+
+                    switch (fld.kind)
+                    {
+                      case KFunction(f1):
+                        switch (c2.fields[fldNames.indexOf(fld.name)].kind)
+                        {
+                          case KFunction(f2):
+                            var funcExpr = #if hscriptPos f2.expr.e; #else f2.expr; #end
+
+                            // If the function isn't in a block, turn it into a block.
+                            switch (funcExpr)
+                            {
+                              case EBlock(b):
+                                b.insert(insertIndex, f1.expr);
+                              default:
+                                var exprArray:Array<Expr> = [f2.expr];
+                                exprArray.insert(insertIndex, f1.expr);
+                                funcExpr = EBlock(exprArray);
+                            }
+                          default:
+                            Polymod.warning(ASSET_MERGE_FAILED, 'Field ${fld.name} from the base class ${c2.name} is not a function. Skipping.');
+                        }
+                      default:
+                        Polymod.warning(ASSET_MERGE_FAILED, 'Field ${fld.name} from the merge class ${c1.name} is not a function. Skipping.');
+                    }
+                    continue;
+                  }
+
+                  // If the field has the @:mergeOverride metadata, override the class field.
+                  if (fldMetaNames.contains(":mergeOverride"))
+                  {
+                    removeFields.push(c2.fields[fldNames.indexOf(fld.name)]);
+                    fld.meta.remove(fld.meta[fldMetaNames.indexOf(":mergeOverride")]);
+                    c2.fields.push(fld);
+                    continue;
+                  }
+
+                  // If the field has the @:mergeAdd metadata, add it to the class if it doesn't already exist.
+                  if (fldMetaNames.contains(":mergeAdd"))
+                  {
+                    if (!fldNames.contains(fld.name))
+                    {
+                      c2.fields.push(fld);
+                    }
+                    else
+                    {
+                      Polymod.warning(ASSET_MERGE_FAILED, 'Field ${fld.name} from the merge class ${c1.name} already exists in the base class. Skipping.');
+                    }
+
+                    continue;
+                  }
+
+                  // Otherwise, throw a warning.
+                  Polymod.warning(ASSET_MERGE_FAILED, 'Field ${fld.name} from the merge class ${c1.name} doesn\'t have any merge metadata. Skipping.');
+                }
+
+                for (fld in removeFields)
+                {
+                  c2.fields.remove(fld);
+                }
+
+              default:
+            }
+          }
+
+          if (removeDecl != null) baseDecls.remove(removeDecl);
+          if (!hasClass) baseDecls.push(decl);
+        case DEnum(e1):
+          // For Enums: if the base script has an enum with the same name, throw a warning.
+          // Otherwise, add it to the base script.
+
+          var hasEnum:Bool = false;
+          for (decl2 in baseDecls)
+          {
+            switch (decl2)
+            {
+              case DEnum(e2):
+                if (e1.name == e2.name)
+                {
+                  hasEnum = true;
+                  Polymod.error(ASSET_MERGE_FAILED, 'Script merge error: Base Script already has an Enum ' + e1.name + ". Skipping.");
+                  continue;
+                }
+
+              default:
+            }
+          }
+
+          if (!hasEnum) baseDecls.push(decl);
+        default:
+      }
+    }
+
+    var realOutput:String = printer.modulesToString(baseDecls);
+    if (realOutput.length > 0) return realOutput;
+
+    // Failsafe in case the printing didn't work.
+    return output;
+  }
+}
+#end
+
 enum TextFileFormat
 {
   PLAINTEXT;
@@ -697,6 +963,7 @@ enum TextFileFormat
   TSV;
   XML;
   JSON;
+  #if hscript SCRIPT; #end
 }
 
 enum EndLineType

--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -488,4 +488,193 @@ class Printer
     #end
     return message;
   }
+
+  public function modulesToString(m:Array<ModuleDecl>)
+  {
+    var output:String = "";
+    if (m.length == 0) return output;
+
+    // Order the modules by priority (see hscript.Expr.ModuleDecl).
+    m.sort(function(a:ModuleDecl, b:ModuleDecl) {
+      var orderA:Int = Type.enumIndex(a);
+      var orderB:Int = Type.enumIndex(b);
+
+      return orderA == orderB ? 0 : orderA > orderB ? 1 : -1;
+    });
+
+    // Stringify every ModuleDecl.
+    for (module in m)
+    {
+      switch (module)
+      {
+        case DPackage(path):
+          output += "package " + path.join(".") + ";";
+
+        case DImport(path, star, name):
+          output += "import " + path.join(".");
+          if ((star ?? false))
+          {
+            output += ".*";
+          }
+          else
+          {
+            if (name != null) output += " as " + name;
+          }
+          output += ";";
+
+        case DUsing(path, star, name):
+          output += "using " + path.join(".");
+          if ((star ?? false))
+          {
+            output += ".*";
+          }
+          else
+          {
+            if (name != null) output += " as " + name;
+          }
+          output += ";";
+
+        case DClass(c):
+          output += metaToString(c.meta);
+          output += c.isPrivate ? "private " : "";
+          output += c.isExtern ? "extern " : "";
+          output += "class " + c.name;
+          if (Reflect.fields(c.params).length > 0) output += "<>"; // Once params are actually functional, this should be implemented.
+          output += " ";
+
+          if (c.extend != null) output += "extends " + this.typeToString(c.extend) + " ";
+          for (imp in c.implement)
+          {
+            output += "implements " + imp + " ";
+          }
+
+          output += "\n{";
+          output += classFieldsToString(c.fields);
+          output += "}";
+
+        case DTypedef(t):
+          output += metaToString(t.meta);
+          output += t.isPrivate ? "private " : "";
+          output += "typedef " + t.name;
+          if (Reflect.fields(t.params).length > 0) output += "<>"; // Once params are actually functional, this should be implemented.
+          output += " = " + this.typeToString(t.t);
+
+        case DEnum(e):
+          output += "enum " + e.name;
+          output += "\n{\n";
+
+          for (fld in e.fields)
+          {
+            output += fld.name;
+            if (fld.args.length > 0)
+            {
+              output += "(";
+              for (i in 0...fld.args.length)
+              {
+                var arg:EnumArgDecl = fld.args[i];
+                output += arg.name + (arg.type != null ? this.typeToString(arg.type) : "");
+                if (i < fld.args.length - 1) output += ", ";
+              }
+              output += ")";
+            }
+            output += "\n";
+          }
+
+          output += "}";
+      }
+
+      output += "\n";
+    }
+
+    return output;
+  }
+
+  function classFieldsToString(fields:Array<FieldDecl>)
+  {
+    if (fields.length == 0) return "\n";
+    var output:String = "\n";
+    for (fld in fields)
+    {
+      output += metaToString(fld.meta);
+
+      for (acc in fld.access)
+      {
+        switch (acc)
+        {
+          case APublic:
+            output += "public ";
+          case APrivate:
+            output += "private ";
+          case AInline:
+            output += "inline ";
+          case AOverride:
+            output += "override ";
+          case AStatic:
+            output += "static ";
+          case AMacro:
+            output += "macro ";
+        }
+      }
+
+      switch (fld.kind)
+      {
+        case KFunction(f):
+          output += "function " + fld.name + "(";
+          for (i in 0...f.args.length)
+          {
+            var arg:Argument = f.args[i];
+            if (arg.opt ?? false) output += "?";
+            output += arg.name + this.typeToString(arg.t);
+            if (arg.value != null) output += " = " + this.exprToString(arg.value);
+
+            if (i < f.args.length - 1) output += ", ";
+          }
+
+          output += ")";
+          if (f.ret != null) output += this.typeToString(f.ret);
+
+          output += this.exprToString(f.expr);
+
+        case KVar(v):
+          output += "var " + fld.name;
+          if (v.get != null || v.set != null)
+          {
+            output += "(" + (v.get ?? "default") + ", " + (v.set ?? "default") + ")";
+          }
+
+          if (v.type != null) output += this.typeToString(v.type);
+          if (v.expr != null) output += " = " + this.exprToString(v.expr);
+          output += ";";
+      }
+
+      output += "\n";
+    }
+
+    return output;
+  }
+
+  function metaToString(meta:Metadata)
+  {
+    if (meta.length == 0) return "";
+
+    var output:String = "";
+    for (m in meta)
+    {
+      output += "@" + m.name;
+      if (m.params != null)
+      {
+        output += "(";
+        for (i in 0...m.params.length)
+        {
+          var param:Expr = m.params[i];
+          output += this.exprToString(param);
+          if (i < m.params.length - 1) output += ", ";
+        }
+        output += ")";
+      }
+      output += "\n";
+    }
+
+    return output;
+  }
 }


### PR DESCRIPTION
This PR adds the ability to merge two or more scripts into one using the `_merge` method. Merging works similar to other merging methods, just with a different way things are patched in the base class.
This method is only available with the `hscript` library installed.

# Setup
In your project's `ParseRules`, you can set files and file extensions to have the `SCRIPT` as the file extension type. This will make it so that those specific files and files with the extension will be registered as scripts by Polymod and use the script merging method. For this method, only merging is available, appending will throw a warning.

# The process behind this
How merging works is that both the base text and the merged text will be split into tiny blocks using `hscript.Parser`. If the parser throws an error, the merging process is aborted. After the blocks have been merged, `PolymodPrinterEx` prints out the new text to be used for the script and furhter merging processes (albeit not very prettily).
Different "blocks" use different methods of being inserted into the base script.

## Packages
Packages are handled in a simple manner. If the base script doesn't have a set package, the package from the merged script will be used. Otherwise, nothing will happen.

## Imports
All imports from the merged script are added onto the base script because duplicate imports are handled later in `PolymodInterpEx`.

## Classes
The classes are the most complex part of the merging.
To start off, if the base script does not have a class named exactly like one from the merged script, the one from the merged script is added to the base script. If it does, you can use the newly-introduced metadata `@:mergeOverride` on the class to override the entire class from the base script.
Without the metadata, all fields are added from the merged class into the base class. If a merged field has the same name as a base class field, you can use `@:mergeOverride` on the field to override its value. Works on both variables and functions. Without the metadata, the merged field is ignored.
For functions, there exists another special metadata, `@:mergeInsert(index)`. If a merged function has this, the contents of the merged function will be merged into the base function at the index `index` (an integer value, will default to `0` if not defined). This means that if you have a base function
```
function foo()
{
 trace("foo!");
}
```
and a merge function
```
@:mergeInsert(1)
function foo()
{
 trace("foo2!");
}
```
the final result will look (roughly) like this
```
function foo()
{
 trace("foo!");
 trace("foo2!");
}
```

## Typedefs
Typedefs work similarly to classes, just much simpler. If there isn't a typedef with the same name as the merged typedef in the base script, the merged typedef is added into the base script.
Otherwise you can use the `@:mergeOverride` metadata to override the typedef.
If the merged and base typedefs have the same name and the typedefs are an anonymous structure, the missing fields from the merged typedef are copied over while the others are untouched.

## Enums (EXPERIMENTAL BRANCH ONLY)
Enums don't support metadata, so their way of merging is rather simple.
If merged and base enums have the same name, the fields from the merged enum are copied onto the base enum.
Otherwise, the merged enum is added into the base script.

# Closing
This will require a fuckton of testing so feel free to try it out and lemme know if there are bugs with anything! :] 

this repo kicks ass and i can make PRs while browsing
hahahahaha dude this PR is so fucking funny it makes me wanna merge scripts without looking