### PR TITLE
Simplify multi-argument function calling

### DIFF
--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -23,29 +23,9 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
 			case _:
 				if (this.findFunction(name) != null)
 				{
-					var fn = this.findFunction(name);
-					var nargs = 0;
-					if (fn.args != null)
-					{
-						nargs = fn.args.length;
-					}
-					switch (nargs)
-					{
-						case 0: return this.callFunction0.bind(name);
-						case 1: return this.callFunction1.bind(name, _);
-						case 2: return this.callFunction2.bind(name, _, _);
-						case 3: return this.callFunction3.bind(name, _, _, _);
-						case 4: return this.callFunction4.bind(name, _, _, _, _);
-						#if neko
-						case _: @:privateAccess this._interp.error(ECustom("only 4 params allowed in script class functions (.bind limitation)"));
-						#else
-						case 5: return this.callFunction5.bind(name, _, _, _, _, _);
-						case 6: return this.callFunction6.bind(name, _, _, _, _, _, _);
-						case 7: return this.callFunction7.bind(name, _, _, _, _, _, _, _);
-						case 8: return this.callFunction8.bind(name, _, _, _, _, _, _, _, _);
-						case _: @:privateAccess this._interp.error(ECustom("only 8 params allowed in script class functions (.bind limitation)"));
-						#end
-					}
+					return Reflect.makeVarArgs(function(args:Array<Dynamic>) {
+						return this.callFunction(name, args);
+					});
 				}
 				else if (this.findVar(name) != null)
 				{

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1526,7 +1526,7 @@ class PolymodInterpEx extends Interp
 		}
 	}
 
-	public function hasScriptClassStaticFunction(clsName:String, fnName:String, args:Array<Dynamic> = null):Bool {
+	public function hasScriptClassStaticFunction(clsName:String, fnName:String):Bool {
 		var imports:Map<String, PolymodClassImport> = [];
 
 		var cls:Null<PolymodClassDeclEx> = _scriptClassDescriptors.get(clsName);
@@ -1562,7 +1562,7 @@ class PolymodInterpEx extends Interp
 			if (!this.variables.exists(prefixedName)) {
 				switch (fieldDecl.kind) {
 					case KFunction(fn):
-						var result = buildScriptClassStaticFunction(clsName, fieldName, fn);
+						var result = buildScriptClassStaticFunction(clsName, fieldName);
 						this.variables.set(prefixedName, result);
 						return result;
 					case KVar(v):
@@ -1570,7 +1570,7 @@ class PolymodInterpEx extends Interp
 							switch (v.get) {
 								case 'get':
 									var getterFunc = 'get_${fieldName}';
-									if (hasScriptClassStaticFunction(clsName, getterFunc, [])) {
+									if (hasScriptClassStaticFunction(clsName, getterFunc)) {
 										return callScriptClassStaticFunction(clsName, getterFunc, []);
 									} else {
 										throw 'Could not resolve getter for property ${prefixedName}';
@@ -1602,54 +1602,10 @@ class PolymodInterpEx extends Interp
 		}
 	}
 
-	private function buildScriptClassStaticFunction(clsName:String, fieldName:String, fn:FunctionDecl):Dynamic {
-		var argCount = fn.args.length;
-		switch(argCount) {
-			case 0: return function():Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, []);
-			};
-
-			case 1: return function(a:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a]);
-			};
-
-			case 2: return function(a:Dynamic, b:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a, b]);
-			};
-
-			case 3: return function(a:Dynamic, b:Dynamic, c:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a, b, c]);
-			}
-
-			case 4: return function(a:Dynamic, b:Dynamic, c:Dynamic, d:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a, b, c, d]);
-			}
-
-			#if neko
-			case _: @:privateAccess error(ECustom("only 4 params allowed in script class functions (.bind limitation)"));
-			#else
-			case 5: return function(a:Dynamic, b:Dynamic, c:Dynamic, d:Dynamic, e:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a, b, c, d, e]);
-			}
-
-			case 6: return function(a:Dynamic, b:Dynamic, c:Dynamic, d:Dynamic, e:Dynamic, f:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a, b, c, d, e, f]);
-			}
-
-			case 7: return function(a:Dynamic, b:Dynamic, c:Dynamic, d:Dynamic, e:Dynamic, f:Dynamic, g:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a, b, c, d, e, f, g]);
-			}
-
-			case 8: return function(a:Dynamic, b:Dynamic, c:Dynamic, d:Dynamic, e:Dynamic, f:Dynamic, g:Dynamic, h:Dynamic):Dynamic {
-				return callScriptClassStaticFunction(clsName, fieldName, [a, b, c, d, e, f, g, h]);
-			}
-
-			case _: @:privateAccess error(ECustom("only 8 params allowed in script class functions (.bind limitation)"));
-			#end
-		}
-
-		// Fallthrough
-		return null;
+	private inline function buildScriptClassStaticFunction(clsName:String, fieldName:String):Dynamic {
+		return Reflect.makeVarArgs(function(args:Array<Dynamic>):Dynamic {
+			return callScriptClassStaticFunction(clsName, fieldName, args);
+		});
 	}
 
 	public function setScriptClassStaticField(clsName:String, fieldName:String, value:Dynamic):Dynamic {
@@ -1665,7 +1621,7 @@ class PolymodInterpEx extends Interp
 							switch (v.set) {
 								case 'set':
 									var setterFunc = 'set_${fieldName}';
-									if (hasScriptClassStaticFunction(clsName, setterFunc, [value])) {
+									if (hasScriptClassStaticFunction(clsName, setterFunc)) {
 										return callScriptClassStaticFunction(clsName, setterFunc, [value]);
 									} else {
 										throw 'Could not resolve setter for property ${prefixedName}';

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -724,53 +724,6 @@ class PolymodScriptClass
 		return name;
 	}
 
-	private inline function callFunction0(name:String):Dynamic
-	{
-		return callFunction(name);
-	}
-
-	private inline function callFunction1(name:String, arg0:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0]);
-	}
-
-	private inline function callFunction2(name:String, arg0:Dynamic, arg1:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0, arg1]);
-	}
-
-	private inline function callFunction3(name:String, arg0:Dynamic, arg1:Dynamic, arg2:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0, arg1, arg2]);
-	}
-
-	private inline function callFunction4(name:String, arg0:Dynamic, arg1:Dynamic, arg2:Dynamic, arg3:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0, arg1, arg2, arg3]);
-	}
-
-	private inline function callFunction5(name:String, arg0:Dynamic, arg1:Dynamic, arg2:Dynamic, arg3:Dynamic, arg4:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0, arg1, arg2, arg3, arg4]);
-	}
-
-	private inline function callFunction6(name:String, arg0:Dynamic, arg1:Dynamic, arg2:Dynamic, arg3:Dynamic, arg4:Dynamic, arg5:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0, arg1, arg2, arg3, arg4, arg5]);
-	}
-
-	private inline function callFunction7(name:String, arg0:Dynamic, arg1:Dynamic, arg2:Dynamic, arg3:Dynamic, arg4:Dynamic, arg5:Dynamic,
-			arg6:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0, arg1, arg2, arg3, arg4, arg5, arg6]);
-	}
-
-	private inline function callFunction8(name:String, arg0:Dynamic, arg1:Dynamic, arg2:Dynamic, arg3:Dynamic, arg4:Dynamic, arg5:Dynamic, arg6:Dynamic,
-			arg7:Dynamic):Dynamic
-	{
-		return callFunction(name, [arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7]);
-	}
-
 	/**
 	 * Search for a function field with the given name. Excludes variables and static functions.
 	 * @param name The name of the function to search for.


### PR DESCRIPTION
Instead of a giant switch case just to handle a bunch of different amounts of arguments (which even is limited) we can just use `Reflect.makeVarArgs` which is simple and has no limits for arguments (except on some targets).