### PR TITLE
[FIX] `Math` and `Std` not being avaliable for static functions 

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -51,8 +51,6 @@ class PolymodInterpEx extends Interp
 	{
 		super();
 		_proxy = proxy;
-		variables.set("Math", Math);
-		variables.set("Std", Std);
 		this.targetCls = targetCls;
 	}
 
@@ -217,6 +215,12 @@ class PolymodInterpEx extends Interp
 			Polymod.debug('Registering scripted class $name');
 			_scriptClassDescriptors.set(name, c);
 		}
+	}
+
+	override function resetVariables() {
+		super.resetVariables();
+		variables.set("Math", Math);
+		variables.set("Std", Std);
 	}
 
 	public function clearScriptClassDescriptors():Void {


### PR DESCRIPTION
The merge of #247 introduced a bug where trying to access either of those classes in a static function would cause a missing import error, this is because it causes the static interpreter's variables to get reset to HScript's defaults.