### PR TITLE
[FIX] Allow functions of `using` classes to be used in static contexts

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -140,7 +140,8 @@ class PolymodInterpEx extends Interp
 			// Force call super function.
 			return super.fcall(o, '__super_${f}', args);
 		}
-		else if (Std.isOfType(o, PolymodStaticClassReference)) {
+		else if (Std.isOfType(o, PolymodStaticClassReference))
+		{
 			var ref:PolymodStaticClassReference = cast(o, PolymodStaticClassReference);
 
 			return ref.callFunction(f, args);
@@ -153,50 +154,60 @@ class PolymodInterpEx extends Interp
 		}
 
 		var func = get(o, f);
+		if (func != null)
+		{
+			return call(o, func, args);
+		}
 
 		@:privateAccess
+		if (_proxy != null && _proxy._cachedUsingFunctions.exists(f))
 		{
-			if (func == null && _proxy != null && _proxy._cachedUsingFunctions.exists(f))
+			return _proxy._cachedUsingFunctions[f]([o].concat(args));
+		}
+		else if (_classDeclOverride != null)
+		{
+			// TODO: Optimize with a cache
+			var usingFuncs:Map<String, Array<Dynamic>->Dynamic> = [];
+			PolymodScriptClass.buildExtensionFunctionCache(_classDeclOverride, usingFuncs);
+
+			if (usingFuncs.exists(f))
 			{
-				return _proxy._cachedUsingFunctions[f]([o].concat(args));
+				return usingFuncs[f]([o].concat(args));
 			}
 		}
 
 		#if html5
 		// Workaround for an HTML5-specific issue.
 		// https://github.com/HaxeFoundation/haxe/issues/11298
-		if (func == null && f == "contains") {
+		if (f == "contains")
+		{
 			func = get(o, "includes");
 		}
-
 		// For web: remove is inlined so we have to use something else.
-		if (func == null && f == "remove")
+		else if (f == "remove")
 		{
 			@:privateAccess
 			return HxOverrides.remove(cast o, args[0]);
 		}
 		#end
 
-		if (func == null)
+		if (Std.isOfType(o, HScriptedClass))
 		{
-			if (Std.isOfType(o, HScriptedClass))
+			// This is a scripted class!
+			// We should try to call the function on the scripted class.
+			// If it doesn't exist, `asc.callFunction()` will handle generating an error message.
+			if (o.scriptCall != null)
 			{
-				// This is a scripted class!
-				// We should try to call the function on the scripted class.
-				// If it doesn't exist, `asc.callFunction()` will handle generating an error message.
-				if (o.scriptCall != null) {
-					return o.scriptCall(f, args);
-				}
+				return o.scriptCall(f, args);
+			}
 
-				errorEx(EInvalidScriptedFnAccess(f));
-			}
-			else
-			{
-				// Throw an error for a missing function.
-				errorEx(EInvalidAccess(f));
-			}
+			return errorEx(EInvalidScriptedFnAccess(f));
 		}
-		return call(o, func, args);
+		else
+		{
+			// Throw an error for a missing function.
+			return errorEx(EInvalidAccess(f));
+		}
 	}
 
 	private static var _scriptClassDescriptors:Map<String, PolymodClassDeclEx> = new Map<String, PolymodClassDeclEx>();

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -925,7 +925,7 @@ class PolymodScriptClass
 	private var _cachedSuperFunctionDecls:Map<String, Dynamic> = [];
 	private var _cachedFunctionDecls:Map<String, FunctionDecl> = [];
 	private var _cachedVarDecls:Map<String, VarDecl> = [];
-	private var _cachedUsingFunctions:Map<String, Dynamic> = [];
+	private var _cachedUsingFunctions:Map<String, Array<Dynamic>->Dynamic> = [];
 
 	private function buildCaches()
 	{
@@ -935,22 +935,7 @@ class PolymodScriptClass
 		_cachedVarDecls.clear();
 		_cachedUsingFunctions.clear();
 
-		for (n => u in _c.usings)
-		{
-			var fields = Type.getClassFields(u.cls);
-			if (fields.length == 0) continue;
-
-			for (fld in fields)
-			{
-				var func:Dynamic = function(params:Array<Dynamic>)
-				{
-					var prop:Dynamic = Reflect.getProperty(u.cls, fld);
-					return Reflect.callMethod(u.cls, prop, params);
-				}
-
-				_cachedUsingFunctions.set(fld, func);
-			}
-		}
+		buildExtensionFunctionCache(_c, _cachedUsingFunctions);
 
 		for (f in _c.fields)
 		{
@@ -994,5 +979,32 @@ class PolymodScriptClass
 		}
 
 		return 'PolymodScriptClass<$fullyQualifiedName>';
+	}
+
+	/**
+	 * Populates a string map with functions from a 'using' class.
+	 * @param clsDecl The class to retrieve functions from.
+	 * @param usingCache The map to populate.
+	 */
+	public static function buildExtensionFunctionCache(clsDecl:PolymodClassDeclEx, usingCache:Map<String, Array<Dynamic>->Dynamic>):Void
+	{
+		for (_ => u in clsDecl.usings)
+		{
+			var fields = Type.getClassFields(u.cls);
+			if (fields.length == 0) continue;
+
+			for (fld in fields)
+			{
+				var field:Dynamic = Reflect.getProperty(u.cls, fld);
+				if (!Reflect.isFunction(field)) continue;
+
+				var func:Dynamic = function(params:Array<Dynamic>)
+				{
+					return Reflect.callMethod(u.cls, field, params);
+				}
+
+				usingCache.set(fld, func);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Until now these were only available to non-static functions. Currently it's not cached (but so are other static things)
The diff is a bit big because I decided to give stuff some refactor