### PR TITLE
[FIX] Fix mod assets always going into the `default` library

### DIFF
--- a/polymod/backends/HEAPSBackend.hx
+++ b/polymod/backends/HEAPSBackend.hx
@@ -241,7 +241,7 @@ class ModFileEntry extends BytesFileEntry
 		{
 			if (id.indexOf(dirPath) != 0)
 				continue;
-			if (id.indexOf(PolymodConfig.appendFolder) == 0 || id.indexOf(PolymodConfig.mergeFolder) == 0)
+			if (Util.isMergeOrAppend(id))
 				continue;
 			if (p.ignoredFiles.indexOf(id) != -1)
 				continue;

--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -870,7 +870,7 @@ class LimeModLibrary extends LimeAssetLibrary
 			if (p.isAssetExcluded(id)) continue;
 
 			// Skip append/merge files.
-			if (id.startsWith(PolymodConfig.appendFolder) || id.startsWith(PolymodConfig.mergeFolder))
+			if (Util.isMergeOrAppend(id))
 				continue;
 
 			#if firetongue

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -249,7 +249,7 @@ class PolymodAssetLibrary
 		{
 			if (items.indexOf(id) != -1)
 				continue;
-			if (id.indexOf('_append') == 0 || id.indexOf('_merge') == 0)
+			if (Util.isMergeOrAppend(id))
 				continue;
 			if (type == null || type == BYTES || check(id, type))
 			{
@@ -502,8 +502,13 @@ class PolymodAssetLibrary
 			var assetType = getExtensionType(ext);
 			type.set(f, assetType);
 
-			var libi = Util.uIndexOf(f, "/");
-			var lib:String = libi != -1 ? f.substring(0, libi + 1) : '';
+			var kruePath:String = f;
+			for (folder in [PolymodConfig.mergeFolder, PolymodConfig.appendFolder])
+			{
+				if (Util.uIndexOf(f, '$folder/') == 0) { kruePath = Util.uSubstring(f, folder.length + 1); break; }
+			}
+			var libi = Util.uIndexOf(kruePath, '/');
+			var lib:String = libi != -1 ? Util.uSubstring(kruePath, 0, libi) : '';
 			if (lib != '')
 			{
 				var added = false;

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -39,6 +39,11 @@ class Util
 		return parentDirs;
 	}
 
+	public static inline function isMergeOrAppend(id:String):Bool
+	{
+		return uIndexOf(id, PolymodConfig.mergeFolder) == 0 || uIndexOf(id, PolymodConfig.appendFolder) == 0;
+	}
+
 	public static function mergeAndAppendText(baseText:String, id:String, dirs:Array<String>, getModText:String->String->String, fileSystem:IFileSystem,
 			parseRules:ParseRules = null):String
 	{
@@ -360,7 +365,7 @@ class Util
 		return result;
 	}
 
-	public static function sl():String
+	public static inline function sl():String
 	{
 		return '/';
 	}
@@ -503,7 +508,7 @@ class Util
 		return extension;
 	}
 
-	public static function uIndexOf(str:String, substr:String, ?startIndex:Int):Int
+	public static inline function uIndexOf(str:String, substr:String, ?startIndex:Int):Int
 	{
 		#if unifill
 		return Unifill.uIndexOf(str, substr, startIndex);
@@ -512,7 +517,7 @@ class Util
 		#end
 	}
 
-	public static function uLastIndexOf(str:String, value:String, ?startIndex:Int):Int
+	public static inline function uLastIndexOf(str:String, value:String, ?startIndex:Int):Int
 	{
 		#if unifill
 		return Unifill.uLastIndexOf(str, value, startIndex);
@@ -521,7 +526,7 @@ class Util
 		#end
 	}
 
-	public static function uLength(str:String):Int
+	public static inline function uLength(str:String):Int
 	{
 		#if unifill
 		return Unifill.uLength(str);
@@ -609,7 +614,7 @@ class Util
 		return str;
 	}
 
-	public static function uSplit(str:String, substr:String):Array<String>
+	public static inline function uSplit(str:String, substr:String):Array<String>
 	{
 		#if unifill
 		return Unifill.uSplit(str, substr);
@@ -642,7 +647,7 @@ class Util
 		return sb.toString();
 	}
 
-	public static function uSubstr(str:String, pos:Int, ?len:Int):String
+	public static inline function uSubstr(str:String, pos:Int, ?len:Int):String
 	{
 		#if unifill
 		return Unifill.uSubstr(str, pos, len);
@@ -651,7 +656,7 @@ class Util
 		#end
 	}
 
-	public static function uSubstring(str:String, startIndex:Int, ?endIndex:Int):String
+	public static inline function uSubstring(str:String, startIndex:Int, ?endIndex:Int):String
 	{
 		#if unifill
 		return Unifill.uSubstring(str, startIndex, endIndex);
@@ -686,7 +691,7 @@ class Util
         return -1;
     }
 
-    public inline static function containsInsens(arr:Array<String>, x:String, ignoreConfig:Bool = false):Bool
+    public static inline function containsInsens(arr:Array<String>, x:String, ignoreConfig:Bool = false):Bool
     {
         return indexOfInsens(arr, x, ignoreConfig) != -1;
     }


### PR DESCRIPTION
## Description

A previous pull request optimized the asset loading code, and with it introduced code where mod assets are redirected to the proper libraries based on the first folder in the path; however it failed to realize it was including the slash when comparing the library names, so for instance it would compare `shared/ == shared`, basically failing every time. This PR fixes that.

Aside from the minor adjustments, it will also now check if the path is in an `_append` or `_merge` folder, though it doesn't fix how other libraries are not being accounted for in the append/merge path, so given a file in `shared:someFile.txt`, appending will require the path to be `_append/someFile.txt` instead of `_append/shared/someFile.txt`. All usually mergeable/appendable files in FNF are in the `default` library anyway so this could be solved in the future.