### PR TITLE
[FIX] Fix yet another case of context loss

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -564,8 +564,6 @@ class PolymodScriptClass
 		}
 	}
 
-	static final previousValues:Map<String, Dynamic> = [];
-
 	@:privateAccess(hscript.Interp)
 	public function callFunction(fnName:String, args:Array<Dynamic> = null):Dynamic
 	{
@@ -575,7 +573,7 @@ class PolymodScriptClass
 		if (fn != null)
 		{
 			// previousValues is used to restore variables after they are shadowed in the local scope.
-			previousValues.clear();
+			var previousValues:Map<String, Dynamic> = [];
 			var i = 0;
 			for (a in fn.args)
 			{


### PR DESCRIPTION
### Minimal repro
```haxe
function func1(event)
{
  func2(); // This function causes "event" to be deleted after `func1` is exited
  trace(event); 
}

function func2()
{
  //yadayada
}

public override function onUpdate(event:ScriptEvent):Void
{
  if (FlxG.keys.justPressed.HOME)
  {
    func1(event);
    trace(event); // With the variable now lost this line causes an EInvalidAccess("event") error
  }
}
```
This is because `previousValues` is now a static Map rather than part of the execution's local scope (which was apparently done as an optimization), which means all scripted functions share the same set of previous values. So every time a function is called inside another the previous context gets lost.
And the argument becomes a figment of our minds in this snippet. Since the previous value doesn't exist in `previousValues` anymore whatever existing variable with the same name ends up being removed.
https://github.com/larsiusprime/polymod/blob/0d2868e53d45f2cbad7f9255f617aafd98d33cf3/polymod/hscript/_internal/PolymodScriptClass.hx#L625-L635

I think though that a proper fix would be to revert to the previous code where it's a local variable, or maybe append the function name to the argument names so that existing variables aren't prone to issues.