### PR TITLE
[BUGFIX] Fix the `remove` function in arrays not working on web

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -159,12 +159,14 @@ class PolymodInterpEx extends Interp
 			func = get(o, "includes");
 		}
 
+		#if html5
 		// For web: remove is inlined so we have to use something else.
 		if (func == null && f == "remove")
 		{
 			@:privateAccess
 			return HxOverrides.remove(cast o, args[0]);
 		}
+		#end
 
 		if (func == null)
 		{


### PR DESCRIPTION
They made my man `remove` inlined literally why
<img width="436" height="70" alt="image" src="https://github.com/user-attachments/assets/9e22ce3f-f049-467e-8bd2-7e0888c90723" />
