### PR TITLE
[FIX] Fix NOR when trying to iterate `null`

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -950,6 +950,7 @@ class PolymodInterpEx extends Interp
 
 	override function makeIterator(v:Dynamic):Iterator<Dynamic>
 	{
+		if (v == null) errorEx(EInvalidIterator(v));
 		if (v.iterator != null)
 		{
 			try


### PR DESCRIPTION
The feloner:
```haxe
var array = null;
for (i in array)
{
	// code no workie cuz game crashie :(
}
```
Makes it so instead of it making the game implode it now causes a `Invalid iterator: null` error.