### PR TITLE
[FEATURE] Allow scripted classes to extend other scripted classes

### DIFF
--- a/polymod/hscript/_internal/PolymodClassDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodClassDeclEx.hx
@@ -64,6 +64,12 @@ class PolymodStaticClassReference {
 		}
 
 		var scriptedObj = asc.superClass;
+
+		while (Std.isOfType(scriptedObj, PolymodScriptClass))
+		{
+			scriptedObj = scriptedObj.superClass;
+		}
+
 		Reflect.setField(scriptedObj, '_asc', asc);
 		return scriptedObj;
 	}

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -135,7 +135,7 @@ class PolymodInterpEx extends Interp
 	override function fcall(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic
 	{
 		// OVERRIDE CHANGE: Custom logic to handle super calls to prevent infinite recursion
-		if (_proxy != null && o == _proxy.superClass)
+		if (_proxy != null && o == _proxy.superClass && !Std.isOfType(o, PolymodScriptClass))
 		{
 			// Force call super function.
 			return super.fcall(o, '__super_${f}', args);
@@ -271,6 +271,30 @@ class PolymodInterpEx extends Interp
 			var clsPath = cls.pkg != null ? (cls.pkg.join(".") + ".") : "";
 			clsPath += cls.name;
 
+			// Automatically import classes with the same package or a parent package.
+			for (imp in _scriptClassDescriptors)
+			{
+				if (cls == imp) continue;
+
+				var classImport = {
+					name: imp.name,
+					pkg: imp.pkg,
+					fullPath: (imp.pkg?.join(".") ?? "") + ((imp.pkg?.length ?? 0) > 0 ? "." : "") + imp.name
+				}
+
+				if ((imp.pkg?.length ?? 0) == 0)
+				{
+					cls.imports.set(imp.name, classImport);
+					continue;
+				}
+
+				var fullPackage:String = cls.pkg.join(".") + ".";
+				if (clsPath.indexOf(fullPackage) == 0)
+				{
+					cls.imports.set(imp.name, classImport);
+				}
+			}
+
 			for (key => imp in cls.importsToValidate)
 			{
 				if (_scriptClassDescriptors.exists(imp.fullPath))
@@ -287,19 +311,52 @@ class PolymodInterpEx extends Interp
 
 				Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not import ${imp.fullPath}', clsPath);
 			}
+
+			// Check if the scripted classes extend the right type.
+			if (cls.extend == null) continue;
+
+			var superClassPath:String = new hscript.Printer().typeToString(cls.extend);
+			if (!cls.imports.exists(superClassPath))
+			{
+				switch (cls.extend)
+				{
+					case CTPath(path, params):
+						if (params != null && params.length > 0)
+						{
+							Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not extend ${superClassPath}, do not include type parameters in super class name', clsPath);
+						}
+
+						default:
+							// Other error handling?
+				}
+
+				// Default
+				Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not extend ${superClassPath}, is the type imported?', clsPath);
+			}
+			else
+			{
+				switch (cls.extend)
+				{
+					case CTPath(_, params):
+						cls.extend = CTPath(cls.imports.get(superClassPath).fullPath.split('.'), params);
+					case _:
+				}
+			}
 		}
 	}
 
 	override function setVar(id:String, v:Dynamic)
 	{
-		if (_proxy != null && _proxy.superClass != null)
+		if (_proxy != null && _proxy.superHasField(id))
 		{
-			if (_proxy.superHasField(id))
+			if (Std.isOfType(_proxy.superClass, PolymodScriptClass))
 			{
-				// Set in super class.
-				Reflect.setProperty(_proxy.superClass, id, v);
-				return;
+				var superClass:PolymodAbstractScriptClass = cast (_proxy.superClass, PolymodScriptClass);
+				return superClass.fieldWrite(id, v);
 			}
+
+			Reflect.setProperty(_proxy.superClass, id, v);
+			return;
 		}
 
 		// Fallback to setting in local scope.
@@ -313,14 +370,18 @@ class PolymodInterpEx extends Interp
 			case EIdent(id):
 				// Make sure setting superclass fields directly works.
 				// Also ensures property functions are accounted for.
-				if (_proxy != null && _proxy.superClass != null)
+				if (_proxy != null && _proxy.superHasField(id))
 				{
-					if (_proxy.superHasField(id))
+					var v = expr(e2);
+
+					if (Std.isOfType(_proxy.superClass, PolymodScriptClass))
 					{
-						var v = expr(e2);
-						Reflect.setProperty(_proxy.superClass, id, v);
-						return v;
+						var superClass:PolymodAbstractScriptClass = cast (_proxy.superClass, PolymodScriptClass);
+						return superClass.fieldWrite(id, v);
 					}
+
+					Reflect.setProperty(_proxy.superClass, id, v);
+					return v;
 				}
 
 				@:privateAccess
@@ -360,14 +421,18 @@ class PolymodInterpEx extends Interp
 					case EIdent(id0):
 						if (id0 == "this")
 						{
-							if (_proxy != null && _proxy.superClass != null)
+							if (_proxy != null && _proxy.superHasField(id))
 							{
-								if (_proxy.superHasField(id))
+								var v = expr(e2);
+
+								if (Std.isOfType(_proxy.superClass, PolymodScriptClass))
 								{
-									var v = expr(e2);
-									Reflect.setProperty(_proxy.superClass, id, v);
-									return v;
+									var superClass:PolymodAbstractScriptClass = cast (_proxy.superClass, PolymodScriptClass);
+									return superClass.fieldWrite(id, v);
 								}
+
+								Reflect.setProperty(_proxy.superClass, id, v);
+								return v;
 							}
 						}
 						else
@@ -1149,6 +1214,12 @@ class PolymodInterpEx extends Interp
 			}
 			else if (proxy.superClass != null && proxy.superHasField(f))
 			{
+				if (Std.isOfType(proxy.superClass, PolymodScriptClass))
+				{
+					var superClass:PolymodAbstractScriptClass = cast (proxy.superClass, PolymodScriptClass);
+					return superClass.fieldRead(f);
+				}
+
 				return Reflect.getProperty(proxy.superClass, f);
 			}
 			else
@@ -1241,12 +1312,14 @@ class PolymodInterpEx extends Interp
 			{
 				proxy._interp.variables.set(f, v);
 			}
-			else if (proxy.superClass != null && Reflect.hasField(proxy.superClass, f))
+			else if (proxy.superClass != null && proxy.superHasField(f))
 			{
-				Reflect.setProperty(proxy.superClass, f, v);
-			}
-			else if (proxy.superClass != null && Type.getInstanceFields(Type.getClass(_proxy.superClass)).contains(f))
-			{
+				if (Std.isOfType(proxy.superClass, PolymodScriptClass))
+				{
+					var superClass:PolymodAbstractScriptClass = cast (proxy.superClass, PolymodScriptClass);
+					return superClass.fieldWrite(f, v);
+				}
+
 				Reflect.setProperty(proxy.superClass, f, v);
 			}
 			else
@@ -1380,6 +1453,13 @@ class PolymodInterpEx extends Interp
 		else if (_proxy != null && _proxy.superHasField(id))
 		{
 			_nextCallObject = _proxy.superClass;
+
+			if (Std.isOfType(_proxy.superClass, PolymodScriptClass))
+			{
+				var superClass:PolymodAbstractScriptClass = cast (_proxy.superClass, PolymodScriptClass);
+				return superClass.fieldRead(id);
+			}
+
 			return Reflect.getProperty(_proxy.superClass, id);
 		}
 		else if (_proxy != null)
@@ -1852,38 +1932,6 @@ class PolymodInterpEx extends Interp
 					Polymod.debug('Using class ${importedClass.name} from ${importedClass.fullPath}');
 					usings.set(importedClass.name, importedClass);
 				case DClass(c):
-					var extend = c.extend;
-					if (extend != null)
-					{
-						var superClassPath = new hscript.Printer().typeToString(extend);
-						if (!imports.exists(superClassPath)) {
-							switch (extend) {
-								case CTPath(path, params):
-									if (params != null && params.length > 0) {
-										errorEx(EClassUnresolvedSuperclass(superClassPath, 'do not include type parameters in super class name'));
-									}
-								default:
-									// Other error handling?
-							}
-							// Default
-							errorEx(EClassUnresolvedSuperclass(superClassPath, 'not recognized, is the type imported?'));
-						}
-
-						if (imports.exists(superClassPath))
-						{
-							var extendImport = imports.get(superClassPath);
-							if (extendImport.cls == null)
-								errorEx(EClassUnresolvedSuperclass(superClassPath, 'expected a class'));
-
-							switch (extend)
-							{
-								case CTPath(_, params):
-									extend = CTPath(imports.get(superClassPath).fullPath.split('.'), params);
-								case _:
-							}
-						}
-					}
-
 					var instanceFields = [];
 					var staticFields = [];
 					for (f in c.fields)
@@ -1904,7 +1952,7 @@ class PolymodInterpEx extends Interp
 						params: c.params,
 						meta: c.meta,
 						isPrivate: c.isPrivate,
-						extend: extend,
+						extend: c.extend,
 						implement: c.implement,
 						fields: instanceFields,
 						isExtern: c.isExtern,

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -387,7 +387,10 @@ class PolymodScriptClass
 				var clsPath = pth.join('.');
 				var clsName = pth[pth.length - 1];
 
-				if (scriptClassOverrides.exists(clsPath)) {
+				if (PolymodInterpEx.findScriptClassDescriptor(clsName) != null) {
+					targetClass = null;
+				}
+				else if (scriptClassOverrides.exists(clsPath)) {
 					targetClass = scriptClassOverrides.get(clsPath);
 				}
 				else if (c.imports.exists(clsName))
@@ -434,7 +437,19 @@ class PolymodScriptClass
 		// Reflect.hasField(this, name) is REALLY expensive so we use a cache.
 		if (__superClassFieldList == null)
 		{
-			__superClassFieldList = Reflect.fields(superClass).concat(Type.getInstanceFields(Type.getClass(superClass)));
+			__superClassFieldList = [];
+
+			var _superClass = superClass;
+			while (Std.isOfType(_superClass, PolymodScriptClass))
+			{
+				var scriptFields:Array<String> = [for (key in (_superClass._cachedFieldDecls?.keys() ?? [])) key.name];
+				__superClassFieldList = __superClassFieldList.concat(scriptFields);
+
+				_superClass = _superClass.superClass;
+			}
+
+			__superClassFieldList = __superClassFieldList.concat(Reflect.fields(_superClass));
+			__superClassFieldList = __superClassFieldList.concat(Type.getInstanceFields(Type.getClass(_superClass)));
 		}
 		return __superClassFieldList.indexOf(name) != -1;
 	}
@@ -827,6 +842,15 @@ class PolymodScriptClass
 			return _cachedSuperFunctionDecls.get(name);
 		}
 
+		if (Std.isOfType(superClass, PolymodScriptClass))
+		{
+			var func = Reflect.field(superClass, name);
+			if (func == null) return null;
+
+			_cachedSuperFunctionDecls.set(name, func);
+			return func;
+		}
+
 		// OVERRIDE CHANGE: Use __super_ when calling superclass
 		var fixedName = '__super_${name}';
 
@@ -936,7 +960,7 @@ class PolymodScriptClass
 					var prop:Dynamic = Reflect.getProperty(u.cls, fld);
 					return Reflect.callMethod(u.cls, prop, params);
 				}
-					
+
 				_cachedUsingFunctions.set(fld, func);
 			}
 		}


### PR DESCRIPTION
This PR does what it says in the title.

<img width="551" height="571" alt="image" src="https://github.com/user-attachments/assets/9961b58f-c47c-4ee8-bdfc-64dcd5a1004c" />
<img width="378" height="128" alt="image" src="https://github.com/user-attachments/assets/5dc280cb-d3be-4bc3-bfac-c59f7be92e4e" />


The extends have been moved to `validateImports` to check for any scripted classes registered after the scripts have been loaded. To add to this, I've also added a feature to automatically import classes with the same or the parent package, since it felt weird writing `import Adversary;` in the same file as the class itself.

Like expected, `super` points to the parent script class. Using `this` also works on scripted fields`.