### PR TITLE
[FIX] Fix NOR when evaluating static variables with null expr

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -354,10 +354,10 @@ class PolymodInterpEx extends Interp
 						var decl = _proxy.findVar(id);
 						if (decl != null)
 						{
-							var v = switch (decl.get)
+							var v:Dynamic = switch (decl.get)
 							{
 								case "get": _proxy.callFunction('get_$id');
-								default: expr(decl.expr);
+								default: decl.expr != null ? expr(decl.expr) : null;
 							}
 
 							if (prefix)
@@ -1425,9 +1425,12 @@ class PolymodInterpEx extends Interp
 						this.variables.set(prefixedName, result);
 						return result;
 					case KVar(v):
-						var result = this.expr(v.expr);
-						this.variables.set(prefixedName, result);
-						return result;
+						if (v.expr != null) {
+							var result = this.expr(v.expr);
+							this.variables.set(prefixedName, result);
+							return result;
+						}
+						return null;
 					default:
 						throw 'Wuh?';
 				}


### PR DESCRIPTION
## Related issue
https://github.com/FunkinCrew/Funkin/issues/5576

## Minimal repro of the issues in question
```haxe
public static var statObj1:Dynamic = null;
public static var statObj2:Dynamic; // <- the feloner...
public var prop(default, set):Int;

// NOTE: Can't do return prop = v because it'll just infinitely call the setter recursively, I don't think this is the intended behavior.
public function set_prop(v) { return v; } 

public function test() {
  trace (statObj1 == null); // No issues at all
  trace (statObj2 == null); // Polymod implodes here
  trace(prop++); // Implodes here too
}
```

## Description
Fixes static variables with no default value (e.g `static var x:Int;`) causing a NOR when accessed, also does the same for when a property is used in an in/decrement operation.