### PR TITLE
Fix ZIP assets being listed as lowercase when using case-insensitive config

### DIFF
--- a/polymod/fs/SysZipFileSystem.hx
+++ b/polymod/fs/SysZipFileSystem.hx
@@ -159,20 +159,16 @@ class SysZipFileSystem extends SysFileSystem
 
 			// We check if directory ==, because
 			// we don't want to read the directory recursively.
-			final keys = insensitive ? (cast filesLocations).keysLowerCase() : filesLocations.keys();
-			for (file in keys)
+			for (file in filesLocations.keys())
 			{
-				var filePath = Path.directory(file);
-				if (filePath == path)
+				if (Path.directory(insensitive ? file.toLowerCase() : file) == path)
 				{
 					result.push(Path.withoutDirectory(file));
 				}
 			}
 			for (dir in fileDirectories)
 			{
-				var dirPath = Path.directory(dir);
-				if (insensitive) dirPath = dirPath.toLowerCase();
-				if (dirPath == path)
+				if (Path.directory(insensitive ? dir.toLowerCase() : dir) == path)
 				{
 					result.push(Path.withoutDirectory(dir));
 				}

--- a/polymod/util/InsensitiveMap.hx
+++ b/polymod/util/InsensitiveMap.hx
@@ -51,10 +51,6 @@ class InsensitiveMap<T> implements IMap<String, T> {
       return originalKeys.iterator();
     }
 
-    public inline function keysLowerCase():Iterator<String> {
-      return data.keys();
-    }
-
     public function keyValueIterator() {
       return {
         final it = originalKeys.keys();


### PR DESCRIPTION
This was the result of an attempt at optimizing something that went real wrong. For instance trying to load QT-Rewired as a mod this caused all characters to fail to load since the mod made them all uppercase for some reason.