### PR TITLE
Make text asset caching opt-in

### DIFF
--- a/polymod/PolymodConfig.hx
+++ b/polymod/PolymodConfig.hx
@@ -237,4 +237,21 @@ class PolymodConfig
     if (caseInsensitiveZipLoading == null) caseInsensitiveZipLoading = DefineUtil.getDefineBool('POLYMOD_ZIP_INSENSITIVE', true);
     return caseInsensitiveZipLoading;
   }
+
+  /**
+   * Whether the contents of text assets are cached, so that they're loaded faster.
+   * Don't enable this if mods need to modify these assets.
+   *
+   * Enable this option by setting the `POLYMOD_ENABLE_TEXT_CACHE` Haxe define at compile time,
+   * or by setting this value in your code.
+   *
+   * @default `false`
+   */
+  public static var enableTextCache(get, default):Null<Bool>;
+
+  static function get_enableTextCache():Null<Bool>
+  {
+    if (enableTextCache == null) enableTextCache = DefineUtil.getDefineBool('POLYMOD_ENABLE_TEXT_CACHE', false);
+    return enableTextCache;
+  }
 }

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -182,14 +182,18 @@ class PolymodAssetLibrary
   public function mergeAndAppendText(id:String, modText:String):String
   {
     var cacheKey = PolymodConfig.mergeFolder + id;
-    if (_textCache.exists(cacheKey))
+    if (PolymodConfig.enableTextCache && _textCache.exists(cacheKey))
     {
       return _textCache.get(cacheKey);
     }
 
     modText = Util.mergeAndAppendText(modText, id, dirs, getTextDirectly, fileSystem, parseRules);
 
-    _textCache.set(cacheKey, modText);
+    if (PolymodConfig.enableTextCache)
+    {
+      _textCache.set(cacheKey, modText);
+    }
+
     return modText;
   }
 
@@ -247,14 +251,14 @@ class PolymodAssetLibrary
 
   public function getText(id:String):String
   {
-    if (_textCache.exists(id))
+    if (PolymodConfig.enableTextCache && _textCache.exists(id))
     {
       return _textCache.get(id);
     }
 
     var result = backend.getText(id);
 
-    if (result != null)
+    if (PolymodConfig.enableTextCache && result != null)
     {
       _textCache.set(id, result);
     }


### PR DESCRIPTION
This PR aims to fix this quite niche issue (https://github.com/FunkinCrew/Funkin/issues/6675) which was introduced by the assets caching PR.

To sum it up, if you have a mod that constantly needs to modify a text file and later on you have to get the contents you've written, you'll just get the same thing instead of what was written to it due to the contents getting cached.

Since I don't think retrieving text files is something that happens a lot, or at least not in the base game, I think it's fine to disable this caching by default (although my actual reasoning for this is because I know that even if this is merged as an opt-out someone will forget to disable it)