### PR TITLE
[Breaking Change] Rename `init` and make it not use the super constructor arguments

### DIFF
--- a/polymod/hscript/HScriptedClass.hx
+++ b/polymod/hscript/HScriptedClass.hx
@@ -22,7 +22,7 @@ interface HScriptedClass
    * @param constArgs The arguments to pass to the constructor.
    * @return The instance of the scripted class.
    */
-  // public static function init(clsName:String, constArgs:Array<Dynamic>):ThisType;
+  // public static function scriptInit(clsName:String, ...constArgs:Dynamic):ThisType;
   /**
    * Call a custom static function on a scripted class, by the given name, with the given arguments.
    *

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -91,7 +91,7 @@ class HScriptedClassMacro
 
   /**
    * Create the complicated parts of the generated class,
-   * specifically the `init()` function and the override methods.
+   * specifically the `scriptInit()` function and the override methods.
    */
   public static function buildHScriptClass(cls:haxe.macro.Type.ClassType, fields:Array<Field>):Array<Field>
   {
@@ -123,7 +123,7 @@ class HScriptedClassMacro
                 for (arg in args)
                   {name: arg.name, opt: arg.opt, type: Context.toComplexType(arg.t)}
               ];
-              var initField:Field = buildScriptedClassInit(cls, superCls, constArgs);
+              var initField:Field = buildScriptedClassInit(cls, superCls);
               fields.push(initField);
               constructor = buildScriptedClassConstructor(constArgs);
             case TLazy(builder):
@@ -136,7 +136,7 @@ class HScriptedClassMacro
                     for (arg in args)
                       {name: arg.name, opt: arg.opt, type: Context.toComplexType(arg.t)}
                   ];
-                  var initField:Field = buildScriptedClassInit(cls, superCls, constArgs);
+                  var initField:Field = buildScriptedClassInit(cls, superCls);
                   fields.push(initField);
                   constructor = buildScriptedClassConstructor(constArgs);
                 default:
@@ -151,7 +151,7 @@ class HScriptedClassMacro
           constructor = buildEmptyScriptedClassConstructor();
           // Create scripted class utility functions.
           Context.info('  Creating scripted class utils...', Context.currentPos());
-          var initField:Field = buildScriptedClassInit(cls, superCls, []);
+          var initField:Field = buildScriptedClassInit(cls, superCls);
           fields.push(initField);
           fields.push(constructor);
         }
@@ -166,13 +166,10 @@ class HScriptedClassMacro
     return fields;
   }
 
-  static function buildScriptedClassInit(cls:haxe.macro.Type.ClassType, superCls:haxe.macro.Type.ClassType, superConstArgs:Array<FunctionArg>):Field
+  static function buildScriptedClassInit(cls:haxe.macro.Type.ClassType, superCls:haxe.macro.Type.ClassType):Field
   {
     // Context.info('  Building scripted class init() function', Context.currentPos());
     var clsTypeName:String = cls.pack.join('.') != '' ? '${cls.pack.join('.')}.${cls.name}' : cls.name;
-    var superClsTypeName:String = superCls.pack.join('.') != '' ? '${superCls.pack.join('.')}.${superCls.name}' : superCls.name;
-
-    var constArgs = [for (arg in superConstArgs) macro $i{arg.name}];
     var typePath:haxe.macro.TypePath =
       {
         pack: cls.pack,
@@ -180,7 +177,7 @@ class HScriptedClassMacro
       };
     var function_init:Field =
       {
-        name: 'init',
+        name: 'scriptInit',
         doc: "Initializes a scripted class instance using the given scripted class name and constructor arguments.",
         access: [APublic, AStatic],
         meta: null,
@@ -188,7 +185,7 @@ class HScriptedClassMacro
         kind: FFun(
           {
             args: [
-              {name: 'clsName', type: macro :String},].concat(superConstArgs),
+              {name: 'clsName', type: macro :String}, {name: 'args', type: macro :...Dynamic}],
             params: null,
             ret: Context.toComplexType(Context.getType(clsTypeName)),
             expr: macro
@@ -204,7 +201,7 @@ class HScriptedClassMacro
 
               try
               {
-                var result = clsRef.instantiate([$a{constArgs}]);
+                var result = clsRef.instantiate((cast args) ?? []);
                 if (result == null)
                 {
                   polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
@@ -333,6 +330,17 @@ class HScriptedClassMacro
         pos: cls.pos,
       };
 
+    var var__isHScriptedClass:Field =
+      {
+        name: '_isHScriptedClass',
+        doc: 'Field used to identify a HScriptedClass.',
+        access: [APrivate, AStatic],
+        meta: [
+          {name: ':noCompletion', pos: cls.pos}],
+        pos: cls.pos,
+        kind: FVar(macro :Bool, macro true)
+      };
+
     var function_listScriptClasses:Field =
       {
         name: 'listScriptClasses',
@@ -444,6 +452,7 @@ class HScriptedClassMacro
 
     return [
       var__asc,
+      var__isHScriptedClass,
       function_listScriptClasses,
       function_scriptCall,
       function_scriptGet,

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1256,6 +1256,14 @@ class PolymodInterpEx extends Interp
   {
     if (o == null) errorEx(ENullObjectReference(f));
 
+    // Backwards compatibility for scripts using HScriptedClass.init
+    // Std.isOfType(o, HScriptedClass) only works with class instances
+    // so we look for a specific field to double check the type
+    if ((f == 'init' || f == 'scriptInit') && o._isHScriptedClass)
+    {
+      return Reflect.makeVarArgs((args:Array<Dynamic>) -> return o.scriptInit(args[0], args.slice(1)));
+    }
+
     var oCls:String = Util.getTypeNameOf(o);
 
     // Check if the field is a blacklisted static field.


### PR DESCRIPTION
Resolves #241 

`HScriptedClass.init` is pretty odd because it's used throughout FNF as the equivalent of `new` for script classes, but it accepts the super class's constructor arguments as its own, and then initializes an instance of the script class using those arguments, however a script class is actually independent from the super class in this regard and can have any arguments it wants, which may not be the same the super class has. When scripts use it, it causes issues in some targets, where some of the arguments either get converted incorrectly, become null or, on HashLink, throws an error about the incompatible type.

One instance of that in FNF is `phillyTrain.hxc`, which instantiates an instance of `BuildingEffectShader` with `ScriptedFlxRuntimeShader.init('BuildingEffectShader', 1.0)`, which calls an `init` of arguments (Null\<String>, Null\<String>, Null\<String>), it works fine on C++ since there is no type-checking, but on HL it throws an error about being unable to cast a float to a string. This is not a mistake on the script's end, since it does accept a float as its argument.

So I've made it use [haxe.Rest](https://api.haxe.org/haxe/Rest.html) for the arguments, however since it doesn't work well with Reflect I had to add some backwards compatibility handling for scripts using it.

The registries and other parts of Haxe code that call `init` seem to work well with these changes somehow, but I recommend caution regarding any breaking changes this could introduce.