### PR TITLE
[FIX] Call super class constructor arguments properly

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1303,7 +1303,7 @@ class PolymodInterpEx extends Interp
 			}
 			else if (_proxy.superClass == null)
 			{
-				return _proxy.superConstructor;
+				return Reflect.makeVarArgs(_proxy.createSuperClass);
 			}
 			else
 			{

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -10,11 +10,6 @@ import polymod.hscript._internal.PolymodClassDeclEx;
 
 using StringTools;
 
-enum Param
-{
-	Unused;
-}
-
 /**
  * Provides handlers for scripted classes
  * Based on code by Ian Harrigan
@@ -727,20 +722,6 @@ class PolymodScriptClass
 		}
 		name += _c.name;
 		return name;
-	}
-
-	private function superConstructor(arg0:Dynamic = Unused, arg1:Dynamic = Unused, arg2:Dynamic = Unused, arg3:Dynamic = Unused)
-	{
-		var args = [];
-		if (arg0 != Unused)
-			args.push(arg0);
-		if (arg1 != Unused)
-			args.push(arg1);
-		if (arg2 != Unused)
-			args.push(arg2);
-		if (arg3 != Unused)
-			args.push(arg3);
-		createSuperClass(args);
 	}
 
 	private inline function callFunction0(name:String):Dynamic


### PR DESCRIPTION
Currently, the way `super` calls the super class' constructor in Polymod is a bit jank, because not only any null arguments get skipped but also anything past 4 arguments.
We can't just call `createSuperClass` directly because it has an array as the argument, but we can use `Reflect.makeVarArgs` to turn it into a function that, when called by `Reflect.callMethod`, will correctly accept the arguments as an array.

One issue this solves is this case with a scriptable note kind, which is currently borked.
```hx
package test.notekind;

import funkin.play.notes.notekind.ScriptedNoteKind;

class CustomAnimNoteKind extends ScriptedNoteKind
{
  final DISABLE_ANIMATIONS:Bool = true;

  public function new()
  {
    super("somekind", "Are we broken?", null, [], DISABLE_ANIMATIONS);
    trace(this.noteKind);
    trace(this.description);
    trace(this.noteStyleId);
    trace(this.params);
    trace(this.noanim);
    trace(this.suffix);
  }
}
```

Despite the arguments being correct, the fields are not.
<img width="501" height="121" alt="image" src="https://github.com/user-attachments/assets/f9935d35-1cc2-4f69-9a27-f17e31cfd158" />

With this fix, that doesn't happen anymore.
<img width="495" height="120" alt="image" src="https://github.com/user-attachments/assets/98111382-e3d0-4bac-8f74-5a18b79b0618" />
