### PR TITLE
[BUGFIX] Fix locals getting dropped after calling script's own `scriptCall`

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -599,6 +599,9 @@ class PolymodScriptClass
 
 			// Polymod.debug('Calling scripted class function "${fullyQualifiedName}.${fnName}(${args})"', null);
 
+			// Copy the locals and store them for later.
+			var localsCopy:Map<String, {r:Dynamic, ?isfinal:Null<Bool>}> = _interp.locals.copy();
+
 			var r:Dynamic = null;
 			try
 			{
@@ -631,6 +634,9 @@ class PolymodScriptClass
 					_interp.variables.remove(a.name);
 				}
 			}
+
+			// Restore the locals.
+			_interp.locals = localsCopy;
 
 			return r;
 		}


### PR DESCRIPTION
Basically fixes locals getting dropped when doing something like this
```
function onCreate(event:ScriptEvent)
{
    var i:Int = 0;
    scriptCall("americaYa");
    trace(i); // Normally this would cause a NOR
}

function americaYa()
{
    trace("hallo :D");
}
```

I wouldnt be surprised if this change fixes other instances of locals getting dropped since I modified PolymodScriptClass' `callFunction` function.