### PR TITLE
Fixes for HashLink

### DIFF
--- a/polymod/hscript/_internal/HLWrapperMacro.hx
+++ b/polymod/hscript/_internal/HLWrapperMacro.hx
@@ -1,0 +1,187 @@
+package polymod.hscript._internal;
+
+#if (!macro && hl)
+@:build(polymod.hscript._internal.HLWrapperMacro.buildWrapperClass())
+class HLMath extends Math {}
+
+@:build(polymod.hscript._internal.HLWrapperMacro.buildWrapperClass())
+@:haxe.warning("-WDeprecated")
+class HLStd extends Std
+{
+  public static function is(v:Dynamic, t:Dynamic)
+    return isOfType(v, t);
+
+  public static function isOfType(v:Dynamic, t:Dynamic):Bool
+  {
+    // HL oddly uses hl.Bytes for strings sometimes
+    // We do a hack since we can't just do isOfType(v, hl.Bytes)
+    if (t == String && !Std.isOfType(v, String))
+    {
+      function bytesTest(_:hl.Bytes) {}
+      try
+      {
+        bytesTest(v);
+        return true;
+      }
+      catch (_)
+      {
+        return false;
+      }
+    }
+
+    return Std.isOfType(v, t);
+  }
+}
+#else
+import haxe.macro.MacroStringTools;
+import haxe.macro.TypedExprTools;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.Type;
+
+using Lambda;
+using haxe.macro.TypeTools;
+using haxe.macro.ComplexTypeTools;
+using haxe.macro.ExprTools;
+using StringTools;
+
+/**
+ * Macro that generates wrapper fields for substitutes of `std` classes to make them avaliable to Reflection.
+ * Currently only works for static fields.
+ */
+class HLWrapperMacro
+{
+  public static macro function buildWrapperClass():Array<Field>
+  {
+    var localClass = Context.getLocalClass().get();
+    var superClass = localClass.superClass;
+    if (superClass == null) throw 'Class ${localClass.name} does not extend class it wants to wrap';
+    var cls = superClass.t.get();
+    var buildFields = Context.getBuildFields();
+
+    for (field in cls.statics.get())
+    {
+      if (field.isPublic && !buildFields.exists((f) -> f.name == field.name))
+      {
+        var wrapper = generateWrapper(field, cls);
+        if (wrapper != null) buildFields.push(wrapper);
+      }
+    }
+    buildFields.push(generateToString(cls));
+
+    return buildFields;
+  }
+
+  static function generateWrapper(field:ClassField, cls:ClassType):Null<Field>
+  {
+    if (field == null) throw 'Field is null';
+
+    var newField:Field =
+      {
+        name: field.name,
+        doc: field.doc,
+        meta: null,
+        pos: field.pos,
+        access: [APublic, AStatic, AInline],
+        kind: null
+      };
+
+    function populateNewField(t:Type):Bool
+    {
+      return switch (t)
+      {
+        case TLazy(lz):
+          var ty = lz();
+          return populateNewField(ty);
+        case TFun(args, ret):
+          var funcArgs:Array<FunctionArg> = [
+            for (arg in args)
+              {
+                name: arg.name,
+                opt: arg.opt,
+                type: Context.toComplexType(arg.t)
+              }
+          ];
+          var ret = Context.toComplexType(ret);
+          var callArgs:Array<Expr> = [for (arg in funcArgs) macro $i{arg.name}];
+          var funcParams:Array<TypeParamDecl> = [for (p in field.params) {name: p.name, constraints: getConstraints(p.t)}];
+          var body:Expr = macro $p{[cls.name, field.name]}($a{callArgs});
+
+          newField.kind = FFun(
+            {
+              args: funcArgs,
+              params: funcParams,
+              ret: ret,
+              expr: doesReturnVoid(ret) ? (macro $body) : (macro return $body)
+            });
+          return true;
+        default: false;
+      }
+    }
+
+    if (populateNewField(field.type))
+    {
+      return newField;
+    }
+    else if (field.expr() == null)
+    {
+      var overKind = switch (field.kind)
+      {
+        case FVar(_, _):
+          // We're overriding a VARIABLE, it shouldn't be modifiable
+          FieldType.FProp('default', 'null', Context.toComplexType(field.type), macro $p{[cls.name, field.name]});
+        default: throw "Not implemented!";
+      }
+
+      return {
+        name: field.name,
+        doc: field.doc,
+        meta: field.meta.get(),
+        pos: field.pos,
+        access: [APublic, AStatic],
+        kind: overKind
+      };
+    }
+
+    return null;
+  }
+
+  static function generateToString(cls:ClassType):Field
+  {
+    return {
+      name: 'toString',
+      access: [APublic],
+      pos: cls.pos,
+      kind: FFun(
+        {
+          args: [],
+          ret: macro :String,
+          expr: macro return $v{cls.name}
+        })
+    };
+  }
+
+  static function getConstraints(t:Type)
+  {
+    return switch (t)
+    {
+      case TInst(_.get() => c, _):
+        switch (c.kind)
+        {
+          case KTypeParameter(consts): [for (c in consts) Context.toComplexType(c)];
+          default: throw 'Invalid class kind, it is not a TypeParameter';
+        }
+      case _: throw '$t has not been implemented!';
+    }
+  }
+
+  static inline function doesReturnVoid(rt:ComplexType)
+  {
+    return switch (rt)
+    {
+      case TPath(tp): tp.name == "Void";
+      default: false;
+    }
+  }
+}
+#end

--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -244,6 +244,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
       @:privateAccess this._interp.error(EInvalidAccess(name));
       // throw "field '" + name + "' does not exist in script class '" + this.fullyQualifiedName + "' or super class '" + Type.getClassName(Type.getClass(this.superClass)) + "'";
     }
+    return null;
   }
 
   private static function retrieveClassObjectFields(o:Dynamic):Array<String>

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -247,8 +247,8 @@ class PolymodInterpEx extends Interp
   {
     super.resetVariables();
 
-    variables.set("Math", Math);
-    variables.set("Std", Std);
+    variables.set("Math", #if hl polymod.hscript._internal.HLWrapperMacro.HLMath #else Math #end);
+    variables.set("Std", #if hl polymod.hscript._internal.HLWrapperMacro.HLStd #else Std #end);
 
     variables.set("Array", Array);
     variables.set("Bool", Bool);
@@ -1201,7 +1201,12 @@ class PolymodInterpEx extends Interp
     {
       try
       {
+        #if hl
+        // HL is a bit weird with iterators with arguments
+        v = Reflect.callMethod(v, v.iterator, []);
+        #else
         v = v.iterator();
+        #end
       }
       catch (e:Dynamic) {};
     }
@@ -1352,6 +1357,7 @@ class PolymodInterpEx extends Interp
     }
 
     var oCls:String = Util.getTypeNameOf(o);
+    #if hl oCls = oCls.replace('$', ''); #end
 
     // Check if the field is a blacklisted static field.
     if (PolymodScriptClass.blacklistedStaticFields.exists(o) && PolymodScriptClass.blacklistedStaticFields.get(o).contains(f))
@@ -1437,8 +1443,27 @@ class PolymodInterpEx extends Interp
       // #end
       // return result;
     }
+    #if (hl && haxe4)
+    else if (Std.isOfType(o, Enum))
+    {
+      try
+      {
+        return (o : Enum<Dynamic>).createByName(f);
+      }
+      catch (e)
+      {
+        error(EInvalidAccess(f));
+      }
+    }
+    #end
 
     // Default behavior
+    #if hl
+    // On HL, hasField on properties returns true but Reflect.field
+    // might return null so we have to check if a getter exists too.
+    // This happens mostly when the programmer mistakenly makes the field access (get, null) instead of (get, never)
+    return Reflect.getProperty(o, f);
+    #else
     if (Reflect.hasField(o, f))
     {
       return Reflect.field(o, f);
@@ -1454,6 +1479,7 @@ class PolymodInterpEx extends Interp
         return Reflect.field(o, f);
       }
     }
+    #end
     // return super.get(o, f);
   }
 
@@ -1462,6 +1488,7 @@ class PolymodInterpEx extends Interp
     if (o == null) error(ENullObjectReference(f));
 
     var oCls:String = Util.getTypeNameOf(o);
+    #if hl oCls = oCls.replace('$', ''); #end
 
     // Check if the field is a blacklisted static field.
     if (PolymodScriptClass.blacklistedStaticFields.exists(o) && PolymodScriptClass.blacklistedStaticFields.get(o).contains(f))

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -377,6 +377,7 @@ class PolymodScriptClassMacro
                 case FMethod(k):
                   if (k != MethInline) continue;
                   if (abstractPath.startsWith('cpp')) continue;
+                  if (abstractPath.startsWith('hl')) continue;
                   if (abstractPath.startsWith('flixel.graphics.atlas.HashOrArray')) continue; // has to be ragebait
                   if (abstractType.isPrivate) continue;
 


### PR DESCRIPTION
Fixes some issues with HashLink: an error when trying to resolve abstracts, and a workaround for https://github.com/HaxeFoundation/hscript/issues/96 by using a macro that creates a wrapper class for `Std` and `Math`.

Edit: Now also fixes enum values not being evaluated properly