### PR TITLE
Fix local variables persisting in static functions

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1489,11 +1489,6 @@ class PolymodInterpEx extends Interp
       return null;
     }
 
-    if (locals.exists(id))
-    {
-      // NOTE: id may exist but be null
-      return locals.get(id).r;
-    }
     if (variables.exists(id))
     {
       // NOTE: id may exist but be null
@@ -1681,10 +1676,11 @@ class PolymodInterpEx extends Interp
 
       this._classDeclOverride = cls;
 
+      var localsCopy:Map<String, {r:Dynamic, ?isfinal:Null<Bool>}> = this.locals.copy();
       var result:Dynamic = null;
       try
       {
-        result = this.exprReturn(fn.expr);
+        result = this.executeEx(fn.expr);
       }
       catch (err:PolymodExprEx.ErrorEx)
       {
@@ -1716,6 +1712,7 @@ class PolymodInterpEx extends Interp
         }
       }
       this._classDeclOverride = previousClassDecl;
+      this.locals = localsCopy;
 
       return result;
     }


### PR DESCRIPTION
Fixes #277

This addresses a few things I've noticed:

* Checking `locals` in `resolve` is practically useless, since `locals` will have already been checked before hscript's `expr` calls it. I've debugged, and the only instance where `locals` were checked here was when they persisted due to a bug.
* Reverts the change of `executeEx` to `exprReturn`, seems like the bug that was fixed by it was subsequently resolved by a different change. This solves local variables persisting in static functions.
* Copies the fix from #257 to apply it to static functions; solves static properties dropping local variables.