### PR TITLE
[FIX] Fix class name parsing for some objects

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1256,7 +1256,7 @@ class PolymodInterpEx extends Interp
   {
     if (o == null) errorEx(ENullObjectReference(f));
 
-    var oCls:String = Util.getTypeName(Type.typeof(o));
+    var oCls:String = Util.getTypeNameOf(o);
 
     // Check if the field is a blacklisted static field.
     if (PolymodScriptClass.blacklistedStaticFields.exists(o) && PolymodScriptClass.blacklistedStaticFields.get(o).contains(f))
@@ -1266,7 +1266,7 @@ class PolymodInterpEx extends Interp
     }
 
     // If not, check if it is a blacklisted instance field.
-    if (oCls.length > 0)
+    if (oCls.length > 0 && oCls != 'Object')
     {
       if (PolymodScriptClass.blacklistedInstanceFields.exists(oCls) && PolymodScriptClass.blacklistedInstanceFields.get(oCls).contains(f))
       {
@@ -1337,7 +1337,7 @@ class PolymodInterpEx extends Interp
       // return result;
     }
 
-    var abstractKey:String = Type.getClassName(o) + '.' + f;
+    var abstractKey:String = '$oCls.$f';
     if (PolymodScriptClass.abstractClassStatics.exists(abstractKey))
     {
       return Reflect.getProperty(PolymodScriptClass.abstractClassStatics[abstractKey], abstractKey.replace('.', '_'));
@@ -1366,7 +1366,7 @@ class PolymodInterpEx extends Interp
   {
     if (o == null) errorEx(ENullObjectReference(f));
 
-    var oCls:String = Util.getTypeName(Type.typeof(o));
+    var oCls:String = Util.getTypeNameOf(o);
 
     // Check if the field is a blacklisted static field.
     if (PolymodScriptClass.blacklistedStaticFields.exists(o) && PolymodScriptClass.blacklistedStaticFields.get(o).contains(f))
@@ -1376,7 +1376,7 @@ class PolymodInterpEx extends Interp
     }
 
     // If not, check if it is a blacklisted instance field.
-    if (oCls.length > 0)
+    if (oCls.length > 0 && oCls != 'Object')
     {
       if (PolymodScriptClass.blacklistedInstanceFields.exists(oCls) && PolymodScriptClass.blacklistedInstanceFields.get(oCls).contains(f))
       {

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -694,8 +694,9 @@ class Util
     return indexOfInsens(arr, x, ignoreConfig) != -1;
   }
 
-  public static function getTypeName(type:Type.ValueType):String
+  public static function getTypeNameOf(obj:Dynamic):String
   {
+    var type = Type.typeof(obj);
     return switch (type)
     {
       case TClass(cls):
@@ -707,8 +708,14 @@ class Util
         #end
       case TEnum(enm):
         Std.string(enm);
-      case TObject: // Anonymous object
-        'Object';
+      case TObject: // Anonymous object or class type
+        // We assume that if we cannot get the class name then it must be an object
+        #if hl
+        // A bit hacky but it's what the HL implementation does too, except this one avoids a null access error.
+        obj.__name__ ?? 'Object';
+        #else
+        Type.getClassName(obj) ?? 'Object';
+        #end
       default:
         Std.string(type);
     }


### PR DESCRIPTION
> [!NOTE]
>
> This PR now fixes some class types getting parsed to "Object" as if they were anonymous structures. You can still check out the original description below.

## Original Description

https://github.com/larsiusprime/polymod/blob/7f82ddb3e11e33ad0dd42e0c3e1417edc90e38f9/polymod/hscript/_internal/PolymodInterpEx.hx#L1124-L1125

This snippet will convert any object to a string; some anon structures can contain string maps in them which will allocate memory when those are converted to strings when getting or setting a value. One a lot of mods seem to reference is `FlxG.save.data` which can contain a lot of string maps, causing very frequent memory allocations.

https://github.com/user-attachments/assets/a53edb9b-effc-4b90-ad09-b97d87129c10

Since a TObject can be either a class type or a struct I was compelled to either:
 * Use `Type.getClassName` (which is apparently slow even though all it does is access a field behind the scenes? Not saying it is, I just heard it from someone)
 * Take advantage of the fact Polymod has to resolve classes from imports and when initializing objects, and so store these classes in a map along with their names. (Shout out to Kolo for the idea)

I decided to go with the second since `getClassName` has so much hatred. I haven't had the chance to test it thoroughly but testing the blacklist of `FlxSave.resolveFlixelClasses` (static) and `FlxSave.data` (instance) and both worked, and the memory leak disappeared.
