### PR TITLE
Allow scripted classes to not extend anything

### DIFF
--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -906,26 +906,37 @@ class HScriptedClassMacro
 						ret: func_ret,
 						expr: macro
 						{
-							if (_asc != null && _asc.hasScriptFunction($v{funcName}))
+							if (_asc != null)
 							{
-								// trace('ASC: Calling $fieldName() in macro-generated function...');
-								$
+								if (_asc.hasScriptFunction($v{funcName}))
 								{
-									doesReturnVoid
-										? (macro _asc.callFunction($v{funcName}, [$a{func_callArgs}]))
-										: (macro return _asc.callFunction($v{funcName}, [$a{func_callArgs}]))
+									// trace('ASC: Calling $fieldName() in macro-generated function...');
+									$
+									{
+										doesReturnVoid
+											? (macro { _asc.callFunction($v{funcName}, [$a{func_callArgs}]); return; })
+											: (macro return _asc.callFunction($v{funcName}, [$a{func_callArgs}]))
+									}
+								}
+								// If another scripted class is being extended, call if the function exists there
+								else if ((_asc.superClass is polymod.hscript._internal.PolymodScriptClass) && _asc.superClass.hasScriptFunction($v{funcName}))
+								{
+									var _super = (_asc.superClass:polymod.hscript._internal.PolymodScriptClass);
+									$
+									{
+										doesReturnVoid
+											? (macro { _super.callFunction($v{funcName}, [$a{func_callArgs}]); return; })
+											: (macro return _super.callFunction($v{funcName}, [$a{func_callArgs}]))
+									}
 								}
 							}
-							else
+							// Fallback, call the original function.
+							// trace('ASC: Fallback to original ${fieldName}');
+							$
 							{
-								// Fallback, call the original function.
-								// trace('ASC: Fallback to original ${fieldName}');
-								$
-								{
-									doesReturnVoid
-										? (macro super.$funcName($a{func_callArgs}))
-										: (macro return super.$funcName($a{func_callArgs}))
-								}
+								doesReturnVoid
+									? (macro super.$funcName($a{func_callArgs}))
+									: (macro return super.$funcName($a{func_callArgs}))
 							}
 						},
 					}),

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -472,9 +472,7 @@ class HScriptedClassMacro
 				{
 					if (_asc == null)
 					{
-						var clsName = $v{cls.name};
-						var superName = $v{cls.superClass.t.get().name};
-						return 'PolymodScriptedClass<${clsName} extends ${superName}>(NO ASC)';
+						return $v{'PolymodScriptedClass<${cls.name} extends ${cls.superClass.t.get().name}>(NO ASC)'};
 					}
 					else
 					{
@@ -944,7 +942,7 @@ class HScriptedClassMacro
 						ret: func_ret,
 						expr: macro
 						{
-							var fieldName:String = $v{funcName};
+							// var fieldName:String = $v{funcName};
 							// Fallback, call the original function.
 							// trace('ASC: Force call to super ${fieldName}');
 							$

--- a/polymod/hscript/_internal/PolymodClassDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodClassDeclEx.hx
@@ -66,6 +66,7 @@ class PolymodStaticClassReference {
 		var scriptedObj:Null<Dynamic> = asc.superClass;
 		while (Std.isOfType(scriptedObj, PolymodScriptClass))
 		{
+			scriptedObj.topASC = asc;
 			scriptedObj = scriptedObj.superClass;
 		}
 

--- a/polymod/hscript/_internal/PolymodClassDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodClassDeclEx.hx
@@ -63,11 +63,17 @@ class PolymodStaticClassReference {
 			return null;
 		}
 
-		var scriptedObj = asc.superClass;
-
+		var scriptedObj:Null<Dynamic> = asc.superClass;
 		while (Std.isOfType(scriptedObj, PolymodScriptClass))
 		{
 			scriptedObj = scriptedObj.superClass;
+		}
+
+		if (scriptedObj == null)
+		{
+			// We've hit a class that does not extend anything
+			// The ASC will act like a scripted class for us instead.
+			return asc;
 		}
 
 		Reflect.setField(scriptedObj, '_asc', asc);

--- a/polymod/hscript/_internal/PolymodExprEx.hx
+++ b/polymod/hscript/_internal/PolymodExprEx.hx
@@ -55,12 +55,13 @@ EInvalidScriptedFnAccess(f:String);
 EInvalidScriptedVarGet(v:String);
 EInvalidScriptedVarSet(v:String);
 EInvalidFinalSet(f:String);
-EInvalidPropGet(p:String);
-EInvalidPropSet(p:String);
-EPropVarNotReal(p:String);
+EInvalidPropGet(p:String); // Accessing a never/null getter
+EInvalidPropSet(p:String); // Accessing a never/null setter
+EPropVarNotReal(p:String); // Getter/setter accessing a (get/never,set/never) property within itself without "@:isVar"
 EInvalidInStaticContext(v:String); // Accessing "this" or "super" in a static function
 EClassSuperNotCalled;
 EClassUnresolvedSuperclass(c:String, r:String); // superclass and reason
+EClassInvalidSuper; // Accessing "super" in a parentless class
 EScriptThrow(v:Dynamic); // Script called "throw"
 EScriptCallThrow(v:Dynamic); // Script called a function which threw
 // Fallback error type.

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1144,7 +1144,7 @@ class PolymodInterpEx extends Interp
 			this.locals = capturedLocals;
 			this.declared = capturedDeclared;
 			this.depth = capturedDepth;
-			
+
 			if (Std.isOfType(e, PolymodExprEx.ErrorEx) || Std.isOfType(e, hscript.Expr.Error))
 			{
 				throw e;
@@ -1465,6 +1465,12 @@ class PolymodInterpEx extends Interp
 
 		var prop:Dynamic;
 		// We are calling a LOCAL function from the same module.
+		// We first check if any of the child classes has overriden the scripted function
+		if (_proxy != null && _proxy.topASC?.hasScriptFunction(id) ?? false)
+		{
+			_nextCallObject = _proxy.topASC;
+			return _proxy.topASC.resolveField(id);
+		}
 		if (_proxy != null && _proxy.findFunction(id, true) != null)
 		{
 			_nextCallObject = _proxy;

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -42,7 +42,7 @@ class PolymodInterpEx extends Interp
 		if (_proxy == null)
 		{
 			var clsDecl = getClassDecl() ?? return null;
-			return PolymodStaticClassReference.tryBuild(clsDecl.name)?.getFullyQualifiedName();
+			return Util.getFullClassName(clsDecl);
 		}
 
 		return _proxy.fullyQualifiedName;
@@ -205,11 +205,7 @@ class PolymodInterpEx extends Interp
 
 	private static function registerScriptClass(c:PolymodClassDeclEx)
 	{
-		var name = c.name;
-		if (c.pkg != null)
-		{
-			name = c.pkg.join(".") + "." + name;
-		}
+		var name = Util.getFullClassName(c);
 
 		if (_scriptClassDescriptors.exists(name)) {
 			Polymod.error(SCRIPT_CLASS_ALREADY_REGISTERED, 'Scripted class with fully qualified name "$name" has already been defined. Please change the class name or the package name to ensure uniqueness.');
@@ -270,8 +266,7 @@ class PolymodInterpEx extends Interp
 	{
 		for (cls in _scriptClassDescriptors)
 		{
-			var clsPath = cls.pkg != null ? (cls.pkg.join(".") + ".") : "";
-			clsPath += cls.name;
+			var clsPath = Util.getFullClassName(cls);
 
 			// Automatically import classes with the same package or a parent package.
 			for (imp in _scriptClassDescriptors)
@@ -281,7 +276,7 @@ class PolymodInterpEx extends Interp
 				var classImport = {
 					name: imp.name,
 					pkg: imp.pkg,
-					fullPath: (imp.pkg?.join(".") ?? "") + ((imp.pkg?.length ?? 0) > 0 ? "." : "") + imp.name
+					fullPath: Util.getFullClassName(imp)
 				}
 
 				if ((imp.pkg?.length ?? 0) == 0)
@@ -1094,15 +1089,23 @@ class PolymodInterpEx extends Interp
 		}
 		else
 		{
-			try {
+			try
+			{
 				var result = Reflect.callMethod(target, fun, args);
 				_nextCallObject = null;
 				return result;
-			} catch (e) {
-				errorEx(EScriptCallThrow(e));
-				_nextCallObject = null;
-				return null;
 			}
+			catch (e:Dynamic)
+			{
+				_nextCallObject = null;
+
+				if (Std.isOfType(e, PolymodExprEx.ErrorEx) || Std.isOfType(e, hscript.Expr.Error))
+				{
+					throw e;
+				}
+				return errorEx(EScriptCallThrow(e));
+			}
+			return null;
 		}
 	}
 
@@ -1124,7 +1127,8 @@ class PolymodInterpEx extends Interp
 		this.depth++;
 
 		// Call the function.
-		try {
+		try
+		{
 			var result = Reflect.callMethod(_proxy, fun, args);
 
 			// Restore the local scope.
@@ -1133,15 +1137,20 @@ class PolymodInterpEx extends Interp
 			this.depth = capturedDepth;
 
 			return result;
-		} catch (e) {
-			errorEx(EScriptCallThrow(e));
-
+		}
+		catch (e:Dynamic)
+		{
 			// Restore the local scope.
 			this.locals = capturedLocals;
 			this.declared = capturedDeclared;
 			this.depth = capturedDepth;
+			
+			if (Std.isOfType(e, PolymodExprEx.ErrorEx) || Std.isOfType(e, hscript.Expr.Error))
+			{
+				throw e;
+			}
 
-			return null;
+			return errorEx(EScriptCallThrow(e));
 		}
 
 	}
@@ -1381,6 +1390,8 @@ class PolymodInterpEx extends Interp
 			}
 			else if (_proxy.superClass == null)
 			{
+				if (_proxy._c.extend == null)
+					errorEx(EClassInvalidSuper);
 				return Reflect.makeVarArgs(_proxy.createSuperClass);
 			}
 			else

--- a/polymod/hscript/_internal/PolymodPrinterEx.hx
+++ b/polymod/hscript/_internal/PolymodPrinterEx.hx
@@ -31,6 +31,7 @@ class PolymodPrinterEx extends Printer
 			case EInvalidScriptedVarSet(v): "Invalid variable assignment to scripted class: " + v;
 			case EInvalidFinalSet(f): "Invalid final field assignment: " + f;
 			case EClassSuperNotCalled: "Super constructor not called";
+			case EClassInvalidSuper: "Unexpected \"super\" in class that does not extend anything.";
 			case EClassUnresolvedSuperclass(c, r): 'Unresolved superclass $c (reason: $r)';
 			// TODO: Do we need to distinguish these?
 			case EScriptCallThrow(v): "Script threw an exception: \n" + v;

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -7,6 +7,7 @@ import hscript.Expr.FunctionDecl;
 import hscript.Expr.VarDecl;
 import hscript.Printer;
 import polymod.hscript._internal.PolymodClassDeclEx;
+import polymod.util.Util;
 
 using StringTools;
 
@@ -382,7 +383,7 @@ class PolymodScriptClass
 				var clsPath = pth.join('.');
 				var clsName = pth[pth.length - 1];
 
-				if (PolymodInterpEx.findScriptClassDescriptor(clsName) != null) {
+				if (PolymodInterpEx.findScriptClassDescriptor(clsPath) != null) {
 					targetClass = null;
 				}
 				else if (scriptClassOverrides.exists(clsPath)) {
@@ -402,7 +403,10 @@ class PolymodScriptClass
 					Polymod.error(SCRIPT_PARSE_ERROR, 'Could not determine target class for "${pth.join('.')}" (unregistered type?)');
 				}
 			default:
-				Polymod.error(SCRIPT_PARSE_ERROR, 'Could not determine target class for "${c.extend}" (unknown type?)');
+				if (c.extend != null)
+				{
+					Polymod.error(SCRIPT_PARSE_ERROR, 'Could not determine target class for "${c.extend}" (unknown type?)');
+				}
 		}
 		_interp = new PolymodInterpEx(targetClass, this);
 		_c = c;
@@ -434,12 +438,14 @@ class PolymodScriptClass
 		{
 			__superClassFieldList = [];
 
-			var _superClass = superClass;
+			// NOTE: Explicit Dynamic so Haxe doesn't infer it's a PolymodScriptClass
+			var _superClass:Dynamic = superClass;
 			while (Std.isOfType(_superClass, PolymodScriptClass))
 			{
-				var scriptFields:Array<String> = [for (key in (_superClass._cachedFieldDecls?.keys() ?? [])) key.name];
+				var scriptFields:Array<String> = [for (key in ((_superClass:PolymodScriptClass)._cachedFieldDecls.keys())) key];
 				__superClassFieldList = __superClassFieldList.concat(scriptFields);
 
+				if (_superClass.superClass == null) break;
 				_superClass = _superClass.superClass;
 			}
 
@@ -451,6 +457,11 @@ class PolymodScriptClass
 
 	private function createSuperClass(args:Array<Dynamic> = null)
 	{
+		if (_c.extend == null)
+		{
+			_interp.errorEx(EClassInvalidSuper);
+		}
+
 		if (args == null)
 		{
 			args = [];
@@ -468,7 +479,7 @@ class PolymodScriptClass
 		var fullExtendStringParts = fullExtendString.split('.');
 		var extendString = fullExtendStringParts[fullExtendStringParts.length - 1];
 
-		var classDescriptor = PolymodInterpEx.findScriptClassDescriptor(extendString);
+		var classDescriptor = PolymodInterpEx.findScriptClassDescriptor(fullExtendString);
 		if (classDescriptor != null)
 		{
 			var abstractSuperClass:PolymodAbstractScriptClass = new PolymodScriptClass(classDescriptor, args);
@@ -550,6 +561,9 @@ class PolymodScriptClass
 			case EClassSuperNotCalled:
 					Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
 						'Error while executing function ${className}.${fnName}()#${errLine}: ' + '\n' + 'Custom constructor does not call "super()".');
+			case EClassInvalidSuper:
+					Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+						'Error while executing function ${className}.${fnName}()#${errLine}: ' + '\n' + 'Unexpected "super" in class that does not extend anything.');
 			case EInvalidScriptedFnAccess(f):
 				Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
 					'Error while executing function ${className}.${fnName}()#${errLine}: ' + '\n' +
@@ -615,7 +629,6 @@ class PolymodScriptClass
 		}
 	}
 
-	@:privateAccess(hscript.Interp)
 	public function callFunction(fnName:String, args:Array<Dynamic> = null):Dynamic
 	{
 		var field = findField(fnName);
@@ -693,6 +706,11 @@ class PolymodScriptClass
 		}
 		else
 		{
+			if (fnName == 'toString')
+			{
+				return toString();
+			}
+
 			var fn = findSuperFunction(fnName);
 			if (fn == null)
 			{
@@ -755,15 +773,9 @@ class PolymodScriptClass
 
 	public var fullyQualifiedName(get, null):String;
 
-	private function get_fullyQualifiedName():String
+	private inline function get_fullyQualifiedName():String
 	{
-		var name = "";
-		if (_c.pkg != null && _c.pkg.length > 0)
-		{
-			name += (_c.pkg?.join(".") ?? '') + ".";
-		}
-		name += _c.name;
-		return name;
+		return Util.getFullClassName(_c);
 	}
 
 	private inline function callFunction0(name:String):Dynamic
@@ -999,6 +1011,26 @@ class PolymodScriptClass
 					throw 'Unknown field kind: ${f.kind}';
 			}
 		}
+	}
+
+	// Acts like a HScriptedClass override would but for classes not extending anything
+	public function toString():String
+	{
+		if (hasScriptFunction('toString'))
+		{
+			return callFunction('toString', []);
+		}
+		else if (Std.isOfType(superClass, PolymodScriptClass))
+		{
+			var spr = cast(superClass, PolymodScriptClass);
+			// We call it only if it's a script override
+			if (spr.hasScriptFunction('toString'))
+			{
+				return spr.callFunction('toString', []);
+			}
+		}
+
+		return 'PolymodScriptClass<$fullyQualifiedName>';
 	}
 }
 #end

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -442,7 +442,7 @@ class PolymodScriptClass
 			var _superClass:Dynamic = superClass;
 			while (Std.isOfType(_superClass, PolymodScriptClass))
 			{
-				var scriptFields:Array<String> = [for (key in ((_superClass:PolymodScriptClass)._cachedFieldDecls.keys())) key];
+				var scriptFields:Array<String> = [for (key in ((_superClass:PolymodScriptClass)._cachedFieldDecls?.keys() ?? cast [])) key];
 				__superClassFieldList = __superClassFieldList.concat(scriptFields);
 
 				if (_superClass.superClass == null) break;
@@ -711,6 +711,16 @@ class PolymodScriptClass
 				return toString();
 			}
 
+			var _super:Dynamic = superClass;
+			while (Std.isOfType(_super, PolymodScriptClass))
+			{
+				if (_super.hasScriptFunction(fnName))
+				{
+					return _super.callFunction(fnName, args);
+				}
+				_super = _super.superClass;
+			}
+
 			var fn = findSuperFunction(fnName);
 			if (fn == null)
 			{
@@ -770,6 +780,7 @@ class PolymodScriptClass
 	private var _interp:PolymodInterpEx;
 
 	public var superClass:Dynamic = null;
+	public var topASC(default, null):Null<PolymodAbstractScriptClass>;
 
 	public var fullyQualifiedName(get, null):String;
 

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -12,6 +12,9 @@ import polymod.format.ParseRules.CSVParseFormat;
 import polymod.format.ParseRules.TextFileFormat;
 import polymod.format.ParseRules;
 import polymod.fs.PolymodFileSystem.IFileSystem;
+#if hscript
+import polymod.hscript._internal.PolymodClassDeclEx;
+#end
 #if unifill
 import unifill.Unifill;
 #end
@@ -714,4 +717,16 @@ class Util
 				Std.string(type);
 		}
 	}
+
+	#if hscript
+	/**
+	 * Retrieves the full qualified name of a class declaration.
+	 * @param clsDecl The class declaration.
+	 * @return String
+	 */
+	public static function getFullClassName(clsDecl:PolymodClassDeclEx):String
+	{
+		return (clsDecl.pkg != null ? (clsDecl.pkg.join(".") + ".") : "") + clsDecl.name;
+	}
+	#end
 }


### PR DESCRIPTION
Fixes a few instances where classes that don't extend another class aren't properly accounted for.