### PR TITLE
[ENHANCEMENT] Improve properties support

### DIFF
--- a/polymod/hscript/_internal/PolymodExprEx.hx
+++ b/polymod/hscript/_internal/PolymodExprEx.hx
@@ -52,6 +52,9 @@ EInvalidScriptedFnAccess(f:String);
 EInvalidScriptedVarGet(v:String);
 EInvalidScriptedVarSet(v:String);
 EInvalidFinalSet(f:String);
+EInvalidPropGet(p:String);
+EInvalidPropSet(p:String);
+EPropVarNotReal(p:String);
 EInvalidInStaticContext(v:String); // Accessing "this" or "super" in a static function
 EClassSuperNotCalled;
 EClassUnresolvedSuperclass(c:String, r:String); // superclass and reason

--- a/polymod/hscript/_internal/PolymodPrinterEx.hx
+++ b/polymod/hscript/_internal/PolymodPrinterEx.hx
@@ -17,6 +17,9 @@ class PolymodPrinterEx extends Printer
 			case EInvalidIterator(v): "Invalid iterator: " + v;
 			case EInvalidOp(op): "Invalid operator: " + op;
 			case EInvalidAccess(f): "Invalid access to field " + f;
+			case EInvalidPropGet(p): "Cannot access property " + p + " for reading";
+			case EInvalidPropSet(p): "Cannot access property " + p + " for writing";
+			case EPropVarNotReal(p): "Cannot access property " + p + " because it is not a real variable";
 			case EInvalidModule(m): "Invalid module: " + m;
 			case EBlacklistedModule(m): "Blacklisted module: " + m;
 			case EInvalidInStaticContext(v): "Invalid field access from static context: " + v;

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -542,6 +542,18 @@ class PolymodScriptClass
 				Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
 					'Error while executing function ${className}.${fnName}()#${errLine}:' + '\n' +
 					'Tried to access "${f}", but it is not a valid field or method. Is the target object null?');
+			case EInvalidPropGet(p):
+				Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+					'Error while executing function ${className}.${fnName}()#${errLine}:' + '\n' +
+					'Property "${p}" is not accessible for reading.');
+			case EInvalidPropSet(p):
+				Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+					'Error while executing function ${className}.${fnName}()#${errLine}:' + '\n' +
+					'Property "${p}" is not accessible for writing.');
+			case EPropVarNotReal(p):
+				Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+					'Error while executing function ${className}.${fnName}()#${errLine}:' + '\n' +
+					'Property "${p}" cannot be accessed because it is not a real variable. Add @:isVar to enable it.');
 			case EScriptThrow(v):
 				Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
 					'Error while executing function ${className}.${fnName}()#${errLine}:' + '\n' +


### PR DESCRIPTION
Improves support for properties so that they act more like Haxe ones.

* Accessing a property inside its get/set won't cause infinite recursion anymore.
* Properties with both a getter and a setter will act like they don't have a "physical field", so trying to access it inside them will yield an error, just like in Haxe. Adding `@:isVar` to the field will prevent this.
* Fixes postfix increment not acting like it should.