### PR TITLE
[BUGFIX] Stop static class declaration from getting lost in local functions

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -549,6 +549,7 @@ class PolymodInterpEx extends Interp
 				var capturedLocals = duplicate(locals);
 				var me = this;
 				var hasOpt = false, minParams = 0;
+				var capturedClassDecl = _classDeclOverride;
 				for (p in params)
 				{
 					if (p.opt)
@@ -600,8 +601,10 @@ class PolymodInterpEx extends Interp
 					}
 					var old = me.locals;
 					var depth = me.depth;
+					var previousClassDecl = me._classDeclOverride;
 					me.depth++;
 					me.locals = me.duplicate(capturedLocals);
+					me._classDeclOverride = capturedClassDecl;
 					for (i in 0...params.length)
 					{
 						me.locals.set(params[i].name, {r: args[i]});
@@ -651,6 +654,7 @@ class PolymodInterpEx extends Interp
 					restore(oldDecl);
 					me.locals = old;
 					me.depth = depth;
+					me._classDeclOverride = previousClassDecl;
 					return r;
 				};
 
@@ -1324,7 +1328,6 @@ class PolymodInterpEx extends Interp
 			if (result != null) return result;
 		}
 
-		var prop:Dynamic;
 		// We are calling a LOCAL function from the same module.
 		if (_proxy != null && _proxy.findFunction(id, true) != null)
 		{
@@ -1395,6 +1398,7 @@ class PolymodInterpEx extends Interp
 					{
 						case KFunction(func):
 							fn = func;
+							break;
 						case _:
 					}
 				}


### PR DESCRIPTION
Whenever you have a local function that was created by a static function and it is called by something that isn't a scripted class, the `_classDeclOverride` would be null, so any imports and stuff would be missing from the context.

Here's an example script where this happens
```haxe
import funkin.modding.base.Module;
import flixel.util.FlxTimer;
import flixel.FlxG;

class Repro_264 extends Module
{
	function new()
	{
		super('PR_264');
	}

	static function foo()
	{
		FlxTimer.wait(0.1, () -> {
			// Error while executing function ???.anonymous()#17
			// Tried to access "FlxTimer", an unknown variable or identifier.
			new FlxTimer();
		});
	}

	override function onUpdate(e)
	{
		if (FlxG.keys.justPressed.HOME) foo();
	}
}
```