### PR TITLE
Remove unused call to `readDirectory`

### DIFF
--- a/polymod/fs/SysFileSystem.hx
+++ b/polymod/fs/SysFileSystem.hx
@@ -108,7 +108,6 @@ class SysFileSystem implements IFileSystem
 	public function getMetadata(modId:String)
 	{
 		var modPath = Util.pathJoin(modRoot, modId);
-		var test = readDirectory(modRoot);
 		if (exists(modPath))
 		{
 			var meta:ModMetadata = null;


### PR DESCRIPTION
Removes an unused local variable that isn't optimized out in `SysZipFileSystem`.
Made as per request of https://github.com/larsiusprime/polymod/pull/271#discussion_r2651403344