### PR TITLE
[ENHANCEMENT] Display an error when redefining a variable

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -474,6 +474,21 @@ class PolymodScriptClass
 
 			superClass = Type.createInstance(clsToCreate, args);
 		}
+
+		// Throw an error if the script class has an instance field with the same name as one from the super class.
+		for (f in _c.fields)
+		{
+			switch (f.kind)
+			{
+				case KVar(v):
+					if (!f.access.contains(AStatic) && superHasField(f.name))
+					{
+						throw 'Redefinition of variable "${f.name}" from superclass not allowed';
+					}
+
+				case _:
+			}
+		}
 	}
 
 	public static function reportError(err:hscript.Expr.Error, className:String = null, fnName:String = null)


### PR DESCRIPTION
If one were to redefine a variable from the super class inside a scripted class, it could potentially cause a crash. This PR displays a warning whenever that happens so that modders aren't left confused for seemingly no reason.
This only applies to non-static variables - functions are left intact (since otherwise it'd be a breaking change lmao)

<img width="393" height="207" alt="image" src="https://github.com/user-attachments/assets/eefd6d82-2cef-428f-977a-05a572f47891" />
