### PR TITLE
[FIX] Fix weird error reports in local functions

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -37,6 +37,16 @@ class PolymodInterpEx extends Interp
 		}
 	}
 
+	function getClassFullyQualifiedName():Null<String> {
+		if (_proxy == null)
+		{
+			var clsDecl = getClassDecl() ?? return null;
+			return PolymodStaticClassReference.tryBuild(clsDecl.name)?.getFullyQualifiedName();
+		}
+
+		return _proxy.fullyQualifiedName;
+	}
+
 	public function new(targetCls:Class<Dynamic>, proxy:PolymodAbstractScriptClass)
 	{
 		super();
@@ -625,12 +635,12 @@ class PolymodInterpEx extends Interp
 						}
 						catch (err:PolymodExprEx.ErrorEx)
 						{
-							PolymodScriptClass.reportErrorEx(err, _proxy?.fullyQualifiedName, name);
+							PolymodScriptClass.reportErrorEx(err, getClassFullyQualifiedName(), name);
 							r = null;
 						}
 						catch (err:hscript.Expr.Error)
 						{
-							PolymodScriptClass.reportError(err, _proxy?.fullyQualifiedName, name);
+							PolymodScriptClass.reportError(err, getClassFullyQualifiedName(), name);
 							r = null;
 						}
 						catch (err:Dynamic)
@@ -1076,12 +1086,12 @@ class PolymodInterpEx extends Interp
 		}
 		catch (err:PolymodExprEx.ErrorEx)
 		{
-			PolymodScriptClass.reportErrorEx(err, _proxy?.fullyQualifiedName);
+			PolymodScriptClass.reportErrorEx(err, getClassFullyQualifiedName());
 			return null;
 		}
 		catch (err:hscript.Expr.Error)
 		{
-			PolymodScriptClass.reportError(err, _proxy?.fullyQualifiedName);
+			PolymodScriptClass.reportError(err, getClassFullyQualifiedName());
 			return null;
 		}
 		catch (err:Dynamic)

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -625,12 +625,12 @@ class PolymodInterpEx extends Interp
 						}
 						catch (err:PolymodExprEx.ErrorEx)
 						{
-							PolymodScriptClass.reportErrorEx(err, 'anonymous');
+							PolymodScriptClass.reportErrorEx(err, _proxy?.fullyQualifiedName, name);
 							r = null;
 						}
 						catch (err:hscript.Expr.Error)
 						{
-							PolymodScriptClass.reportError(err, 'anonymous');
+							PolymodScriptClass.reportError(err, _proxy?.fullyQualifiedName, name);
 							r = null;
 						}
 						catch (err:Dynamic)
@@ -1076,12 +1076,12 @@ class PolymodInterpEx extends Interp
 		}
 		catch (err:PolymodExprEx.ErrorEx)
 		{
-			PolymodScriptClass.reportErrorEx(err, 'anonymous');
+			PolymodScriptClass.reportErrorEx(err, _proxy?.fullyQualifiedName);
 			return null;
 		}
 		catch (err:hscript.Expr.Error)
 		{
-			PolymodScriptClass.reportError(err, 'anonymous');
+			PolymodScriptClass.reportError(err, _proxy?.fullyQualifiedName);
 			return null;
 		}
 		catch (err:Dynamic)

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -479,12 +479,15 @@ class PolymodScriptClass
 	public static function reportError(err:hscript.Expr.Error, className:String = null, fnName:String = null)
 	{
 		var errEx = PolymodExprEx.ErrorExUtil.toErrorEx(err);
-		reportErrorEx(errEx, fnName);
+		reportErrorEx(errEx, className, fnName);
 	}
 
 	public static function reportErrorEx(err:PolymodExprEx.ErrorEx, className:String = null, fnName:String = null):Void
 	{
 		var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
+
+		className ??= '???';
+		fnName ??= 'anonymous';
 
 		#if hscriptPos
 		switch (err.e)


### PR DESCRIPTION
Fixes instances where errors in local functions report `null` (or erroneously "anonymous" or the function name) as a class

| Named Function | Unamed Function |
|--------|--------|
|<img width="702" height="245" alt="Captura de imagem_20250922_183307" src="https://github.com/user-attachments/assets/a0619737-deec-4a1b-88d6-b1a47b7068b3" />|<img width="710" height="246" alt="Captura de imagem_20250922_181933" src="https://github.com/user-attachments/assets/8775b4a5-ccc4-463c-9273-43791a1c2867" />| 