### PR TITLE
[FIX] Error if HScript isn't installed

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -747,6 +747,7 @@ class Polymod
 		return futures;
 		#else
 		Polymod.warning(SCRIPT_HSCRIPT_NOT_INSTALLED, "Cannot register script classes, HScript is not available.");
+		return [];
 		#end
 	}
 


### PR DESCRIPTION
If hscript isn't installed, it usually won't register script classes but now it just prevents you from compiling all together and this pr fixes that by returning an empty array if hscript isn't installed.