### PR TITLE
[FIX] Fix default argument values not being used by functions/lambdas when the passed values are missing or null.

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -398,6 +398,27 @@ class Parser
     return parseExprNext(mk(EObject(fl), p1));
   }
 
+  /**
+   * Transform an Expr to an Argument for lambda functions
+   *
+   * @param e The expression
+   * @return The function argument
+   */
+  function exprToArg(e:Expr):Argument {
+    return switch (expr(e)) {
+      case EIdent(v):
+        {name: v, t: null, opt: false, value: null};
+      case ECheckType({e: EIdent(v)}, t):
+        {name: v, t: t, opt: false, value: null};
+      case EBinop("=", {e: EIdent(v)}, def):
+        {name: v, t: null, opt: false, value: def};
+      case EBinop("=", {e: ECheckType({e: EIdent(v)}, t)}, def):
+        {name: v, t: t, opt: false, value: def};
+      default:
+        null;
+    }
+  }
+
   function parseExpr()
   {
     var tk = token();
@@ -423,28 +444,58 @@ class Parser
         if (tk == TPClose)
         {
           ensureToken(TOp("->"));
-          var eret = parseExpr();
-          return mk(EFunction([], mk(EReturn(eret), p1)), p1);
+          return mk(EFunction([], mk(EReturn(parseExpr()), p1)), p1);
         }
+
+        var isOpt = false;
+        if (tk == TQuestion) {
+          isOpt = true;
+          tk = token();
+        }
+
         push(tk);
         var e = parseExpr();
         tk = token();
+
         switch (tk)
         {
           case TPClose:
+            if (maybe(TOp("->")))
+            {
+              var arg = exprToArg(e);
+              if (arg == null) return unexpected(tk);
+              arg.opt = isOpt;
+              return mk(EFunction([arg], mk(EReturn(parseExpr()), p1)), p1);
+            }
             return parseExprNext(mk(EParent(e), p1, tokenMax));
+
           case TDoubleDot:
             var t = parseType();
+            var v0 = maybe(TOp("=")) ? parseExpr() : null;
+
             tk = token();
             switch (tk)
             {
               case TPClose:
-                return parseExprNext(mk(ECheckType(e, t), p1, tokenMax));
+                if (maybe(TOp("->")))
+                {
+                  switch (expr(e))
+                  {
+                    case EIdent(v):
+                      var arg:Argument = {name: v, t: t, value: v0, opt: isOpt};
+                      return mk(EFunction([arg], mk(EReturn(parseExpr()), p1)), p1);
+                    default:
+                  }
+                }
+
+                var e2 = mk(ECheckType(e, t), p1, tokenMax);
+                if (v0 != null) e2 = mk(EBinop("=", e2, v0), p1, tokenMax);
+                return parseExprNext(e2);
               case TComma:
                 switch (expr(e))
                 {
-                  case EIdent(v): return parseLambda([
-                      {name: v, t: t}], pmin(e));
+                  case EIdent(v):
+                    return parseLambda([{name: v, t: t, value: v0}], p1);
                   default:
                 }
               default:
@@ -452,8 +503,8 @@ class Parser
           case TComma:
             switch (expr(e))
             {
-              case EIdent(v): return parseLambda([
-                  {name: v}], pmin(e));
+              case EIdent(v):
+                return parseLambda([{name: v}], p1);
               default:
             }
           default:
@@ -574,11 +625,9 @@ class Parser
       if (maybe(TQuestion)) arg.opt = true;
       arg.name = getIdent();
 
-      if (allowTypes)
-      {
-        if (maybe(TDoubleDot)) arg.t = parseType();
-        if (maybe(TOp("="))) arg.value = parseExpr();
-      }
+      if (allowTypes && maybe(TDoubleDot)) arg.t = parseType();
+      if (maybe(TOp("="))) arg.value = parseExpr();
+
       args.push(arg);
 
       var tk = token();
@@ -593,8 +642,7 @@ class Parser
       }
     }
     ensureToken(TOp("->"));
-    var eret = parseExpr();
-    return mk(EFunction(args, mk(EReturn(eret), pmin)), pmin);
+    return mk(EFunction(args, mk(EReturn(parseExpr()), pmin)), pmin);
   }
 
   function parseMetaArgs()
@@ -1043,8 +1091,8 @@ class Parser
         if (allowTypes)
         {
           if (maybe(TDoubleDot)) arg.t = parseType();
-          if (maybe(TOp("="))) arg.value = parseExpr();
         }
+        if (maybe(TOp("="))) arg.value = parseExpr();
         tk = token();
         switch (tk)
         {

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -570,9 +570,17 @@ class Parser
   {
     while (true)
     {
-      var id = getIdent();
-      var t = maybe(TDoubleDot) ? parseType() : null;
-      args.push({name: id, t: t});
+      var arg:Argument = {name: null};
+      if (maybe(TQuestion)) arg.opt = true;
+      arg.name = getIdent();
+
+      if (allowTypes)
+      {
+        if (maybe(TDoubleDot)) arg.t = parseType();
+        if (maybe(TOp("="))) arg.value = parseExpr();
+      }
+      args.push(arg);
+
       var tk = token();
       switch (tk)
       {

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -664,47 +664,55 @@ class PolymodInterpEx extends Interp
           {
             hasOpt = true;
           }
-          else
+          if (!p.opt && p.value == null)
           {
             minParams++;
           }
         }
 
-        // This CREATES a new function in memory, that we call later.
-        var newFun:Dynamic = function(args:Array<Dynamic>) {
-          if (((args == null) ? 0 : args.length) != params.length)
+				// This CREATES a new function in memory, that we call later.
+				var newFun:Dynamic = function(args:Array<Dynamic>)
+				{
+          if (args == null) args = [];
+
+          if (args.length < minParams)
           {
-            if (args.length < minParams)
+            var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
+            if (name != null)
+              str += " for function '" + name + "'";
+            errorEx(ECustom(str));
+          }
+
+          // make sure mandatory args are forced
+          var args2 = [];
+          var pos = 0;
+          for (p in params)
+          {
+            if (pos < args.length)
             {
-              var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
-              if (name != null) str += " for function '" + name + "'";
-              errorEx(ECustom(str));
-            }
-            // make sure mandatory args are forced
-            var args2 = [];
-            var extraParams = args.length - minParams;
-            var pos = 0;
-            for (p in params)
-            {
-              if (p.opt)
+              var arg = args[pos++];
+              if (arg == null && p.value != null)
               {
-                if (extraParams > 0)
-                {
-                  args2.push(args[pos++]);
-                  extraParams--;
-                }
-                else
-                {
-                  args2.push(null);
-                }
+                args2.push(expr(p.value));
               }
               else
               {
-                args2.push(args[pos++]);
+                args2.push(arg);
               }
             }
-            args = args2;
+            else
+            {
+              if (p.value != null)
+              {
+                args2.push(expr(p.value));
+              }
+              else
+              {
+                args2.push(null);
+              }
+            }
           }
+          args = args2;
 
           clone.depth++;
 
@@ -1657,31 +1665,9 @@ class PolymodInterpEx extends Interp
     {
       // Populate function arguments.
 
-      // previousValues is used to restore variables after they are shadowed in the local scope.
       var previousClassDecl = _classDeclOverride;
-      var previousValues:Map<String, Dynamic> = [];
-      var i = 0;
-      for (a in fn.args)
-      {
-        var value:Dynamic = null;
-
-        if (args != null && i < args.length)
-        {
-          value = args[i];
-        }
-        else if (a.value != null)
-        {
-          value = this.expr(a.value);
-        }
-
-        // NOTE: We assign these as variables rather than locals because those get wiped when we enter the function.
-        if (this.variables.exists(a.name))
-        {
-          previousValues.set(a.name, this.variables.get(a.name));
-        }
-        this.variables.set(a.name, value);
-        i++;
-      }
+      // previousValues is used to restore variables after they are shadowed in the local scope.
+      var previousValues:Map<String, Dynamic> = setFunctionValues(fn, args);
 
       this._classDeclOverride = cls;
 
@@ -1732,6 +1718,45 @@ class PolymodInterpEx extends Interp
         'Static function "${fnName}" does not exist! Define it or call the correct function.');
       return null;
     }
+  }
+
+  /**
+	 * Initializes function arguments within the interpreter scope.
+   *
+	 * @param fn The function declaration to extract arguments from.
+	 * @param args The arguments to pass to the function.
+	 * @return The Map containing the variable values before they are shadowed in the local scope.
+	 */
+  public function setFunctionValues(fn:Null<FunctionDecl>, args:Array<Dynamic> = null):Map<String, Dynamic>
+  {
+    var previousValues:Map<String, Dynamic> = [];
+    if (fn == null) return previousValues;
+
+    var i = 0;
+    for (a in fn.args)
+    {
+      var value:Dynamic = null;
+
+      // Uses the passed value if provided and not null, if not fall back to the default value defined in the function argument.
+      if (args != null && i < args.length && args[i] != null)
+      {
+        value = args[i];
+      }
+      else if (a.value != null)
+      {
+        value = this.expr(a.value);
+      }
+
+      // NOTE: We assign these as variables rather than locals because those get wiped when we enter the function.
+      if (this.variables.exists(a.name))
+      {
+        previousValues.set(a.name, this.variables.get(a.name));
+      }
+      this.variables.set(a.name, value);
+      i++;
+    }
+
+    return previousValues;
   }
 
   public function hasScriptClassStaticFunction(clsName:String, fnName:String):Bool

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -657,31 +657,13 @@ class PolymodInterpEx extends Interp
         // Fix to ensure callback functions catch thrown errors.
         // Using a clone to prevent locals getting wiped out.
         var clone = this.clone();
-        var hasOpt = false, minParams = 0;
-        for (p in params)
-        {
-          if (p.opt)
-          {
-            hasOpt = true;
-          }
-          if (!p.opt && p.value == null)
-          {
-            minParams++;
-          }
-        }
 
 				// This CREATES a new function in memory, that we call later.
 				var newFun:Dynamic = function(args:Array<Dynamic>)
 				{
           if (args == null) args = [];
 
-          if (args.length < minParams)
-          {
-            var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
-            if (name != null)
-              str += " for function '" + name + "'";
-            errorEx(ECustom(str));
-          }
+          validateArgumentCount(params, args, name);
 
           // make sure mandatory args are forced
           var args2 = [];
@@ -1667,7 +1649,7 @@ class PolymodInterpEx extends Interp
 
       var previousClassDecl = _classDeclOverride;
       // previousValues is used to restore variables after they are shadowed in the local scope.
-      var previousValues:Map<String, Dynamic> = setFunctionValues(fn, args);
+      var previousValues:Map<String, Dynamic> = setFunctionValues(fn, args, fnName);
 
       this._classDeclOverride = cls;
 
@@ -1725,12 +1707,15 @@ class PolymodInterpEx extends Interp
    *
 	 * @param fn The function declaration to extract arguments from.
 	 * @param args The arguments to pass to the function.
+	 * @param name The function's name
 	 * @return The Map containing the variable values before they are shadowed in the local scope.
 	 */
-  public function setFunctionValues(fn:Null<FunctionDecl>, args:Array<Dynamic> = null):Map<String, Dynamic>
+  public function setFunctionValues(fn:Null<FunctionDecl>, args:Array<Dynamic> = null, name:String = "Unknown"):Map<String, Dynamic>
   {
     var previousValues:Map<String, Dynamic> = [];
     if (fn == null) return previousValues;
+
+    validateArgumentCount(fn.args, args, name);
 
     var i = 0;
     for (a in fn.args)
@@ -1757,6 +1742,30 @@ class PolymodInterpEx extends Interp
     }
 
     return previousValues;
+  }
+
+  /**
+   * Validates the minimum argument requirement by using the rightmost required argument index
+   * and ensures the param count is matching the actual length of the given arguments.
+   * Throws an error if validation fails.
+   *
+   * @param param The function parameters
+   * @param args The given arguments
+   * @param name The function name
+   */
+  public function validateArgumentCount(params:Array<Argument>, args:Array<Dynamic>, name:Null<String>)
+  {
+    var minParams = 0;
+    for (i in 0...params.length)
+    {
+      var p = params[i];
+      if (!p.opt && p.value == null) minParams = i + 1;
+    }
+
+    if (args.length < minParams)
+    {
+      errorEx(ECustom('Invalid number of parameters. Got ${args.length}, required $minParams${(name != null) ? " for function '" + name + "'" : ""}.'));
+    }
   }
 
   public function hasScriptClassStaticFunction(clsName:String, fnName:String):Bool

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -669,7 +669,7 @@ class PolymodScriptClass
     if (fn != null)
     {
       // previousValues is used to restore variables after they are shadowed in the local scope.
-      var previousValues:Map<String, Dynamic> = _interp.setFunctionValues(fn, args);
+      var previousValues:Map<String, Dynamic> = _interp.setFunctionValues(fn, args, fnName);
 
       // Polymod.debug('Calling scripted class function "${fullyQualifiedName}.${fnName}(${args})"', null);
 

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -669,29 +669,7 @@ class PolymodScriptClass
     if (fn != null)
     {
       // previousValues is used to restore variables after they are shadowed in the local scope.
-      var previousValues:Map<String, Dynamic> = [];
-      var i = 0;
-      for (a in fn.args)
-      {
-        var value:Dynamic = null;
-
-        if (args != null && i < args.length)
-        {
-          value = args[i];
-        }
-        else if (a.value != null)
-        {
-          value = _interp.expr(a.value);
-        }
-
-        // NOTE: We assign these as variables rather than locals because those get wiped when we enter the function.
-        if (_interp.variables.exists(a.name))
-        {
-          previousValues.set(a.name, _interp.variables.get(a.name));
-        }
-        _interp.variables.set(a.name, value);
-        i++;
-      }
+      var previousValues:Map<String, Dynamic> = _interp.setFunctionValues(fn, args);
 
       // Polymod.debug('Calling scripted class function "${fullyQualifiedName}.${fnName}(${args})"', null);
 


### PR DESCRIPTION
This PR fixes the way default argument values are handled when called a function/lambda.

Currently setting a default argument in functions won't use the argument when the passed argument is `null` or just missing. This was caused because of the `if` statement not checking correctly for the argument passed, and instead just checking if arguments exist at all or if the argument length matches, so it never reached the `a.value` part to set the default function value.

For lambdas, the minimum argument requirement shouldn't count default values if they exist, so this PR also fixes that. Also default values are applied if the value is `null` or just missing.

### With this PR:

<img width="687" height="533" alt="image" src="https://github.com/user-attachments/assets/f645c68d-8b18-4562-b93c-ce935dffc745" />

<img width="848" height="353" alt="image" src="https://github.com/user-attachments/assets/2b878463-8f5c-4c50-bb76-b037fdcc2643" />

### Without this PR:

<img width="668" height="554" alt="image" src="https://github.com/user-attachments/assets/61ebfcf0-b76e-4e67-a06f-859102468527" />

<img width="823" height="332" alt="image" src="https://github.com/user-attachments/assets/f003fc17-6127-4740-b4ae-d4188560da16" />

### Haxe behavior
Even in Try haxe it's the same behavior:

Functions: https://try.haxe.org/#F5c4e9b2
Lambdas: https://try.haxe.org/#96735bBF

<img width="1095" height="403" alt="image" src="https://github.com/user-attachments/assets/ba316172-e0f6-4992-adbb-e8656249c3c7" />

<img width="1110" height="319" alt="image" src="https://github.com/user-attachments/assets/094451c2-7e13-4120-a3a2-f0710301ec65" />
