### PR TITLE
[FIX] Don't call function from `using` class if the target object has it

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -157,19 +157,19 @@ class PolymodInterpEx extends Interp
 
 		@:privateAccess
 		{
-			if (_proxy != null && _proxy._cachedUsingFunctions.exists(f))
+			if (func == null && _proxy != null && _proxy._cachedUsingFunctions.exists(f))
 			{
 				return _proxy._cachedUsingFunctions[f]([o].concat(args));
 			}
 		}
 
+		#if html5
 		// Workaround for an HTML5-specific issue.
 		// https://github.com/HaxeFoundation/haxe/issues/11298
 		if (func == null && f == "contains") {
 			func = get(o, "includes");
 		}
 
-		#if html5
 		// For web: remove is inlined so we have to use something else.
 		if (func == null && f == "remove")
 		{


### PR DESCRIPTION
### Description
Whenever you have `using StringTools` and try to do something like `array.contains`, `StringTools.contains` will incorrectly be called instead, and this PR fixes that. In the C++ target that surprisingly doesn't cause any issues since the array gets converted into a string for some reason which miraculously makes it work, but that may not be the case for other classes and types. In Haxe, if a type and a `using` class for that type have functions with the same name the one from the type will be called, so this basically makes it act like Haxe would too.

Originally this involved using a macro to add RTTI data to all classes with `Tools` on their name and using that data to compare the type of the first argument of the function with the type, but I quickly realized that was overkill. If the macro seems like a good idea tell me if I should re-implement it.