### PR TITLE
[OPTIMIZATION] Optimize listing modded assets from libraries

### DIFF
--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -863,7 +863,7 @@ class LimeModLibrary extends LimeAssetLibrary
 			}
 		};
 
-		var libraryItems = [for (i in p.type.keys()) i];
+		var libraryItems = p.typeLibraries.get(libraryId) ?? [];
 		for (id in libraryItems)
 		{
 			// Skip ignored files.

--- a/polymod/backends/PolymodAssets.hx
+++ b/polymod/backends/PolymodAssets.hx
@@ -145,6 +145,7 @@ class PolymodAssets
 			extensionMap: params.extensionMap,
 			fileSystem: params.fileSystem,
 			assetPrefix: params.assetPrefix,
+			frameworkParams: params.frameworkParams,
 			#if firetongue
 			firetongue: params.firetongue,
 			#end


### PR DESCRIPTION
Closes https://github.com/larsiusprime/polymod/issues/238

Hyper pointed it out to me in a DM that around 8 months ago there has been made a commit that made every lime library list every asset from the game, regardless of if the library itself has the asset or not. This PR fixes it by implementing library checking in `PolymodAssetLibrary`.