### PR TITLE
Fix an issue with blacklisted fields maps

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -872,7 +872,7 @@ class Polymod
 	public static function blacklistInstanceFields(parentClass:Class<Dynamic>, fields:Array<String>):Void
 	{
 		#if hscript
-		PolymodScriptClass.blacklistedInstanceFields.set(parentClass, fields);
+		PolymodScriptClass.blacklistedInstanceFields.set(Type.getClassName(parentClass), fields);
 		#else
 		Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes imports were requested, but hscript is not installed.');
 		#end

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -1,6 +1,7 @@
 package polymod.hscript._internal;
 
 #if hscript
+import haxe.ds.ObjectMap;
 import hscript.Expr.FieldDecl;
 import hscript.Expr.FunctionDecl;
 import hscript.Expr.VarDecl;
@@ -40,16 +41,17 @@ class PolymodScriptClass
 	public static final defaultImports:Map<String, Class<Dynamic>> = new Map<String, Class<Dynamic>>();
 
 	/**
-	 * Provide a class name with an array of its static fields to blacklist them.
+	 * Provide a class with an array of its static fields to blacklist them.
 	 * Blacklisted fields cannot be gotten or set.
 	 */
-	public static final blacklistedStaticFields:Map<Dynamic, Array<String>> = new Map<Dynamic, Array<String>>();
+	public static final blacklistedStaticFields:ObjectMap<Dynamic, Array<String>> = new ObjectMap<Dynamic, Array<String>>();
 
 	/**
 	 * Provide a class name with an array of its instance fields to blacklist them.
+	 * Needs to be a string map because class instances won't point to the same reference.
 	 * Blacklisted fields cannot be gotten or set.
 	 */
-	public static final blacklistedInstanceFields:Map<Dynamic, Array<String>> = new Map<Dynamic, Array<String>>();
+	public static final blacklistedInstanceFields:Map<String, Array<String>> = new Map<String, Array<String>>();
 
 	/*
 	 * STATIC METHODS


### PR DESCRIPTION
Fixes whatever this bullshit is
<img width="961" height="109" alt="image" src="https://github.com/user-attachments/assets/1718172b-ac61-42b7-871b-d8a35bc4bf5c" />

This is causing objects to be forcibly converted into strings when passed into this check, which can be an issue because destroyed Flixel objects can try to be passed into it and cause crashes.

https://github.com/larsiusprime/polymod/blob/f56cbf3edc594766d51c413cec7fc1008ca6c886/polymod/hscript/_internal/PolymodInterpEx.hx#L1131