### PR TITLE
A possible "fix" for the code completion/Intellisense in Funkin'

### DIFF
--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -19,6 +19,11 @@ class HScriptedClassMacro
 	 */
 	public static macro function build():Array<Field>
 	{
+		// This macro seems to cause issues in the language server in macro-heavy projects,
+		// so we prevent it to run on display (for some reason the define doesn't really work so we have to check at runtime)
+		// TODO: Remove this when whatever causes those issues is resolved.
+		if (Context.getDisplayMode() != None) return null;
+
 		var cls:haxe.macro.Type.ClassType = Context.getLocalClass().get();
 		var initialFields:Array<Field> = Context.getBuildFields();
 		var fields:Array<Field> = [].concat(initialFields);


### PR DESCRIPTION
The gist of it is that we prevent `HScriptedClassMacro` of ever running on the language server because when it does so code completion will stop working. I have no idea what in the macro causes this issue; I feel like it could be a problem with Haxe itself. Unfortunately while it works, the code completion will be painfully slow thanks to HaxeUI macros.

Note that `#if display` simply doesn't work (this is mentioned in the comment I left in the code), the only thing that did was checking `Context.getDisplayMode()`.