### PR TITLE
Move the FunkinCrew/HScript fork to be built into Polymod

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -8,9 +8,7 @@ import polymod.backends.PolymodAssets;
 import polymod.format.JsonHelp;
 import polymod.format.ParseRules;
 import polymod.fs.PolymodFileSystem;
-#if hscript
 import polymod.hscript._internal.PolymodScriptClass;
-#end
 import polymod.util.DependencyUtil;
 import polymod.util.VersionUtil;
 import thx.semver.Version;
@@ -327,7 +325,6 @@ class Polymod
 		prevParams = params;
 
 		// Do scripted class initialization now that the assetLibrary is loaded.
-		#if hscript
 		if (params.useScriptedClasses)
 		{
 			Polymod.notice(PolymodErrorCode.SCRIPT_PARSING, 'Parsing script classes...');
@@ -342,12 +339,6 @@ class Polymod
 				Polymod.notice(PolymodErrorCode.SCRIPT_PARSED, 'Parsed and registered ${classList.length} scripted classes.');
 			}
 		}
-		#else
-		if (params.useScriptedClasses)
-		{
-			Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes were requested, but hscript is not installed.');
-		}
-		#end
 
 		return sortedModsToLoad;
 	}
@@ -653,7 +644,6 @@ class Polymod
 	 */
 	public static function clearScripts():Void
 	{
-		#if hscript
 		@:privateAccess
 		polymod.hscript._internal.PolymodScriptClass.clearScriptedClasses();
 		polymod.hscript._internal.PolymodEnum.clearScriptedEnums();
@@ -661,9 +651,6 @@ class Polymod
 		polymod.hscript._internal.PolymodTyperEx.clearAllModules();
 		#end
 		polymod.hscript.HScriptable.ScriptRunner.clearScripts();
-		#else
-		Polymod.warning(SCRIPT_HSCRIPT_NOT_INSTALLED, "Cannot register script classes, HScript is not available.");
-		#end
 	}
 
 	/**
@@ -671,7 +658,6 @@ class Polymod
 	 */
 	public static function registerAllScriptClasses():Void
 	{
-		#if hscript
 		@:privateAccess {
 			// Go through each script and parse any classes in them.
 			var potentialScripts:Array<String> = Polymod.assetLibrary.list(TEXT);
@@ -705,9 +691,6 @@ class Polymod
 
 			polymod.hscript._internal.PolymodInterpEx.validateImports();
 		}
-		#else
-		Polymod.warning(SCRIPT_HSCRIPT_NOT_INSTALLED, "Cannot register script classes, HScript is not available.");
-		#end
 	}
 
 	/**
@@ -716,7 +699,6 @@ class Polymod
 	 */
 	public static function registerAllScriptClassesAsync():Array<lime.app.Future<Bool>>
 	{
-		#if hscript
 		// Go through each script and parse any classes in them.
 		var potentialScripts:Array<String> = Polymod.assetLibrary.list(TEXT);
 		var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
@@ -745,10 +727,6 @@ class Polymod
 		polymod.hscript._internal.PolymodInterpEx.validateImports();
 
 		return futures;
-		#else
-		Polymod.warning(SCRIPT_HSCRIPT_NOT_INSTALLED, "Cannot register script classes, HScript is not available.");
-		return [];
-		#end
 	}
 
 	public static function error(code:PolymodErrorCode, message:String, origin:PolymodErrorOrigin = UNKNOWN):Void
@@ -810,19 +788,13 @@ class Polymod
 	 * @param importClass The class type to import instead.
 	 */
 	public static function addImportAlias(importAlias:String, importClass:Class<Dynamic>):Void {
-		#if hscript
 		PolymodScriptClass.importOverrides.set(importAlias, importClass);
-		#else
-		Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes imports were requested, but hscript is not installed.');
-		#end
+
 	}
 
 	public static function removeImportAlias(importAlias:String):Void {
-		#if hscript
 		PolymodScriptClass.importOverrides.remove(importAlias);
-		#else
-		Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes imports were requested, but hscript is not installed.');
-		#end
+
 	}
 
 	/**
@@ -831,11 +803,7 @@ class Polymod
 	 * @param importAlias (optional) The alias to use for the import. If not provided, the full class path will be used.
 	 */
 	public static function addDefaultImport(importClass:Class<Dynamic>, ?importAlias:String):Void {
-		#if hscript
 		PolymodScriptClass.defaultImports.set(importAlias == null ? Type.getClassName(importClass) : importAlias, importClass);
-		#else
-		Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes imports were requested, but hscript is not installed.');
-		#end
 	}
 
 	/**
@@ -843,11 +811,7 @@ class Polymod
 	 * @param importPath The full import path to blacklist, as a string.
 	 */
 	public static function blacklistImport(importPath:String):Void {
-		#if hscript
 		addImportAlias(importPath, null);
-		#else
-		Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes imports were requested, but hscript is not installed.');
-		#end
 	}
 
 	/**
@@ -857,11 +821,7 @@ class Polymod
 	 */
 	public static function blacklistStaticFields(parentClass:Class<Dynamic>, fields:Array<String>):Void
 	{
-		#if hscript
 		PolymodScriptClass.blacklistedStaticFields.set(parentClass, fields);
-		#else
-		Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes imports were requested, but hscript is not installed.');
-		#end
 	}
 
 	/**
@@ -871,11 +831,7 @@ class Polymod
 	 */
 	public static function blacklistInstanceFields(parentClass:Class<Dynamic>, fields:Array<String>):Void
 	{
-		#if hscript
 		PolymodScriptClass.blacklistedInstanceFields.set(Type.getClassName(parentClass), fields);
-		#else
-		Polymod.warning(PolymodErrorCode.SCRIPT_HSCRIPT_NOT_INSTALLED, 'Scripted classes imports were requested, but hscript is not installed.');
-		#end
 	}
 }
 
@@ -1310,12 +1266,6 @@ enum abstract PolymodErrorCode(String) from String to String
 	 * - Make sure you call Polymod.init before attempting to call this function.
 	 */
 	var POLYMOD_NOT_LOADED:String = 'polymod_not_loaded';
-
-	/**
-	 * Script classes are currently disabled because the `hscript` library is not available.
-	 * - Make sure you have the `hscript` Haxelib installed if you want to use scripts.
-	 */
-	var SCRIPT_HSCRIPT_NOT_INSTALLED:String = 'script_hscript_not_installed';
 
 	/**
 	 * A script file of the given name could not be found.

--- a/polymod/hscript/HScriptable.hx
+++ b/polymod/hscript/HScriptable.hx
@@ -1,10 +1,10 @@
 package polymod.hscript;
 
 import haxe.Json;
+import polymod.hscript._internal.Expr;
 import polymod.Polymod;
 import polymod.util.Util;
 
-#if hscript
 /**
  * This interface triggers the execution of a macro on any elements which use the `@:hscript` annotation.
  * Adding the annotation to the function will cause the associate script to be executed.
@@ -17,10 +17,10 @@ interface HScriptable
 
 /**
  * Used to provide additional parameters to a script function.
- * 
+ *
  * `@:hscript({context, pathName, ...})` can be added to any function to make it scriptable.
  * Add constant identifiers to `context` to make values accessible to the script and use the other values to define the script's behavior.
- * 
+ *
  * For the purposes of backwards compatibility, `@:hscript(A, B, C)` can also be used, which will specify the context.
  * `@:hscript(A, B, C)` is equivalent to `@:hscript({context: [A, B, C]})` but doesn't allow modifying other parameters.
  * The new syntax should be adopted where possible.
@@ -81,7 +81,7 @@ class HScriptParams
 	 * to determine the pathname of the script to run.
 	 *
 	 * This can be the name of a String variable, or of a function.
-	 * 
+	 *
 	 * DON'T SET `pathNameDynId` DIRECTLY!
 	 * Just pass an identifier into `pathName` instead of a constant.
 	 */
@@ -273,7 +273,7 @@ class Script
 {
 	private static var parser:polymod.hscript._internal.PolymodParserEx;
 
-	public var program:hscript.Expr;
+	public var program:Expr;
 	public var interp:polymod.hscript._internal.PolymodInterpEx;
 
 	public static function buildParser():polymod.hscript._internal.PolymodParserEx
@@ -312,4 +312,3 @@ class Script
 		};
 	}
 }
-#end

--- a/polymod/hscript/_internal/Async.hx
+++ b/polymod/hscript/_internal/Async.hx
@@ -1,0 +1,601 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package polymod.hscript._internal;
+
+import polymod.hscript._internal.Expr;
+
+enum VarMode
+{
+  Defined;
+  ForceSync;
+}
+
+class Async
+{
+  var definedVars:Array<{n:String, prev:Null<VarMode>}>;
+  var vars:Map<String, VarMode>;
+  var currentFun:String;
+  var currentLoop:Expr;
+  var currentBreak:Expr->Expr;
+  var uid = 0;
+
+  public var asyncIdents:Map<String, Bool>;
+
+  static var nullExpr:Expr = #if hscriptPos
+    {
+      e: null,
+      pmin: 0,
+      pmax: 0,
+      origin: "<null>",
+      line: 0
+    } #else null #end;
+  static var nullId = mk(EIdent("null"), nullExpr);
+
+  inline static function expr(e:Expr)
+  {
+    return #if hscriptPos e.e #else e #end;
+  }
+
+  inline static function mk(e, inf:Expr):Expr
+  {
+    return #if hscriptPos
+      {
+        e: e,
+        pmin: inf.pmin,
+        pmax: inf.pmax,
+        origin: inf.origin,
+        line: inf.line
+      } #else e #end;
+  }
+
+  /**
+    Convert a script into asynchronous one.
+    - calls such as foo(a,b,c) are translated to a_foo(function(r) ...rest, a,b,c) where r is the result value
+    - object access such obj.bar(a,b,c) are translated to obj.a_bar(function(r) ...rest, a, b, c)
+    - @async expr will execute the expression but continue without waiting for it to finish
+    - @split [ e1, e2, e3 ] is transformed to split(function(_) ...rest, [e1, e2, e3]) which
+      should execute asynchronously all expressions - until they return - before continuing the execution
+    - for(i in v) block; loops are translated to the following:
+      var _i = makeIterator(v);
+      function _loop() {
+        if( !_i.hasNext() ) return;
+        var v = _i.next();
+        block(function(_) _loop());
+      }
+      _loop()
+    - while loops are translated similar to for loops
+    - break and continue are correctly handled
+    - you can use @sync <expr> to disable async transformation in some code parts (for performance reason)
+    - a few expressions are still not supported (complex calls, try/catch, and a few others)
+
+    In these examples ...rest represents the continuation of execution of the script after the expression
+  **/
+  public static function toAsync(e:Expr, topLevelSync = false)
+  {
+    var a = new Async();
+    return a.build(e, topLevelSync);
+  }
+
+  public dynamic function getTopLevelEnd()
+  {
+    return ignore();
+  }
+
+  public function build(e:Expr, topLevelSync = false)
+  {
+    if (topLevelSync)
+    {
+      return buildSync(e, null);
+    }
+    else
+    {
+      var end = getTopLevelEnd();
+      return toCps(e, end, end);
+    }
+  }
+
+  function defineVar(v:String, mode)
+  {
+    definedVars.push({n: v, prev: vars.get(v)});
+    vars.set(v, mode);
+  }
+
+  function lookupFunctions(el:Array<Expr>)
+  {
+    for (e in el)
+      switch (expr(e))
+      {
+        case EFunction(_, _, name, _) if (name != null):
+          defineVar(name, Defined);
+        case EMeta("sync", _, expr(_) => EFunction(_, _, name, _)) if (name != null):
+          defineVar(name, ForceSync);
+        default:
+      }
+  }
+
+  function buildSync(e:Expr, exit:Expr):Expr
+  {
+    switch (expr(e))
+    {
+      case EFunction(_, _, name, _):
+        if (name != null) return toCps(e, null, null);
+        return e;
+      case EBlock(el):
+        var v = saveVars();
+        lookupFunctions(el);
+        var e = block([for (e in el) buildSync(e, exit)], e);
+        restoreVars(v);
+        return e;
+      case EMeta("async", _, e):
+        return toCps(e, ignore(), ignore());
+      case EMeta("sync", args, ef = expr(_) => EFunction(fargs, body, name, ret)):
+        return mk(EMeta("sync", args, mk(EFunction(fargs, buildSync(body, null), name, ret), ef)), e);
+      case EBreak if (currentBreak != null):
+        return currentBreak(e);
+      case EContinue if (currentLoop != null):
+        return block([retNull(currentLoop, e), mk(EReturn(), e)], e);
+      case EFor(_), EWhile(_):
+        var oldLoop = currentLoop, oldBreak = currentBreak;
+        currentLoop = null;
+        currentBreak = null;
+        e = Tools.map(e, buildSync.bind(_, exit));
+        currentLoop = oldLoop;
+        currentBreak = oldBreak;
+        return e;
+      case EReturn(eret) if (exit != null):
+        return block([eret == null ? retNull(exit, e) : call(exit, [eret], e), mk(EReturn(), e)], e);
+      default:
+        return Tools.map(e, buildSync.bind(_, exit));
+    }
+  }
+
+  public function new()
+  {
+    vars = new Map();
+    definedVars = [];
+  }
+
+  function ignore(?e):Expr
+  {
+    var inf = e == null ? nullExpr : e;
+    return fun("_", block(e == null ? [] : [e], inf));
+  }
+
+  inline function ident(str, e)
+  {
+    return mk(EIdent(str), e);
+  }
+
+  inline function fun(arg:String, e, ?name)
+  {
+    return mk(EFunction([
+      {name: arg, t: null}], e, name), e);
+  }
+
+  inline function funs(arg:Array<String>, e, ?name)
+  {
+    return mk(EFunction([for (a in arg) {name: a, t: null}], e, name), e);
+  }
+
+  inline function block(arr:Array<Expr>, e)
+  {
+    if (arr.length == 1 && expr(arr[0]).match(EBlock(_))) return arr[0];
+    return mk(EBlock(arr), e);
+  }
+
+  inline function field(e, f, inf)
+  {
+    return mk(EField(e, f), inf);
+  }
+
+  inline function binop(op, e1, e2, inf)
+  {
+    return mk(EBinop(op, e1, e2), inf);
+  }
+
+  inline function call(e, args, inf)
+  {
+    return mk(ECall(e, args), inf);
+  }
+
+  function retNull(e:Expr, ?pos):Expr
+  {
+    switch (expr(e))
+    {
+      case EFunction([
+        {name: "_"}], e, _, _):
+        return e;
+      default:
+    }
+    return call(e, [nullId], pos == null ? e : pos);
+  }
+
+  function makeCall(ecall, args:Array<Expr>, rest:Expr, exit, sync = false)
+  {
+    var names = [for (i in 0...args.length) "_a" + uid++];
+    var rargs = [for (i in 0...args.length) ident(names[i], ecall)];
+    if (!sync) rargs.unshift(rest);
+    var rest = mk(sync ? ECall(rest, [call(ecall, rargs, ecall)]) : ECall(ecall, rargs), ecall);
+    var i = args.length - 1;
+    while (i >= 0)
+    {
+      rest = toCps(args[i], fun(names[i], rest), exit);
+      i--;
+    }
+    return rest;
+  }
+
+  var syncFlag:Bool;
+
+  function isSync(e:Expr)
+  {
+    syncFlag = true;
+    checkSync(e);
+    return syncFlag;
+  }
+
+  inline function isAsyncIdent(id:String)
+  {
+    return asyncIdents == null || asyncIdents.exists(id);
+  }
+
+  function checkSync(e:Expr)
+  {
+    if (!syncFlag) return;
+    switch (expr(e))
+    {
+      case ECall(expr(_) => EIdent(i), _) if (isAsyncIdent(i) || vars.get(i) == Defined):
+        syncFlag = false;
+      case ECall(expr(_) => EField(_, i), _) if (isAsyncIdent(i)):
+        syncFlag = false;
+      case EFunction(_, _, name, _) if (name != null):
+        syncFlag = false;
+      case EMeta("sync" | "async", _, _):
+        // isolated from the sync part
+      default:
+        Tools.iter(e, checkSync);
+    }
+  }
+
+  function saveVars()
+  {
+    return definedVars.length;
+  }
+
+  function restoreVars(k)
+  {
+    while (definedVars.length > k)
+    {
+      var v = definedVars.pop();
+      if (v.prev == null) vars.remove(v.n)
+      else
+        vars.set(v.n, v.prev);
+    }
+  }
+
+  public function toCps(e:Expr, rest:Expr, exit:Expr):Expr
+  {
+    if (isSync(e)) return call(rest, [buildSync(e, exit)], e);
+    switch (expr(e))
+    {
+      case EBlock(el):
+        var el = el.copy();
+        var vold = saveVars();
+        lookupFunctions(el);
+        while (el.length > 0)
+        {
+          var e = toCps(el.pop(), rest, exit);
+          rest = ignore(e);
+        }
+        restoreVars(vold);
+        return retNull(rest);
+      case EFunction(args, body, name, t):
+        var vold = saveVars();
+        if (name != null) defineVar(name, Defined);
+        for (a in args)
+          defineVar(a.name, Defined);
+        args.unshift({name: "_onEnd", t: null});
+        var frest = ident("_onEnd", e);
+        var oldFun = currentFun;
+        currentFun = name;
+        var body = toCps(body, frest, frest);
+        var f = mk(EFunction(args, body, name, t), e);
+        restoreVars(vold);
+        return rest == null ? f : call(rest, [f], e);
+      case EParent(e):
+        return mk(EParent(toCps(e, rest, exit)), e);
+      case EMeta("sync", _, e):
+        return call(rest, [buildSync(e, exit)], e);
+      case EMeta("async", _, e):
+        var nothing = ignore();
+        return block([toCps(e, nothing, nothing), retNull(rest)], e);
+      case EMeta("split", _, e):
+        var args = switch (expr(e))
+        {
+          case EArrayDecl(el): el;
+          default: throw "@split expression should be an array";
+        };
+        var args = [for (a in args) fun("_rest", toCps(block([a], a), ident("_rest", a), exit))];
+        return call(ident("split", e), [rest, mk(EArrayDecl(args), e)], e);
+      case ECall(expr(_) => EIdent(i), args):
+        var mode = vars.get(i);
+        return makeCall(ident(mode != null ? i : "a_" + i, e), args, rest, exit, mode == ForceSync);
+      case ECall(expr(_) => EField(e, f), args):
+        return makeCall(field(e, "a_" + f, e), args, rest, exit);
+      case EFor(v, eit, eloop):
+        var id = ++uid;
+        var it = ident("_i" + id, e);
+        var oldLoop = currentLoop, oldBreak = currentBreak;
+        var loop = ident("_loop" + id, e);
+        currentLoop = loop;
+        currentBreak = function(inf) return block([retNull(rest, inf), mk(EReturn(), inf)], inf);
+        var efor = block([
+          mk(EVar("_i" + id, call(ident("makeIterator", eit), [eit], eit)), eit),
+          fun("_", block([
+            mk(EIf(mk(EUnop("!", true, call(field(it, "hasNext", it), [], it)), it), currentBreak(it)), it),
+            mk(EVar(v, call(field(it, "next", it), [], it)), it),
+            toCps(eloop, loop, exit),
+          ], it), "_loop" + id),
+          retNull(loop, e),
+        ], e);
+        currentLoop = oldLoop;
+        currentBreak = oldBreak;
+        return efor;
+      case EUnop(op = "!", prefix, eop):
+        return toCps(eop, fun("_r", call(rest, [mk(EUnop(op, prefix, ident("_r", e)), e)], e)), exit);
+      case EBinop(op, e1, e2):
+        switch (op)
+        {
+          case "=", "+=", "-=", "/=", "*=", "%=", "&=", "|=", "^=":
+            switch (expr(e1))
+            {
+              case EIdent(_):
+                var id = "_r" + uid++;
+                return toCps(e2, fun(id, call(rest, [binop(op, e1, ident(id, e1), e1)], e1)), exit);
+              case EField(ef1, f):
+                var id1 = "_r" + uid++;
+                var id2 = "_r" + uid++;
+                return toCps(ef1, fun(id1, toCps(e2, fun(id2, call(rest, [binop(op, field(ident(id1, e1), f, ef1), ident(id2, e2), e)], e)), exit)), exit);
+              case EArray(earr, eindex):
+                var idArr = "_r" + uid++;
+                var idIndex = "_r" + uid++;
+                var idVal = "_r" + uid++;
+                return toCps(earr, fun(idArr, toCps(eindex, fun(idIndex, toCps(e2, fun(idVal, call(rest, [
+                  binop(op, mk(EArray(ident(idArr, earr), ident(idIndex, eindex)), e1), ident(idVal, e1), e)
+                ], e)), exit)), exit)), exit);
+              default:
+                throw "assert " + e1;
+            }
+          case "||":
+            var id1 = "_r" + uid++;
+            var id2 = "_r" + uid++;
+            return toCps(e1,
+              fun(id1, mk(EIf(binop("==", ident(id1, e1), ident("true", e1), e1), call(rest, [ident("true", e1)], e1), toCps(e2, rest, exit)), e)), exit);
+          case "&&":
+            var id1 = "_r" + uid++;
+            var id2 = "_r" + uid++;
+            return toCps(e1,
+              fun(id1, mk(EIf(binop("!=", ident(id1, e1), ident("true", e1), e1), call(rest, [ident("false", e1)], e1), toCps(e2, rest, exit)), e)), exit);
+          default:
+            var id1 = "_r" + uid++;
+            var id2 = "_r" + uid++;
+            return toCps(e1, fun(id1, toCps(e2, fun(id2, call(rest, [binop(op, ident(id1, e1), ident(id2, e2), e)], e)), exit)), exit);
+        }
+      case EIf(cond, e1, e2), ETernary(cond, e1, e2):
+        return toCps(cond, fun("_c", mk(EIf(ident("_c", cond), toCps(e1, rest, exit), e2 == null ? retNull(rest) : toCps(e2, rest, exit)), e)), exit);
+      case EWhile(cond, ewh):
+        var id = ++uid;
+        var loop = ident("_loop" + id, cond);
+        var oldLoop = currentLoop, oldBreak = currentBreak;
+        currentLoop = loop;
+        currentBreak = function(e) return block([retNull(rest, e), mk(EReturn(), e)], e);
+        var ewhile = block([
+          fun("_r", toCps(cond, fun("_c", mk(EIf(ident("_c", cond), toCps(ewh, loop, exit), retNull(rest, cond)), cond)), exit), "_loop" + id),
+          retNull(loop, cond),
+        ], e);
+        currentLoop = oldLoop;
+        currentBreak = oldBreak;
+        return ewhile;
+      case EReturn(eret):
+        return eret == null ? retNull(exit, e) : toCps(eret, exit, exit);
+      case EObject(fields):
+        var id = "_o" + uid++;
+        var rest = call(rest, [ident(id, e)], e);
+        fields.reverse();
+        for (f in fields)
+          rest = toCps(f.e, fun("_r", block([
+            binop("=", mk(EField(ident(id, f.e), f.name), f.e), ident("_r", f.e), f.e),
+            rest,
+          ], f.e)), exit);
+        return block([mk(EVar(id, mk(EObject([]), e)), e), rest,], e);
+      case EArrayDecl(el):
+        var id = "_a" + uid++;
+        var rest = call(rest, [ident(id, e)], e);
+        var i = el.length - 1;
+        while (i >= 0)
+        {
+          var e = el[i];
+          rest = toCps(e, fun("_r", block([
+            binop("=", mk(EArray(ident(id, e), mk(EConst(CInt(i)), e)), e), ident("_r", e), e),
+            rest,
+          ], e)), exit);
+          i--;
+        }
+        return block([mk(EVar(id, mk(EArrayDecl([]), e)), e), rest,], e);
+      case EArray(earr, eindex):
+        var id1 = "_r" + uid++;
+        var id2 = "_r" + uid++;
+        return toCps(earr, fun(id1, toCps(eindex, fun(id2, call(rest, [mk(EArray(ident(id1, e), ident(id2, e)), e)], e)), exit)), exit);
+      case EVar(v, t, ev):
+        if (ev == null) return block([e, retNull(rest, e)], e);
+        return block([
+          mk(EVar(v, t), e),
+          toCps(ev, fun("_r", block([binop("=", ident(v, e), ident("_r", e), e), retNull(rest, e)], e)), exit),
+        ], e);
+      case EConst(_), EIdent(_), EUnop(_), EField(_):
+        return call(rest, [e], e);
+      case ENew(cl, args):
+        var names = [for (i in 0...args.length) "_a" + uid++];
+        var rargs = [for (i in 0...args.length) ident(names[i], args[i])];
+        var rest = call(rest, [mk(ENew(cl, rargs), e)], e);
+        var i = args.length - 1;
+        while (i >= 0)
+        {
+          rest = toCps(args[i], fun(names[i], rest), exit);
+          i--;
+        }
+        return rest;
+      case EBreak:
+        if (currentBreak == null) throw "Break outside loop";
+        return currentBreak(e);
+      case EContinue:
+        if (currentLoop == null) throw "Continue outside loop";
+        return block([retNull(currentLoop, e), mk(EReturn(), e)], e);
+      case ESwitch(v, cases, def):
+        var cases = [for (c in cases) {values: c.values, expr: toCps(c.expr, rest, exit)}];
+        return toCps(v, mk(EFunction([
+          {name: "_c", t: null}],
+          mk(ESwitch(ident("_c", v), cases, def == null ? retNull(rest) : toCps(def, rest, exit)), e)), e), exit);
+      case EThrow(v):
+        return toCps(v, mk(EFunction([
+          {name: "_v", t: null}], mk(EThrow(v), v)), v), exit);
+      case EMeta(name, _, e) if (name.charCodeAt(0) == ":".code): // ignore custom ":" metadata
+        return toCps(e, rest, exit);
+      // case EDoWhile(_), ETry(_), ECall(_):
+      default:
+        throw "Unsupported async expression " + Printer.toString(e);
+    }
+  }
+}
+
+class AsyncInterp extends Interp
+{
+  public function setContext(api:Dynamic)
+  {
+    var funs = new Array();
+    for (v in variables.keys())
+      if (Reflect.isFunction(variables.get(v))) funs.push({v: v, obj: null});
+
+    variables.set("split", split);
+    variables.set("makeIterator", makeIterator);
+
+    var c = Type.getClass(api);
+    for (f in (c == null ? Reflect.fields(api) : Type.getInstanceFields(c)))
+    {
+      var fv = Reflect.field(api, f);
+      if (!Reflect.isFunction(fv)) continue;
+      if (f.charCodeAt(0) == "_".code) f = f.substr(1);
+      variables.set(f, fv);
+      // create the async wrapper if doesn't exists
+      if (f.substr(0, 2) != "a_") funs.push({v: f, obj: api});
+    }
+
+    for (v in funs)
+    {
+      if (variables.exists("a_" + v.v)) continue;
+      var fv:Dynamic = variables.get(v.v);
+      var obj = v.obj;
+      variables.set("a_" + v.v, Reflect.makeVarArgs(function(args:Array<Dynamic>) {
+        var onEnd = args.shift();
+        onEnd(Reflect.callMethod(obj, fv, args));
+      }));
+    }
+  }
+
+  public function hasMethod(name:String)
+  {
+    var v = variables.get(name);
+    return v != null && Reflect.isFunction(v);
+  }
+
+  public function callValue(value:Dynamic, args:Array<Dynamic>, ?onResult:Dynamic->Void, ?vthis:{})
+  {
+    var oldThis = variables.get("this");
+    if (vthis != null) variables.set("this", vthis);
+    if (onResult == null) onResult = function(_) {
+    };
+    args.unshift(onResult);
+    Reflect.callMethod(null, value, args);
+    variables.set("this", oldThis);
+  }
+
+  public function callAsync(id:String, args, ?onResult, ?vthis:{})
+  {
+    var v = variables.get(id);
+    if (v == null) throw "Missing function " + id + "()";
+    callValue(v, args, onResult, vthis);
+  }
+
+  function split(rest:Dynamic->Void, args:Array<Dynamic>)
+  {
+    if (args.length == 0) rest(null);
+    else
+    {
+      var count = args.length;
+      function next(_)
+      {
+        if (--count == 0) rest(null);
+      }
+      for (a in args)
+        a(next);
+    }
+  }
+
+  override function fcall(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic
+  {
+    var m = Reflect.field(o, f);
+    if (m == null)
+    {
+      if (f.substr(0, 2) == "a_")
+      {
+        m = Reflect.field(o, f.substr(2));
+        // fallback on sync version
+        if (m != null)
+        {
+          var onEnd = args.shift();
+          onEnd(call(o, m, args));
+          return null;
+        }
+        // fallback on generic script
+        m = Reflect.field(o, "scriptCall");
+        if (m != null)
+        {
+          call(o, m, [args.shift(), f.substr(2), args]);
+          return null;
+        }
+      }
+      else
+      {
+        // fallback on generic script
+        m = Reflect.field(o, "scriptCall");
+        if (m != null)
+        {
+          var result:Dynamic = null;
+          call(o, m, [function(r) result = r, f, args]);
+          return result;
+        }
+      }
+      error(ECustom(o + " has no method " + f));
+    }
+    return call(o, m, args);
+  }
+}

--- a/polymod/hscript/_internal/Bytes.hx
+++ b/polymod/hscript/_internal/Bytes.hx
@@ -1,0 +1,456 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package polymod.hscript._internal;
+
+import polymod.hscript._internal.Expr;
+
+class Bytes
+{
+  var bin:haxe.io.Bytes;
+  var bout:haxe.io.BytesBuffer;
+  var pin:Int;
+  var hstrings:Map<String, Int>;
+  var strings:Array<String>;
+  var nstrings:Int;
+
+  function new(?bin)
+  {
+    this.bin = bin;
+    pin = 0;
+    bout = new haxe.io.BytesBuffer();
+    hstrings = new Map();
+    strings = [null];
+    nstrings = 1;
+  }
+
+  function doEncodeString(v:String)
+  {
+    var vid = hstrings.get(v);
+    if (vid == null)
+    {
+      if (nstrings == 256)
+      {
+        hstrings = new Map();
+        nstrings = 1;
+      }
+      hstrings.set(v, nstrings);
+      bout.addByte(0);
+      var vb = haxe.io.Bytes.ofString(v);
+      bout.addByte(vb.length);
+      bout.add(vb);
+      nstrings++;
+    }
+    else
+      bout.addByte(vid);
+  }
+
+  function doDecodeString()
+  {
+    var id = bin.get(pin++);
+    if (id == 0)
+    {
+      var len = bin.get(pin);
+      var str = #if (haxe_ver < 3.103) bin.readString(pin + 1, len); #else bin.getString(pin + 1, len); #end
+      pin += len + 1;
+      if (strings.length == 255) strings = [null];
+      strings.push(str);
+      return str;
+    }
+    return strings[id];
+  }
+
+  function doEncodeInt(v:Int)
+  {
+    bout.addInt32(v);
+  }
+
+  function doEncodeConst(c:Const)
+  {
+    switch (c)
+    {
+      case CInt(v):
+        if (v >= 0 && v <= 255)
+        {
+          bout.addByte(0);
+          bout.addByte(v);
+        }
+        else
+        {
+          bout.addByte(1);
+          doEncodeInt(v);
+        }
+      case CFloat(f):
+        bout.addByte(2);
+        doEncodeString(Std.string(f));
+      case CString(s):
+        bout.addByte(3);
+        doEncodeString(s);
+    }
+  }
+
+  function doDecodeInt()
+  {
+    var i = bin.getInt32(pin);
+    pin += 4;
+    return i;
+  }
+
+  function doDecodeConst()
+  {
+    return switch (bin.get(pin++))
+    {
+      case 0:
+        CInt(bin.get(pin++));
+      case 1:
+        var i = doDecodeInt();
+        CInt(i);
+      case 2:
+        CFloat(Std.parseFloat(doDecodeString()));
+      case 3:
+        CString(doDecodeString());
+      default:
+        throw "Invalid code " + bin.get(pin - 1);
+    }
+  }
+
+  function doEncode(e:Expr)
+  {
+    #if hscriptPos
+    doEncodeString(e.origin);
+    doEncodeInt(e.line);
+    var e = e.e;
+    #end
+    bout.addByte(exprIndex(e));
+    switch (e)
+    {
+      case EConst(c):
+        doEncodeConst(c);
+      case EIdent(v):
+        doEncodeString(v);
+      case EVar(n, _, e):
+        doEncodeString(n);
+        if (e == null) bout.addByte(255);
+        else
+          doEncode(e);
+      case EParent(e):
+        doEncode(e);
+      case EBlock(el):
+        bout.addByte(el.length);
+        for (e in el)
+          doEncode(e);
+      case EField(e, f):
+        doEncode(e);
+        doEncodeString(f);
+      case EBinop(op, e1, e2):
+        doEncodeString(op);
+        doEncode(e1);
+        doEncode(e2);
+      case EUnop(op, prefix, e):
+        doEncodeString(op);
+        bout.addByte(prefix ? 1 : 0);
+        doEncode(e);
+      case ECall(e, el):
+        doEncode(e);
+        bout.addByte(el.length);
+        for (e in el)
+          doEncode(e);
+      case EIf(cond, e1, e2):
+        doEncode(cond);
+        doEncode(e1);
+        if (e2 == null) bout.addByte(255);
+        else
+          doEncode(e2);
+      case EWhile(cond, e):
+        doEncode(cond);
+        doEncode(e);
+      case EDoWhile(cond, e):
+        doEncode(cond);
+        doEncode(e);
+      case EFor(v, it, e):
+        doEncodeString(v);
+        doEncode(it);
+        doEncode(e);
+      case EForGen(it, e):
+        doEncode(it);
+        doEncode(e);
+      case EBreak, EContinue:
+      case EFunction(params, e, name, _):
+        bout.addByte(params.length);
+        for (p in params)
+          doEncodeString(p.name);
+        doEncode(e);
+        doEncodeString(name == null ? "" : name);
+      case EReturn(e):
+        if (e == null) bout.addByte(255);
+        else
+          doEncode(e);
+      case EArray(e, index):
+        doEncode(e);
+        doEncode(index);
+      case EArrayDecl(el):
+        if (el.length >= 255) throw "assert";
+        bout.addByte(el.length);
+        for (e in el)
+          doEncode(e);
+      case ENew(cl, params):
+        doEncodeString(cl);
+        bout.addByte(params.length);
+        for (e in params)
+          doEncode(e);
+      case EThrow(e):
+        doEncode(e);
+      case ETry(e, v, _, ecatch):
+        doEncode(e);
+        doEncodeString(v);
+        doEncode(ecatch);
+      case EObject(fl):
+        bout.addByte(fl.length);
+        for (f in fl)
+        {
+          doEncodeString(f.name);
+          doEncode(f.e);
+        }
+      case ETernary(cond, e1, e2):
+        doEncode(cond);
+        doEncode(e1);
+        doEncode(e2);
+      case ESwitch(e, cases, def):
+        doEncode(e);
+        for (c in cases)
+        {
+          if (c.values.length == 0) throw "assert";
+          for (v in c.values)
+            doEncode(v);
+          bout.addByte(255);
+          doEncode(c.expr);
+        }
+        bout.addByte(255);
+        if (def == null) bout.addByte(255)
+        else
+          doEncode(def);
+      case EMeta(name, args, e):
+        doEncodeString(name);
+        bout.addByte(args == null ? 0 : args.length + 1);
+        if (args != null) for (e in args)
+          doEncode(e);
+        doEncode(e);
+      case ECheckType(e, _):
+        doEncode(e);
+    }
+  }
+
+  function exprIndex(e):Int
+  {
+    return switch (e)
+    {
+      case EConst(_): 0;
+      case EIdent(_): 1;
+      case EVar(_): 2;
+      case EParent(_): 3;
+      case EBlock(_): 4;
+      case EField(_): 5;
+      case EBinop(_): 6;
+      case EUnop(_): 7;
+      case ECall(_): 8;
+      case EIf(_): 9;
+      case EWhile(_): 10;
+      case EFor(_): 11;
+      case EBreak: 12;
+      case EContinue: 13;
+      case EFunction(_): 14;
+      case EReturn(_): 15;
+      case EArray(_): 16;
+      case EArrayDecl(_): 17;
+      case ENew(_): 18;
+      case EThrow(_): 19;
+      case ETry(_): 20;
+      case EObject(_): 21;
+      case ETernary(_): 22;
+      case ESwitch(_): 23;
+      case EDoWhile(_): 24;
+      case EMeta(_): 25;
+      case ECheckType(_): 26;
+      case EForGen(_): 27;
+    }
+  }
+
+  function doDecode():Expr
+  {
+  #if hscriptPos
+  if (bin.get(pin) == 255)
+  {
+    pin++;
+    return null;
+  }
+  var origin = doDecodeString();
+  var line = doDecodeInt();
+  return {
+    e: _doDecode(),
+    pmin: 0,
+    pmax: 0,
+    origin: origin,
+    line: line
+  };
+  } function _doDecode():ExprDef
+  {
+  #end
+    return switch (bin.get(pin++))
+    {
+      case 0:
+        EConst(doDecodeConst());
+      case 1:
+        EIdent(doDecodeString());
+      case 2:
+        var v = doDecodeString();
+        EVar(v, doDecode());
+      case 3:
+        EParent(doDecode());
+      case 4:
+        var a = new Array();
+        for (i in 0...bin.get(pin++))
+          a.push(doDecode());
+        EBlock(a);
+      case 5:
+        var e = doDecode();
+        EField(e, doDecodeString());
+      case 6:
+        var op = doDecodeString();
+        var e1 = doDecode();
+        EBinop(op, e1, doDecode());
+      case 7:
+        var op = doDecodeString();
+        var prefix = bin.get(pin++) != 0;
+        EUnop(op, prefix, doDecode());
+      case 8:
+        var e = doDecode();
+        var params = new Array();
+        for (i in 0...bin.get(pin++))
+          params.push(doDecode());
+        ECall(e, params);
+      case 9:
+        var cond = doDecode();
+        var e1 = doDecode();
+        EIf(cond, e1, doDecode());
+      case 10:
+        var cond = doDecode();
+        EWhile(cond, doDecode());
+      case 11:
+        var v = doDecodeString();
+        var it = doDecode();
+        EFor(v, it, doDecode());
+      case 12:
+        EBreak;
+      case 13:
+        EContinue;
+      case 14:
+        var params = new Array<Argument>();
+        for (i in 0...bin.get(pin++))
+          params.push({name: doDecodeString()});
+        var e = doDecode();
+        var name = doDecodeString();
+        EFunction(params, e, (name == "") ? null : name);
+      case 15:
+        EReturn(doDecode());
+      case 16:
+        var e = doDecode();
+        EArray(e, doDecode());
+      case 17:
+        var el = new Array();
+        for (i in 0...bin.get(pin++))
+          el.push(doDecode());
+        EArrayDecl(el);
+      case 18:
+        var cl = doDecodeString();
+        var el = new Array();
+        for (i in 0...bin.get(pin++))
+          el.push(doDecode());
+        ENew(cl, el);
+      case 19:
+        EThrow(doDecode());
+      case 20:
+        var e = doDecode();
+        var v = doDecodeString();
+        ETry(e, v, null, doDecode());
+      case 21:
+        var fl = new Array();
+        for (i in 0...bin.get(pin++))
+        {
+          var name = doDecodeString();
+          var e = doDecode();
+          fl.push({name: name, e: e});
+        }
+        EObject(fl);
+      case 22:
+        var cond = doDecode();
+        var e1 = doDecode();
+        var e2 = doDecode();
+        ETernary(cond, e1, e2);
+      case 23:
+        var e = doDecode();
+        var cases = [];
+        while (true)
+        {
+          var v = doDecode();
+          if (v == null) break;
+          var values = [v];
+          while (true)
+          {
+            v = doDecode();
+            if (v == null) break;
+            values.push(v);
+          }
+          cases.push({values: values, expr: doDecode()});
+        }
+        var def = doDecode();
+        ESwitch(e, cases, def);
+      case 24:
+        var cond = doDecode();
+        EDoWhile(cond, doDecode());
+      case 25:
+        var name = doDecodeString();
+        var count = bin.get(pin++);
+        var args = count == 0 ? null : [for (i in 0...count - 1) doDecode()];
+        EMeta(name, args, doDecode());
+      case 26:
+        ECheckType(doDecode(), CTPath(["Void"]));
+      case 27:
+        EForGen(doDecode(), doDecode());
+      case 255:
+        null;
+      default:
+        throw "Invalid code " + bin.get(pin - 1);
+    }
+  }
+
+  public static function encode(e:Expr):haxe.io.Bytes
+  {
+    var b = new Bytes();
+    b.doEncode(e);
+    return b.bout.getBytes();
+  }
+
+  public static function decode(bytes:haxe.io.Bytes):Expr
+  {
+    var b = new Bytes(bytes);
+    return b.doDecode();
+  }
+}

--- a/polymod/hscript/_internal/Checker.hx
+++ b/polymod/hscript/_internal/Checker.hx
@@ -1,0 +1,1600 @@
+package polymod.hscript._internal;
+
+import polymod.hscript._internal.Expr;
+import polymod.hscript._internal.Parser;
+
+/**
+  This is a special type that can be used in API.
+  It will be type-checked as `Script` but will compile/execute as `Real`
+**/
+typedef TypeCheck<Real, Script> = Real;
+
+enum TType
+{
+  TMono(r:{r:TType});
+  TVoid;
+  TInt;
+  TFloat;
+  TBool;
+  TDynamic;
+  TParam(name:String);
+  TUnresolved(name:String);
+  TNull(t:TType);
+  TInst(c:CClass, args:Array<TType>);
+  TEnum(e:CEnum, args:Array<TType>);
+  TType(t:CTypedef, args:Array<TType>);
+  TAbstract(a:CAbstract, args:Array<TType>);
+  TFun(args:Array<{name:String, opt:Bool, t:TType}>, ret:TType);
+  TAnon(fields:Array<{name:String, opt:Bool, t:TType}>);
+  TLazy(f:Void->TType);
+}
+
+private enum WithType
+{
+  NoValue;
+  Value;
+  WithType(t:TType);
+}
+
+enum CTypedecl
+{
+  CTClass(c:CClass);
+  CTEnum(e:CEnum);
+  CTTypedef(t:CTypedef);
+  CTAlias(t:TType);
+  CTAbstract(a:CAbstract);
+}
+
+typedef CMetadata = Array<{name:String, params:Null<Array<Expr>>}>;
+
+typedef CNamedType =
+{
+  var name:String;
+  var params:Array<TType>;
+  var ?meta:CMetadata;
+}
+
+typedef CClass =
+{
+  > CNamedType,
+  var ?superClass:TType;
+  var ?constructor:CField;
+  var ?interfaces:Array<TType>;
+  var ?isInterface:Bool;
+  var fields:Map<String, CField>;
+  var statics:Map<String, CField>;
+}
+
+typedef CField =
+{
+  var isPublic:Bool;
+  var canWrite:Bool;
+  var complete:Bool;
+  var params:Array<TType>;
+  var name:String;
+  var t:TType;
+  var ?meta:CMetadata;
+}
+
+typedef CEnum =
+{
+  > CNamedType,
+  var constructors:Array<{name:String, ?args:Array<{name:String, opt:Bool, t:TType}>}>;
+}
+
+typedef CTypedef =
+{
+  > CNamedType,
+  var t:TType;
+}
+
+typedef CAbstract =
+{
+  > CNamedType,
+  var t:TType;
+  var from:Array<TType>;
+  var to:Array<TType>;
+}
+
+class Completion
+{
+  public var expr:Expr;
+  public var t:TType;
+
+  public function new(expr, t)
+  {
+    this.expr = expr;
+    this.t = t;
+  }
+}
+
+@:allow(hscript.Checker)
+class CheckerTypes
+{
+  var types:Map<String, CTypedecl> = new Map();
+  var t_string:TType;
+  var localParams:Map<String, TType>;
+  var parser:Parser;
+
+  public function new()
+  {
+    types = new Map();
+    types.set("Void", CTAlias(TVoid));
+    types.set("Int", CTAlias(TInt));
+    types.set("Float", CTAlias(TFloat));
+    types.set("Bool", CTAlias(TBool));
+    types.set("Dynamic", CTAlias(TDynamic));
+    parser = new Parser();
+  }
+
+  public function addXmlApi(api:Xml)
+  {
+    var types = new haxe.rtti.XmlParser();
+    types.process(api, "");
+    var todo = [];
+    for (v in types.root)
+      addXmlType(v, todo);
+    for (f in todo)
+      f();
+    t_string = getType("String");
+  }
+
+  public function defineClass(name:String, ?ct:CClass)
+  {
+    if (ct == null) ct =
+      {
+        name: name,
+        fields: [],
+        statics: [],
+        params: [],
+      };
+    types.set(name, CTClass(ct));
+    return ct;
+  }
+
+  function addXmlType(x:haxe.rtti.CType.TypeTree, todo:Array<Void->Void>)
+  {
+    switch (x)
+    {
+      case TPackage(name, full, subs):
+        for (s in subs)
+          addXmlType(s, todo);
+      case TClassdecl(c):
+        if (types.exists(c.path)) return;
+        var cl:CClass =
+          {
+            name: c.path,
+            params: [],
+            fields: new Map(),
+            statics: new Map(),
+          };
+        addMeta(c, cl);
+        if (c.isInterface) cl.isInterface = true;
+        for (p in c.params)
+          cl.params.push(TParam(p));
+        todo.push(function() {
+          localParams = [for (t in cl.params) c.path + "." + Checker.typeStr(t) => t];
+          if (c.superClass != null) cl.superClass = getType(c.superClass.path, [for (t in c.superClass.params) makeXmlType(t)]);
+          if (c.interfaces != null)
+          {
+            cl.interfaces = [];
+            for (i in c.interfaces)
+              cl.interfaces.push(getType(i.path, [for (t in i.params) makeXmlType(t)]));
+          }
+          var pkeys = [];
+          function initField(f:haxe.rtti.CType.ClassField, fields)
+          {
+            if (f.isOverride || f.name.substr(0, 4) == "get_" || f.name.substr(0, 4) == "set_") return;
+            var complete = !StringTools.startsWith(f.name, "__"); // __uid, etc. (no metadata in such fields)
+            for (m in f.meta)
+            {
+              if (m.name == ":noScript") return;
+              if (m.name == ":noCompletion") complete = false;
+            }
+            var fl:CField =
+              {
+                isPublic: f.isPublic,
+                canWrite: f.set.match(RNormal | RCall(_) | RDynamic),
+                complete: complete,
+                params: [],
+                name: f.name,
+                t: null
+              };
+            for (p in f.params)
+            {
+              var pt = TParam(p);
+              var key = f.name + "." + p;
+              pkeys.push(key);
+              fl.params.push(pt);
+              localParams.set(key, pt);
+            }
+            fl.t = makeXmlType(f.type);
+            if (f.meta != null && f.meta.length > 0)
+            {
+              fl.meta = [];
+              for (m in f.meta)
+                fl.meta.push({name: m.name, params: [for (p in m.params) try parser.parseString(p) catch (e:hscript.Expr.Error) null]});
+            }
+            while (pkeys.length > 0)
+              localParams.remove(pkeys.pop());
+            if (fl.name == "new") cl.constructor = fl;
+            else
+              fields.set(f.name, fl);
+          }
+          for (f in c.fields)
+            initField(f, cl.fields);
+          for (f in c.statics)
+            initField(f, cl.statics);
+          localParams = null;
+        });
+        types.set(cl.name, CTClass(cl));
+      case TEnumdecl(e):
+        if (types.exists(e.path)) return;
+        var en:CEnum =
+          {
+            name: e.path,
+            params: [],
+            constructors: [],
+          };
+        addMeta(e, en);
+        for (p in e.params)
+          en.params.push(TParam(p));
+        todo.push(function() {
+          localParams = [for (t in en.params) e.path + "." + Checker.typeStr(t) => t];
+          for (c in e.constructors)
+            en.constructors.push({name: c.name, args: c.args == null ? null : [for (a in c.args) {name: a.name, opt: a.opt, t: makeXmlType(a.t)}]});
+          localParams = null;
+        });
+        types.set(en.name, CTEnum(en));
+      case TTypedecl(t):
+        if (types.exists(t.path)) return;
+        var td:CTypedef =
+          {
+            name: t.path,
+            params: [],
+            t: null,
+          };
+        for (p in t.params)
+          td.params.push(TParam(p));
+        if (t.path == "hscript.TypeCheck") td.params.reverse();
+        todo.push(function() {
+          localParams = [for (pt in td.params) t.path + "." + Checker.typeStr(pt) => pt];
+          td.t = makeXmlType(t.type);
+          localParams = null;
+        });
+        types.set(t.path, CTTypedef(td));
+      case TAbstractdecl(a):
+        if (types.exists(a.path)) return;
+        var ta:CAbstract =
+          {
+            name: a.path,
+            params: [],
+            t: null,
+            from: [],
+            to: [],
+          };
+        addMeta(a, ta);
+        for (p in a.params)
+          ta.params.push(TParam(p));
+        todo.push(function() {
+          localParams = [for (t in ta.params) a.path + "." + Checker.typeStr(t) => t];
+          ta.t = makeXmlType(a.athis);
+          for (f in a.from)
+            if (f.field == null) ta.from.push(makeXmlType(f.t));
+          for (t in a.to)
+            if (t.field == null) ta.to.push(makeXmlType(t.t));
+          localParams = null;
+        });
+        types.set(a.path, CTAbstract(ta));
+    }
+  }
+
+  function addMeta(src:haxe.rtti.CType.TypeInfos, to:CNamedType)
+  {
+    if (src.meta == null || src.meta.length == 0) return;
+    to.meta = [];
+    for (m in src.meta)
+      to.meta.push({name: m.name, params: [for (p in m.params) try parser.parseString(p) catch (e:hscript.Expr.Error) null]});
+  }
+
+  function makeXmlType(t:haxe.rtti.CType.CType):TType
+  {
+    return switch (t)
+    {
+      case CUnknown: TUnresolved("Unknown");
+      case CEnum(name, params): getType(name, [for (t in params) makeXmlType(t)]);
+      case CClass(name, params): getType(name, [for (t in params) makeXmlType(t)]);
+      case CTypedef(name, params): getType(name, [for (t in params) makeXmlType(t)]);
+      case CFunction(args, ret): TFun([for (a in args) {name: a.name, opt: a.opt, t: makeXmlType(a.t)}], makeXmlType(ret));
+      case CAnonymous(fields):
+        inline function isOpt(m:haxe.rtti.CType.MetaData)
+        {
+          if (m == null) return false;
+          var b = false;
+          for (m in m)
+            if (m.name == ":optional")
+            {
+              b = true;
+              break;
+            }
+          return b;
+        }
+        TAnon([for (f in fields) {name: f.name, t: makeXmlType(f.type), opt: isOpt(f.meta)}]);
+      case CDynamic(t): TDynamic;
+      case CAbstract(name, params):
+        switch (name)
+        {
+          default:
+            getType(name, [for (t in params) makeXmlType(t)]);
+        }
+    }
+  }
+
+  function getType(name:String, ?args:Array<TType>):TType
+  {
+    if (localParams != null)
+    {
+      var t = localParams.get(name);
+      if (t != null) return t;
+    }
+    var t = resolve(name, args);
+    if (t == null)
+    {
+      var pack = name.split(".");
+      if (pack.length > 1)
+      {
+        // bugfix for some args reported as pack._Name.Name while they are not private
+        var priv = pack[pack.length - 2];
+        if (priv.charCodeAt(0) == "_".code)
+        {
+          pack.remove(priv);
+          return getType(pack.join("."), args);
+        }
+      }
+      return TUnresolved(name); // most likely private class
+    }
+    return t;
+  }
+
+  public function resolve(name:String, ?args:Array<TType>):TType
+  {
+    if (name == "Null")
+    {
+      if (args == null || args.length != 1) throw "Missing Null<T> parameter";
+      return TNull(args[0]);
+    }
+    var t = types.get(name);
+    if (t == null) return null;
+    if (args == null) args = [];
+    return switch (t)
+    {
+      case CTClass(c): TInst(c, args);
+      case CTEnum(e): TEnum(e, args);
+      case CTTypedef(t): TType(t, args);
+      case CTAbstract(a): TAbstract(a, args);
+      case CTAlias(t): t;
+    }
+  }
+}
+
+class Checker
+{
+  public var types:CheckerTypes;
+
+  var locals:Map<String, TType>;
+  var globals:Map<String, TType> = new Map();
+  var events:Map<String, TType> = new Map();
+  var currentFunType:TType;
+  var isCompletion:Bool;
+  var allowDefine:Bool;
+  var hasReturn:Bool;
+
+  public var allowAsync:Bool;
+  public var allowReturn:Null<TType>;
+  public var allowGlobalsDefine:Bool;
+  public var allowUntypedMeta:Bool;
+
+  public function new(?types)
+  {
+    if (types == null) types = new CheckerTypes();
+    this.types = types;
+  }
+
+  public function setGlobals(cl:CClass, ?params:Array<TType>, allowPrivate = false)
+  {
+    if (params == null) params = [for (p in cl.params) makeMono()];
+    while (true)
+    {
+      for (f in cl.fields)
+        if (f.isPublic || allowPrivate) setGlobal(f.name, f.params.length == 0 ? f.t : TLazy(function() {
+          var t = apply(f.t, f.params, [for (i in 0...f.params.length) makeMono()]);
+          return apply(t, cl.params, params);
+        }));
+      if (cl.superClass == null) break;
+      cl = switch (cl.superClass)
+      {
+        case TInst(csup, pl):
+          params = [for (p in pl) apply(p, cl.params, params)];
+          csup;
+        default: throw "assert";
+      }
+    }
+  }
+
+  public function removeGlobal(name:String)
+  {
+    globals.remove(name);
+  }
+
+  public function setGlobal(name:String, type:TType)
+  {
+    globals.set(name, type);
+  }
+
+  public function setEvent(name:String, type:TType)
+  {
+    events.set(name, type);
+  }
+
+  public function getGlobals()
+  {
+    return globals;
+  }
+
+  public dynamic function onTopDownEnum(en:CEnum, field:String)
+  {
+    return false;
+  }
+
+  function typeArgs(args:Array<Argument>, pos:Expr)
+  {
+    return [
+      for (i in 0...args.length)
+      {
+        var a = args[i];
+        var at = a.t == null ? makeMono() : makeType(a.t, pos);
+        {name: a.name, opt: a.opt, t: at};
+      }
+    ];
+  }
+
+  public function check(expr:Expr, ?withType:WithType, ?isCompletion = false)
+  {
+    if (withType == null) withType = NoValue;
+    locals = new Map();
+    if (types.t_string == null) types.t_string = types.getType("String");
+    allowDefine = allowGlobalsDefine;
+    this.isCompletion = isCompletion;
+    if (edef(expr).match(EFunction(_))) expr = mk(EBlock([expr]), expr); // single function might be self recursive
+    switch (edef(expr))
+    {
+      case EBlock(el):
+        var delayed = [];
+        var last = TVoid;
+        for (e in el)
+        {
+          while (true)
+          {
+            switch (edef(e))
+            {
+              case EMeta(_, _, e2): e = e2;
+              default: break;
+            }
+          }
+          switch (edef(e))
+          {
+            case EFunction(args, _, name, ret) if (name != null):
+              var tret = ret == null ? makeMono() : makeType(ret, e);
+              var ft = TFun(typeArgs(args, e), tret);
+              locals.set(name, ft);
+              delayed.push(function() {
+                currentFunType = ft;
+                typeExpr(e, NoValue);
+                return ft;
+              });
+            default:
+              for (f in delayed)
+                f();
+              delayed = [];
+              if (el[el.length - 1] == e) last = typeExpr(e, withType); else typeExpr(e, NoValue);
+          }
+        }
+        for (f in delayed)
+          last = f();
+        return last;
+      default:
+    }
+    return typeExpr(expr, withType);
+  }
+
+  inline function edef(e:Expr)
+  {
+    #if hscriptPos
+    return e.e;
+    #else
+    return e;
+    #end
+  }
+
+  inline function error(msg:String, curExpr:Expr)
+  {
+    var e = ECustom(msg);
+    #if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
+    if (!isCompletion) throw e;
+  }
+
+  function saveLocals()
+  {
+    return [for (k in locals.keys()) k => locals.get(k)];
+  }
+
+  function makeType(t:CType, e:Expr):TType
+  {
+    return switch (t)
+    {
+      case CTPath(path, params):
+        var ct = types.resolve(path.join("."), params == null ? [] : [for (p in params) makeType(p, e)]);
+        if (ct == null)
+        {
+          error("Unknown type " + path, e);
+          ct = TDynamic;
+        }
+        return ct;
+      case CTFun(args, ret):
+        var i = 0;
+        return TFun([for (a in args) {name: "p" + (i++), opt: false, t: makeType(a, e)}], makeType(ret, e));
+      case CTAnon(fields):
+        return TAnon([for (f in fields) {name: f.name, opt: false, t: makeType(f.t, e)}]);
+      case CTParent(t):
+        return makeType(t, e);
+      case CTNamed(n, t):
+        return makeType(t, e);
+      case CTOpt(t):
+        return makeType(t, e);
+      case CTExpr(_):
+        error("Unsupported expr type parameter", e);
+        return null;
+    }
+  }
+
+  public static function typeStr(t:TType)
+  {
+    inline function makeArgs(args:Array<TType>)
+      return args.length == 0 ? "" : "<" + [for (t in args) typeStr(t)].join(",") + ">";
+    return switch (t)
+    {
+      case TMono(r): r.r == null ? "Unknown" : typeStr(r.r);
+      case TInst(c, args): c.name + makeArgs(args);
+      case TEnum(e, args): e.name + makeArgs(args);
+      case TType(t, args):
+        if (t.name == "hscript.TypeCheck") typeStr(args[1]); else t.name + makeArgs(args);
+      case TAbstract(a, args): a.name + makeArgs(args);
+      case TFun(args, ret): "(" + [
+          for (a in args) (a.opt ? "?" : "") + (a.name == "" ? "" : a.name + ":") + typeStr(a.t)
+        ].join(", ") + ") -> " + typeStr(ret);
+      case TAnon(fields): "{" + [for (f in fields) (f.opt ? "?" : "") + f.name + ":" + typeStr(f.t)].join(", ") + "}";
+      case TParam(name): name;
+      case TNull(t): "Null<" + typeStr(t) + ">";
+      case TUnresolved(name): "?" + name;
+      default: t.getName().substr(1);
+    }
+  }
+
+  public static function typeIter(t:TType, callb:TType->Void)
+  {
+    switch (t)
+    {
+      case TMono(r) if (r.r != null):
+        callb(r.r);
+      case TNull(t):
+        callb(t);
+      case TInst(_, tl), TAbstract(_, tl), TEnum(_, tl), TType(_, tl):
+        for (t in tl)
+          callb(t);
+      case TFun(args, ret):
+        for (t in args)
+          callb(t.t);
+        callb(ret);
+      case TAnon(fl):
+        for (f in fl)
+          callb(f.t);
+      case TLazy(f):
+        callb(f());
+      default:
+    }
+  }
+
+  function linkLoop(a:TType, t:TType)
+  {
+    if (t == a) return true;
+    switch (t)
+    {
+      case TMono(r):
+        if (r.r == null) return false;
+        return linkLoop(a, r.r);
+      case TEnum(_, tl), TInst(_, tl), TType(_, tl), TAbstract(_, tl):
+        for (t in tl)
+          if (linkLoop(a, t)) return true;
+        return false;
+      case TFun(args, ret):
+        for (arg in args)
+          if (linkLoop(a, arg.t)) return true;
+        return linkLoop(a, ret);
+      case TDynamic:
+        if (t == TDynamic) return false;
+        return linkLoop(a, TDynamic);
+      case TAnon(fl):
+        for (f in fl)
+          if (linkLoop(a, f.t)) return true;
+        return false;
+      default:
+        return false;
+    }
+  }
+
+  function link(a:TType, b:TType, r:{r:TType})
+  {
+    if (linkLoop(a, b)) return follow(b) == a;
+    if (b == TDynamic) return true;
+    r.r = b;
+    return true;
+  }
+
+  function typeEq(t1:TType, t2:TType)
+  {
+    if (t1 == t2) return true;
+    switch ([t1, t2])
+    {
+      case [TMono(r), _]:
+        if (r.r == null)
+        {
+          if (!link(t1, t2, r)) return false;
+          r.r = t2;
+          return true;
+        }
+        return typeEq(r.r, t2);
+      case [_, TMono(r)]:
+        if (r.r == null)
+        {
+          if (!link(t2, t1, r)) return false;
+          r.r = t1;
+          return true;
+        }
+        return typeEq(t1, r.r);
+      case [TType(t1, pl1), TType(t2, pl2)] if (t1 == t2):
+        for (i in 0...pl1.length)
+          if (!typeEq(pl1[i], pl2[i])) return false;
+        return true;
+      case [TType(t1, pl1), _]:
+        return typeEq(apply(t1.t, t1.params, pl1), t2);
+      case [_, TType(t2, pl2)]:
+        return typeEq(t1, apply(t2.t, t2.params, pl2));
+      case [TInst(cl1, pl1), TInst(cl2, pl2)] if (cl1 == cl2):
+        for (i in 0...pl1.length)
+          if (!typeEq(pl1[i], pl2[i])) return false;
+        return true;
+      case [TEnum(e1, pl1), TEnum(e2, pl2)] if (e1 == e2):
+        for (i in 0...pl1.length)
+          if (!typeEq(pl1[i], pl2[i])) return false;
+        return true;
+      case [TAbstract(a1, pl1), TAbstract(a2, pl2)] if (a1 == a2):
+        for (i in 0...pl1.length)
+          if (!typeEq(pl1[i], pl2[i])) return false;
+        return true;
+      case [TNull(t1), TNull(t2)]:
+        return typeEq(t1, t2);
+      case [TNull(t1), _]:
+        return typeEq(t1, t2);
+      case [_, TNull(t2)]:
+        return typeEq(t1, t2);
+      case [TFun(args1, r1), TFun(args2, r2)] if (args1.length == args2.length):
+        for (i in 0...args1.length)
+          if (!typeEq(args1[i].t, args2[i].t)) return false;
+        return typeEq(r1, r2);
+      case [TAnon(a1), TAnon(a2)] if (a1.length == a2.length):
+        var m = new Map();
+        for (f in a2)
+          m.set(f.name, f);
+        for (f1 in a1)
+        {
+          var f2 = m.get(f1.name);
+          if (f2 == null) return false;
+          if (!typeEq(f1.t, f2.t)) return false;
+        }
+        return true;
+      default:
+    }
+    return false;
+  }
+
+  public function tryUnify(t1:TType, t2:TType)
+  {
+    if (t1 == t2) return true;
+    switch ([t1, t2])
+    {
+      case [TMono(r), _]:
+        if (r.r == null)
+        {
+          if (!link(t1, t2, r)) return false;
+          r.r = t2;
+          return true;
+        }
+        return tryUnify(r.r, t2);
+      case [_, TMono(r)]:
+        if (r.r == null)
+        {
+          if (!link(t2, t1, r)) return false;
+          r.r = t1;
+          return true;
+        }
+        return tryUnify(t1, r.r);
+      case [TType(t1, pl1), _]:
+        return tryUnify(apply(t1.t, t1.params, pl1), t2);
+      case [_, TType(t2, pl2)]:
+        return tryUnify(t1, apply(t2.t, t2.params, pl2));
+      case [TNull(t1), _]:
+        return tryUnify(t1, t2);
+      case [_, TNull(t2)]:
+        return tryUnify(t1, t2);
+      case [TFun(args1, r1), TFun(args2, r2)] if (args1.length == args2.length):
+        for (i in 0...args1.length)
+        {
+          var a1 = args1[i];
+          var a2 = args2[i];
+          if (a2.opt && !a1.opt) return false;
+          if (!tryUnify(a2.t, a1.t)) return false;
+        }
+        return tryUnify(r1, r2);
+      case [_, TDynamic]:
+        return true;
+      case [TDynamic, _]:
+        return true;
+      case [TAnon(a1), TAnon(a2)]:
+        if (a2.length == 0) // always unify with {}
+          return true;
+        var m = new Map();
+        for (f in a1)
+          m.set(f.name, f);
+        for (f2 in a2)
+        {
+          var f1 = m.get(f2.name);
+          if (f1 == null)
+          {
+            if (f2.opt) continue;
+            return false;
+          }
+          if (!typeEq(f1.t, f2.t)) return false;
+        }
+        return true;
+      case [TInst(cl1, pl1), TInst(cl2, pl2)]:
+        while (cl1 != cl2)
+        {
+          if (cl1.interfaces != null)
+          {
+            for (i in cl1.interfaces)
+            {
+              switch (i)
+              {
+                case TInst(cli, args):
+                  var i = TInst(cli, [for (a in args) apply(a, cl1.params, pl1)]);
+                  if (tryUnify(i, t2)) return true;
+                default:
+                  throw "assert";
+              }
+            }
+          }
+          switch (cl1.superClass)
+          {
+            case null: return false;
+            case TInst(c, args):
+              pl1 = [for (a in args) apply(a, cl1.params, pl1)];
+              cl1 = c;
+            default: throw "assert";
+          }
+        }
+        for (i in 0...pl1.length)
+          if (!typeEq(pl1[i], pl2[i])) return false;
+        return true;
+      case [TInst(cl1, pl1), TAnon(fl)]:
+        for (i in 0...fl.length)
+        {
+          var f2 = fl[i];
+          var f1 = null;
+          var cl = cl1;
+          while (true)
+          {
+            f1 = cl.fields.get(f2.name);
+            if (f1 != null) break;
+            if (cl.superClass == null) return false;
+            cl = switch (cl.superClass)
+            {
+              case TInst(c, _): c;
+              default: throw "assert";
+            }
+          }
+          if (!typeEq(apply(f1.t, cl1.params, pl1), f2.t)) return false;
+        }
+        return true;
+      case [TInt, TFloat]:
+        return true;
+      case [TFun(_), TAbstract({name: "haxe.Function"}, _)]:
+        return true;
+      case [_, TAbstract(a, args)]:
+        for (ft in a.from)
+        {
+          var t = apply(ft, a.params, args);
+          if (tryUnify(t1, t)) return true;
+        }
+      case [TAbstract(a, args), _]:
+        for (tt in a.to)
+        {
+          var t = apply(tt, a.params, args);
+          if (tryUnify(t, t2)) return true;
+        }
+      default:
+    }
+    return typeEq(t1, t2);
+  }
+
+  public function unify(t1:TType, t2:TType, e:Expr)
+  {
+    if (!tryUnify(t1, t2)) error(typeStr(t1) + " should be " + typeStr(t2), e);
+  }
+
+  public function apply(t:TType, params:Array<TType>, args:Array<TType>)
+  {
+    if (args.length != params.length) throw "Invalid number of type parameters";
+    if (args.length == 0) return t;
+    var subst = new Map();
+    for (i in 0...params.length)
+      subst.set(params[i], args[i]);
+    function map(t:TType)
+    {
+      var st = subst.get(t);
+      if (st != null) return st;
+      return mapType(t, map);
+    }
+    return map(t);
+  }
+
+  public function mapType(t:TType, f:TType->TType)
+  {
+    switch (t)
+    {
+      case TMono(r):
+        if (r.r == null) return t;
+        return f(t);
+      case TVoid, TInt, TFloat, TBool, TDynamic, TParam(_), TUnresolved(_):
+        return t;
+      case TEnum(_, []), TInst(_, []), TAbstract(_, []), TType(_, []):
+        return t;
+      case TNull(t):
+        return TNull(f(t));
+      case TInst(c, args):
+        return TInst(c, [for (t in args) f(t)]);
+      case TEnum(e, args):
+        return TEnum(e, [for (t in args) f(t)]);
+      case TType(t, args):
+        return TType(t, [for (t in args) f(t)]);
+      case TAbstract(a, args):
+        return TAbstract(a, [for (t in args) f(t)]);
+      case TFun(args, ret):
+        return TFun([for (a in args) {name: a.name, opt: a.opt, t: f(a.t)}], f(ret));
+      case TAnon(fields):
+        return TAnon([for (af in fields) {name: af.name, opt: af.opt, t: f(af.t)}]);
+      case TLazy(l):
+        return f(l());
+    }
+  }
+
+  public function follow(t:TType)
+  {
+    return switch (t)
+    {
+      case TMono(r): if (r.r != null) follow(r.r) else t;
+      case TType(t, args): follow(apply(t.t, t.params, args));
+      case TNull(t): follow(t);
+      case TLazy(f): follow(f());
+      default: t;
+    }
+  }
+
+  public function getFields(t:TType):Array<{name:String, t:TType}>
+  {
+    var fields = [];
+    switch (follow(t))
+    {
+      case TInst(c, args):
+        var map = (t) -> apply(t, c.params, args);
+        while (c != null)
+        {
+          for (fname in c.fields.keys())
+          {
+            var f = c.fields.get(fname);
+            if (!f.isPublic || !f.complete) continue;
+            var name = f.name, t = map(f.t);
+            if (allowAsync && StringTools.startsWith(name, "a_"))
+            {
+              t = unasync(t);
+              name = name.substr(2);
+            }
+            fields.push({name: name, t: t});
+          }
+          if (c.isInterface && c.interfaces != null)
+          {
+            for (i in c.interfaces)
+            {
+              for (f in getFields(i))
+                fields.push({name: f.name, t: map(f.t)});
+            }
+          }
+          if (c.superClass == null) break;
+          switch (c.superClass)
+          {
+            case TInst(csup, args):
+              var curMap = map;
+              map = (t) -> curMap(apply(t, csup.params, args));
+              c = csup;
+            default:
+              break;
+          }
+        }
+      case TAnon(fl):
+        for (f in fl)
+          fields.push({name: f.name, t: f.t});
+      case TFun(args, ret):
+        if (isCompletion) fields.push({name: "bind", t: TFun(args, TVoid)});
+      default:
+    }
+    return fields;
+  }
+
+  function getField(t:TType, f:String, e:Expr, forWrite = false)
+  {
+    switch (follow(t))
+    {
+      case TInst(c, args):
+        var cf = c.fields.get(f);
+        if (cf == null && allowAsync)
+        {
+          cf = c.fields.get("a_" + f);
+          if (cf != null)
+          {
+            var isPublic = true; // consider a_ prefixed as script specific
+            cf =
+              {
+                isPublic: isPublic,
+                canWrite: false,
+                params: cf.params,
+                name: cf.name,
+                t: unasync(cf.t),
+                complete: cf.complete
+              };
+            if (cf.t == null) cf = null;
+          }
+        }
+        if (cf == null && c.isInterface && c.interfaces != null)
+        {
+          for (i in c.interfaces)
+          {
+            var ft = getField(i, f, e, forWrite);
+            if (ft != null) return apply(ft, c.params, args);
+          }
+        }
+        if (cf == null)
+        {
+          if (c.superClass == null) return null;
+          var ft = getField(c.superClass, f, e, forWrite);
+          if (ft != null) ft = apply(ft, c.params, args);
+          return ft;
+        }
+        if (!cf.isPublic) error("Can't access private field " + f + " on " + c.name, e);
+        if (forWrite && !cf.canWrite) error("Can't write readonly field " + f + " on " + c.name, e);
+        var t = cf.t;
+        if (cf.params != null) t = apply(t, cf.params, [for (i in 0...cf.params.length) makeMono()]);
+        return apply(t, c.params, args);
+      case TDynamic:
+        return makeMono();
+      case TAnon(fields):
+        for (af in fields)
+          if (af.name == f) return af.t;
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  public function unasync(t:TType):TType
+  {
+    switch (follow(t))
+    {
+      case TFun(args, ret) if (args.length > 0):
+        var rargs = args.copy();
+        switch (follow(rargs.shift().t))
+        {
+          case TFun([r], _): return TFun(rargs, r.t);
+          default:
+        }
+      default:
+    }
+    return null;
+  }
+
+  function typeExprWith(expr:Expr, t:TType)
+  {
+    var et = typeExpr(expr, WithType(t));
+    unify(et, t, expr);
+    return t;
+  }
+
+  function makeMono()
+  {
+    return TMono({r: null});
+  }
+
+  function makeIterator(t):TType
+  {
+    return TAnon([
+      {name: "next", opt: false, t: TFun([], t)},
+      {name: "hasNext", opt: false, t: TFun([], TBool)}
+    ]);
+  }
+
+  function mk(e, p):Expr
+  {
+    #if hscriptPos
+    return {
+      e: e,
+      pmin: p.pmin,
+      pmax: p.pmax,
+      origin: p.origin,
+      line: p.line
+    };
+    #else
+    return e;
+    #end
+  }
+
+  function isString(t:TType)
+  {
+    t = follow(t);
+    return t.match(TInst({name: "String"}, _));
+  }
+
+  function onCompletion(expr:Expr, t:TType)
+  {
+    if (isCompletion) throw new Completion(expr, t);
+  }
+
+  function typeField(o:Expr, f:String, expr:Expr, forWrite:Bool)
+  {
+    var ot = typeExpr(o, Value);
+    if (f == null) onCompletion(expr, ot);
+    var ft = getField(ot, f, expr, forWrite);
+    if (ft == null)
+    {
+      error(typeStr(ot) + " has no field " + f, expr);
+      ft = TDynamic;
+    }
+    return ft;
+  }
+
+  function typeExpr(expr:Expr, withType:WithType):TType
+  {
+    if (expr == null && isCompletion) return switch (withType)
+    {
+      case WithType(t): t;
+      default: TDynamic;
+    }
+    switch (edef(expr))
+    {
+      case EConst(c):
+        return switch (c)
+        {
+          case CInt(_): TInt;
+          case CFloat(_): TFloat;
+          case CString(_): types.t_string;
+        }
+      case EIdent(v):
+        var l = locals.get(v);
+        if (l != null) return l;
+        var g = globals.get(v);
+        if (g != null)
+        {
+          return switch (g)
+          {
+            case TLazy(f): f();
+            default: g;
+          }
+        }
+        if (allowAsync)
+        {
+          g = globals.get("a_" + v);
+          if (g != null) g = unasync(g);
+          if (g != null) return g;
+        }
+        switch (v)
+        {
+          case "null":
+            return makeMono();
+          case "true", "false":
+            return TBool;
+          case "trace":
+            return TDynamic;
+          default:
+            switch (withType)
+            {
+              case WithType(et = TEnum(e, args)):
+                for (c in e.constructors)
+                  if (c.name == v)
+                  {
+                    if (onTopDownEnum(e, v))
+                    {
+                      var ct = c.args == null ? et : TFun(c.args, et);
+                      return apply(ct, e.params, args);
+                    }
+                    break;
+                  }
+              default:
+            }
+            if (isCompletion) return TDynamic;
+            error("Unknown identifier " + v, expr);
+        }
+      case EBlock(el):
+        var t = TVoid;
+        var locals = saveLocals();
+        for (e in el)
+          t = typeExpr(e, e == el[el.length - 1] ? withType : NoValue);
+        this.locals = locals;
+        return t;
+      case EVar(n, t, init):
+        var vt = t == null ? makeMono() : makeType(t, expr);
+        if (init != null)
+        {
+          var et = typeExpr(init, t == null ? Value : WithType(vt));
+          if (t == null) vt = et
+          else
+            unify(et, vt, init);
+        }
+        locals.set(n, vt);
+        return TVoid;
+      case EParent(e):
+        return typeExpr(e, withType);
+      case ECall(e, params):
+        switch (edef(e))
+        {
+          case EField(val, "bind"):
+            var ft = typeExpr(val, Value);
+            switch (ft)
+            {
+              case TFun(args, ret):
+                var remainArgs = args.copy();
+                for (p in params)
+                {
+                  var a = remainArgs.shift();
+                  if (a == null)
+                  {
+                    error("Too many arguments", p);
+                    return TFun([], ret);
+                  }
+                  typeExprWith(p, a.t);
+                }
+                return TFun(remainArgs, ret);
+              default:
+            }
+          default:
+        }
+        var ft = typeExpr(e, switch ([edef(e), withType])
+        {
+          case [EIdent(_), WithType(TEnum(_))]: withType;
+          default: Value;
+        });
+        switch (follow(ft))
+        {
+          case TFun(args, ret):
+            for (i in 0...params.length)
+            {
+              var a = args[i];
+              if (a == null)
+              {
+                error("Too many arguments", params[i]);
+                break;
+              }
+              var t = typeExpr(params[i], a == null ? Value : WithType(a.t));
+              unify(t, a.t, params[i]);
+            }
+            for (i in params.length...args.length)
+              if (!args[i].opt) error("Missing argument " + args[i].name + ":" + typeStr(args[i].t), expr);
+            return ret;
+          case TDynamic:
+            for (p in params)
+              typeExpr(p, Value);
+            return makeMono();
+          default:
+            error(typeStr(ft) + " cannot be called", e);
+            return makeMono();
+        }
+      case EField(o, f):
+        return typeField(o, f, expr, false);
+      case ECheckType(v, t):
+        var ct = makeType(t, expr);
+        var vt = typeExpr(v, WithType(ct));
+        unify(vt, ct, v);
+        return ct;
+      case EMeta(m, _, e):
+        if (m == ":untyped" && allowUntypedMeta) return makeMono();
+        return typeExpr(e, withType);
+      case EIf(cond, e1, e2), ETernary(cond, e1, e2):
+        typeExprWith(cond, TBool);
+        var t1 = typeExpr(e1, withType);
+        if (e2 == null) return t1;
+        var t2 = typeExpr(e2, withType);
+        if (withType == NoValue) return TVoid;
+        if (tryUnify(t2, t1)) return t1;
+        if (tryUnify(t1, t2)) return t2;
+        unify(t2, t1, e2); // error
+      case EWhile(cond, e), EDoWhile(cond, e):
+        typeExprWith(cond, TBool);
+        typeExpr(e, NoValue);
+        return TVoid;
+      case EObject(fl):
+        switch (withType)
+        {
+          case WithType(follow(_) => TAnon(tfields)) if (tfields.length > 0):
+            var map = [for (f in tfields) f.name => f];
+            return TAnon([
+              for (f in fl)
+              {
+                var ft = map.get(f.name);
+                var ft = if (ft == null)
+                {
+                  error("Extra field " + f.name, f.e);
+                  TDynamic;
+                }
+                else ft.t;
+                {t: typeExprWith(f.e, ft), opt: false, name: f.name}
+              }
+            ]);
+          default:
+            return TAnon([for (f in fl) {t: typeExpr(f.e, Value), opt: false, name: f.name}]);
+        }
+      case EBreak, EContinue:
+        return TVoid;
+      case EReturn(v):
+        var et = v == null ? TVoid : typeExpr(v, allowReturn == null ? Value : WithType(allowReturn));
+        hasReturn = true;
+        if (allowReturn == null) error("Return not allowed here", expr);
+        else
+          unify(et, allowReturn, v == null ? expr : v);
+        return makeMono();
+      case EArrayDecl(el):
+        var et = null;
+        for (v in el)
+        {
+          var t = typeExpr(v, et == null ? Value : WithType(et));
+          if (et == null) et = t
+          else if (!tryUnify(t, et))
+          {
+            if (tryUnify(et, t)) et = t
+            else
+              unify(t, et, v);
+          }
+        }
+        if (et == null) et = makeMono();
+        return types.getType("Array", [et]);
+      case EArray(a, index):
+        typeExprWith(index, TInt);
+        var at = typeExpr(a, Value);
+        switch (follow(at))
+        {
+          case TInst({name: "Array"}, [et]): return et;
+          default: error(typeStr(at) + " is not an Array", a);
+        }
+      case EThrow(e):
+        typeExpr(e, Value);
+        return makeMono();
+      case EFunction(args, body, name, ret):
+        var ft = null, tret = null, targs = null;
+        if (currentFunType != null)
+        {
+          switch (currentFunType)
+          {
+            case TFun(args, ret):
+              ft = currentFunType;
+              tret = ret;
+              targs = args;
+            default:
+              throw "assert";
+          }
+          currentFunType = null;
+        }
+        else
+        {
+          tret = ret == null ? makeMono() : makeType(ret, expr);
+        }
+        var locals = saveLocals();
+        var oldRet = allowReturn;
+        var oldGDef = allowDefine;
+        var oldHasRet = hasReturn;
+        allowReturn = tret;
+        allowDefine = false;
+        hasReturn = false;
+        var withArgs = null;
+        if (name != null && !withType.match(WithType(follow(_) => TFun(_))))
+        {
+          var ev = events.get(name);
+          if (ev != null) withType = WithType(ev);
+        }
+        switch (withType)
+        {
+          case WithType(follow(_) => TFun(args, ret)):
+            withArgs = args;
+            unify(tret, ret, expr);
+          default:
+        }
+        if (targs == null) targs = typeArgs(args, expr);
+        for (i in 0...targs.length)
+        {
+          var a = targs[i];
+          if (withArgs != null)
+          {
+            if (i < withArgs.length) unify(withArgs[i].t, a.t, expr);
+            else
+              error("Extra argument " + a.name, expr);
+          }
+          this.locals.set(a.name, a.t);
+        }
+        if (withArgs != null && targs.length < withArgs.length) error("Missing "
+          + (withArgs.length - targs.length)
+          + " arguments ("
+          + [for (i in targs.length...withArgs.length) typeStr(withArgs[i].t)].join(",") + ")",
+          expr);
+        typeExpr(body, NoValue);
+        if (!hasReturn && !tryUnify(tret, TVoid)) error("Missing return " + typeStr(tret), expr);
+        allowDefine = oldGDef;
+        allowReturn = oldRet;
+        hasReturn = oldHasRet;
+        this.locals = locals;
+        if (ft == null)
+        {
+          ft = TFun(targs, tret);
+          if (name != null) locals.set(name, ft);
+        }
+        return ft;
+      case EUnop(op, _, e):
+        var et = typeExpr(e, Value);
+        switch (op)
+        {
+          case "++", "--", "-":
+            unify(et, TInt, e);
+            return et;
+          case "!":
+            unify(et, TBool, e);
+            return et;
+          default:
+        }
+      case EFor(v, it, e):
+        var locals = saveLocals();
+        var itt = typeExpr(it, Value);
+        var vt = getIteratorType(itt, it);
+        this.locals.set(v, vt);
+        typeExpr(e, NoValue);
+        this.locals = locals;
+        return TVoid;
+      case EForGen(it, e):
+        Tools.getKeyIterator(it, function(vk, vv, it) {
+          if (vk == null)
+          {
+            error("Invalid for expression", it);
+            return;
+          }
+          var locals = saveLocals();
+          var itt = typeExpr(it, Value);
+          var types = getKeyIteratorTypes(itt, it);
+          this.locals.set(vk, types.key);
+          this.locals.set(vv, types.value);
+          typeExpr(e, NoValue);
+          this.locals = locals;
+        });
+        return TVoid;
+      case EBinop(op, e1, e2):
+        switch (op)
+        {
+          case "&", "|", "^", ">>", ">>>", "<<":
+            typeExprWith(e1, TInt);
+            typeExprWith(e2, TInt);
+            return TInt;
+          case "=":
+            if (allowDefine)
+            {
+              switch (edef(e1))
+              {
+                case EIdent(i) if (!locals.exists(i) && !globals.exists(i)):
+                  var vt = typeExpr(e2, Value);
+                  locals.set(i, vt);
+                  return vt;
+                default:
+              }
+            }
+            var vt = switch (edef(e1))
+            {
+              case EField(o, f): typeField(o, f, e1, true);
+              default: typeExpr(e1, Value);
+            }
+            typeExprWith(e2, vt);
+            return vt;
+          case "+":
+            var t1 = typeExpr(e1, WithType(TInt));
+            var t2 = typeExpr(e2, WithType(t1));
+            tryUnify(t1, t2);
+            switch ([follow(t1), follow(t2)])
+            {
+              case [TInt, TInt]:
+                return TInt;
+              case [TFloat, TInt], [TInt, TFloat], [TFloat, TFloat]:
+                return TFloat;
+              case [TDynamic, _], [_, TDynamic]:
+                return TDynamic;
+              case [t1, t2]:
+                if (isString(t1) || isString(t2)) return types.t_string;
+                unify(t1, TFloat, e1);
+                unify(t2, TFloat, e2);
+            }
+          case "-", "*", "/", "%":
+            var t1 = typeExpr(e1, WithType(TInt));
+            var t2 = typeExpr(e2, WithType(t1));
+            if (!tryUnify(t1, t2)) unify(t2, t1, e2);
+            switch ([follow(t1), follow(t2)])
+            {
+              case [TInt, TInt]:
+                if (op == "/") return TFloat;
+                return TInt;
+              case [TFloat | TDynamic, TInt | TDynamic], [TInt | TDynamic, TFloat | TDynamic], [TFloat, TFloat]:
+                return TFloat;
+              default:
+                unify(t1, TFloat, e1);
+                unify(t2, TFloat, e2);
+            }
+          case "&&", "||":
+            typeExprWith(e1, TBool);
+            typeExprWith(e2, TBool);
+            return TBool;
+          case "...":
+            typeExprWith(e1, TInt);
+            typeExprWith(e2, TInt);
+            return makeIterator(TInt);
+          case "==", "!=":
+            var t1 = typeExpr(e1, Value);
+            var t2 = typeExpr(e2, WithType(t1));
+            if (!tryUnify(t1, t2)) unify(t2, t1, e2);
+            return TBool;
+          case ">", "<", ">=", "<=":
+            var t1 = typeExpr(e1, Value);
+            var t2 = typeExpr(e2, WithType(t1));
+            if (!tryUnify(t1, t2)) unify(t2, t1, e2);
+            switch (follow(t1))
+            {
+              case TInt, TFloat, TBool, TInst({name: "String"}, _):
+              default:
+                error("Cannot compare " + typeStr(t1), expr);
+            }
+            return TBool;
+          default:
+            if (op.charCodeAt(op.length - 1) == "=".code)
+            {
+              var t = typeExpr(mk(EBinop(op.substr(0, op.length - 1), e1, e2), expr), withType);
+              return typeExpr(mk(EBinop("=", e1, e2), expr), withType);
+            }
+            error("Unsupported operation " + op, expr);
+        }
+      case ETry(etry, v, et, ecatch):
+        var vt = typeExpr(etry, withType);
+
+        var old = locals.get(v);
+        locals.set(v, makeType(et, ecatch));
+        var ct = typeExpr(ecatch, withType);
+        if (old != null) locals.set(v, old)
+        else
+          locals.remove(v);
+
+        if (withType == NoValue) return TVoid;
+        if (tryUnify(vt, ct)) return ct;
+        unify(ct, vt, ecatch);
+        return vt;
+      case ESwitch(value, cases, defaultExpr):
+        var tmin = null;
+        var vt = typeExpr(value, Value);
+        inline function mergeType(t, p)
+        {
+          if (withType != NoValue)
+          {
+            if (tmin == null) tmin = t;
+            else if (!tryUnify(t, tmin))
+            {
+              unify(tmin, t, p);
+              tmin = t;
+            }
+          }
+        }
+        for (c in cases)
+        {
+          for (v in c.values)
+          {
+            var ct = typeExpr(v, WithType(vt));
+            unify(ct, vt, v);
+          }
+          var et = typeExpr(c.expr, withType);
+          mergeType(et, c.expr);
+        }
+        if (defaultExpr != null) mergeType(typeExpr(defaultExpr, withType), defaultExpr);
+        return withType == NoValue ? TVoid : tmin == null ? makeMono() : tmin;
+      case ENew(cl, params):
+    }
+    error("Don't know how to type " + edef(expr).getName(), expr);
+    return TDynamic;
+  }
+
+  function getIteratorType(itt:TType, it:Expr)
+  {
+    switch (follow(itt))
+    {
+      case TInst({name: "Array"}, [t]):
+        return t;
+      default:
+    }
+    var ft = getField(itt, "iterator", it);
+    if (ft == null) switch (itt)
+    {
+      case TAbstract(a, args):
+        // special case : we allow unconditional access
+        // to an abstract iterator() underlying value (eg: ArrayProxy)
+        var at = apply(a.t, a.params, args);
+        return getIteratorType(at, it);
+      default:
+    }
+    if (ft != null) switch (ft)
+    {
+      case TFun([], ret):
+        ft = ret;
+      default:
+        ft = null;
+    }
+    var t = makeMono();
+    var iter = makeIterator(t);
+    unify(ft != null ? ft : itt, iter, it);
+    return t;
+  }
+
+  function getKeyIteratorTypes(itt:TType, it:Expr)
+  {
+    switch (follow(itt))
+    {
+      case TInst({name: "Array"}, [t]):
+        return {key: TInt, value: t};
+      default:
+    }
+    var ft = getField(itt, "keyValueIterator", it);
+    if (ft == null) switch (itt)
+    {
+      case TAbstract(a, args):
+        // special case : we allow unconditional access
+        // to an abstract keyValueIterator() underlying value (eg: ArrayProxy)
+        var at = apply(a.t, a.params, args);
+        return getKeyIteratorTypes(at, it);
+      default:
+    }
+    if (ft != null) switch (ft)
+    {
+      case TFun([], ret):
+        ft = ret;
+      default:
+        ft = null;
+    }
+    var key = makeMono();
+    var value = makeMono();
+    var iter = makeIterator(TAnon([
+      {name: "key", t: key, opt: false}, {name: "value", t: value, opt: false}]));
+    unify(ft != null ? ft : itt, iter, it);
+    return {key: key, value: value};
+  }
+}

--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package polymod.hscript._internal;
+
+enum Const
+{
+  CInt(v:Int);
+  CFloat(f:Float);
+  CString(s:String);
+}
+
+#if hscriptPos
+typedef Expr =
+{
+  var e:ExprDef;
+  var pmin:Int;
+  var pmax:Int;
+  var origin:String;
+  var line:Int;
+}
+
+enum ExprDef
+{
+#else
+typedef ExprDef = Expr;
+
+enum Expr
+{
+#end
+
+EConst(c:Const);
+EIdent(v:String);
+EVar(n:String, ?t:CType, ?e:Expr);
+EFinal(n:String, ?t:CType, ?e:Expr);
+EParent(e:Expr);
+EBlock(e:Array<Expr>);
+EField(e:Expr, f:String);
+EBinop(op:String, e1:Expr, e2:Expr);
+EUnop(op:String, prefix:Bool, e:Expr);
+ECall(e:Expr, params:Array<Expr>);
+EIf(cond:Expr, e1:Expr, ?e2:Expr);
+EWhile(cond:Expr, e:Expr);
+EFor(v:String, it:Expr, e:Expr);
+EBreak;
+EContinue;
+EFunction(args:Array<Argument>, e:Expr, ?name:String, ?ret:CType);
+EReturn(?e:Expr);
+EArray(e:Expr, index:Expr);
+EArrayDecl(e:Array<Expr>);
+ENew(cl:String, params:Array<Expr>);
+EThrow(e:Expr);
+ETry(e:Expr, v:String, t:Null<CType>, ecatch:Expr);
+EObject(fl:Array<{name:String, e:Expr}>);
+ETernary(cond:Expr, e1:Expr, e2:Expr);
+ESwitch(e:Expr, cases:Array<{values:Array<Expr>, expr:Expr}>, ?defaultExpr:Expr);
+EDoWhile(cond:Expr, e:Expr);
+EMeta(name:String, args:Array<Expr>, e:Expr);
+ECheckType(e:Expr, t:CType);
+EForGen(it:Expr, e:Expr);
+} typedef Argument =
+{
+  name:String,
+  ?t:CType,
+  ?opt:Bool,
+  ?value:Expr
+};
+
+typedef Metadata = Array<{name:String, params:Array<Expr>}>;
+
+enum CType
+{
+  CTPath(path:Array<String>, ?params:Array<CType>);
+  CTFun(args:Array<CType>, ret:CType);
+  CTAnon(fields:Array<{name:String, t:CType, ?meta:Metadata}>);
+  CTParent(t:CType);
+  CTOpt(t:CType);
+  CTNamed(n:String, t:CType);
+  CTExpr(e:Expr); // for type parameters only
+}
+
+#if hscriptPos
+class Error
+{
+  public var e:ErrorDef;
+  public var pmin:Int;
+  public var pmax:Int;
+  public var origin:String;
+  public var line:Int;
+
+  public function new(e, pmin, pmax, origin, line)
+  {
+    this.e = e;
+    this.pmin = pmin;
+    this.pmax = pmax;
+    this.origin = origin;
+    this.line = line;
+  }
+
+  public function toString():String
+  {
+    return Printer.errorToString(this);
+  }
+}
+
+enum ErrorDef
+{
+#else
+enum Error
+{
+#end
+
+EInvalidChar(c:Int);
+EUnexpected(s:String);
+EUnterminatedString;
+EUnterminatedComment;
+EInvalidPreprocessor(msg:String);
+EUnknownVariable(v:String);
+EInvalidIterator(v:String);
+EInvalidOp(op:String);
+EInvalidAccess(f:String);
+ECustom(msg:String);
+} enum ModuleDecl
+{
+  DPackage(path:Array<String>);
+  DImport(path:Array<String>, ?everything:Bool, ?name:String);
+  DUsing(path:Array<String>);
+  DClass(c:ClassDecl);
+  DTypedef(c:TypeDecl);
+  DEnum(e:EnumDecl);
+}
+
+typedef ModuleType =
+{
+  var name:String;
+  var params:{}; // TODO : not yet parsed
+  var meta:Metadata;
+  var isPrivate:Bool;
+}
+
+typedef ClassDecl =
+{
+  > ModuleType,
+  var extend:Null<CType>;
+  var implement:Array<CType>;
+  var fields:Array<FieldDecl>;
+  var isExtern:Bool;
+}
+
+typedef EnumDecl =
+{
+  var name:String;
+  var fields:Array<EnumFieldDecl>;
+}
+
+typedef EnumFieldDecl =
+{
+  var name:String;
+  var args:Array<EnumArgDecl>;
+}
+
+typedef EnumArgDecl =
+{
+  var name:String;
+  var type:Null<CType>;
+}
+
+typedef TypeDecl =
+{
+  > ModuleType,
+  var t:CType;
+}
+
+typedef FieldDecl =
+{
+  var name:String;
+  var meta:Metadata;
+  var kind:FieldKind;
+  var access:Array<FieldAccess>;
+}
+
+enum FieldAccess
+{
+  APublic;
+  APrivate;
+  AInline;
+  AOverride;
+  AStatic;
+  AMacro;
+}
+
+enum FieldKind
+{
+  KFunction(f:FunctionDecl);
+  KVar(v:VarDecl);
+}
+
+typedef FunctionDecl =
+{
+  var args:Array<Argument>;
+  var expr:Expr;
+  var ret:Null<CType>;
+}
+
+typedef VarDecl =
+{
+  var get:Null<String>;
+  var set:Null<String>;
+  var expr:Null<Expr>;
+  var type:Null<CType>;
+  var isfinal:Null<Bool>;
+}

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -1,0 +1,871 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package polymod.hscript._internal;
+
+import haxe.PosInfos;
+import polymod.hscript._internal.Expr;
+import haxe.Constraints.IMap;
+
+private enum Stop
+{
+  SBreak;
+  SContinue;
+  SReturn;
+}
+
+class Interp
+{
+  public var variables:Map<String, Dynamic>;
+
+  var locals:Map<String, {r:Dynamic, ?isfinal:Bool}>;
+  var binops:Map<String, Expr->Expr->Dynamic>;
+
+  var depth:Int;
+  var inTry:Bool;
+  var declared:Array<{n:String, old:{r:Dynamic, ?isfinal:Bool}}>;
+  var returnValue:Dynamic;
+
+  #if hscriptPos
+  var curExpr:Expr;
+  #end
+
+  public function new()
+  {
+    locals = new Map();
+    declared = new Array();
+    resetVariables();
+    initOps();
+  }
+
+  private function resetVariables()
+  {
+    variables = new Map<String, Dynamic>();
+    variables.set("null", null);
+    variables.set("true", true);
+    variables.set("false", false);
+    variables.set("trace", Reflect.makeVarArgs(function(el) {
+      var inf = posInfos();
+      var v = el.shift();
+      if (el.length > 0) inf.customParams = el;
+      haxe.Log.trace(Std.string(v), inf);
+    }));
+  }
+
+  public function posInfos():PosInfos
+  {
+    #if hscriptPos
+    if (curExpr != null) return cast {fileName: curExpr.origin, lineNumber: curExpr.line};
+    #end
+    return cast {fileName: "hscript", lineNumber: 0};
+  }
+
+  function initOps()
+  {
+    var me = this;
+    binops = new Map();
+    binops.set("+", function(e1, e2) return me.expr(e1) + me.expr(e2));
+    binops.set("-", function(e1, e2) return me.expr(e1) - me.expr(e2));
+    binops.set("*", function(e1, e2) return me.expr(e1) * me.expr(e2));
+    binops.set("/", function(e1, e2) return me.expr(e1) / me.expr(e2));
+    binops.set("%", function(e1, e2) return me.expr(e1) % me.expr(e2));
+    binops.set("&", function(e1, e2) return me.expr(e1) & me.expr(e2));
+    binops.set("|", function(e1, e2) return me.expr(e1) | me.expr(e2));
+    binops.set("^", function(e1, e2) return me.expr(e1) ^ me.expr(e2));
+    binops.set("<<", function(e1, e2) return me.expr(e1) << me.expr(e2));
+    binops.set(">>", function(e1, e2) return me.expr(e1) >> me.expr(e2));
+    binops.set(">>>", function(e1, e2) return me.expr(e1) >>> me.expr(e2));
+    binops.set("==", function(e1, e2) return me.expr(e1) == me.expr(e2));
+    binops.set("!=", function(e1, e2) return me.expr(e1) != me.expr(e2));
+    binops.set(">=", function(e1, e2) return me.expr(e1) >= me.expr(e2));
+    binops.set("<=", function(e1, e2) return me.expr(e1) <= me.expr(e2));
+    binops.set(">", function(e1, e2) return me.expr(e1) > me.expr(e2));
+    binops.set("<", function(e1, e2) return me.expr(e1) < me.expr(e2));
+    binops.set("||", function(e1, e2) return me.expr(e1) == true || me.expr(e2) == true);
+    binops.set("&&", function(e1, e2) return me.expr(e1) == true && me.expr(e2) == true);
+    binops.set("=", assign);
+    binops.set("...", function(e1, e2) return new IntIterator(me.expr(e1), me.expr(e2)));
+    binops.set("is", function(e1, e2) return #if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (me.expr(e1), me.expr(e2)));
+    binops.set("??", function(e1, e2) return me.expr(e1) ?? me.expr(e2));
+    assignOp("+=", function(v1:Dynamic, v2:Dynamic) return v1 + v2);
+    assignOp("-=", function(v1:Float, v2:Float) return v1 - v2);
+    assignOp("*=", function(v1:Float, v2:Float) return v1 * v2);
+    assignOp("/=", function(v1:Float, v2:Float) return v1 / v2);
+    assignOp("%=", function(v1:Float, v2:Float) return v1 % v2);
+    assignOp("&=", function(v1, v2) return v1 & v2);
+    assignOp("|=", function(v1, v2) return v1 | v2);
+    assignOp("^=", function(v1, v2) return v1 ^ v2);
+    assignOp("<<=", function(v1, v2) return v1 << v2);
+    assignOp(">>=", function(v1, v2) return v1 >> v2);
+    assignOp(">>>=", function(v1, v2) return v1 >>> v2);
+    assignOp("??" + "=", function(v1, v2) return v1 ?? v2);
+  }
+
+  function setVar(name:String, v:Dynamic)
+  {
+    variables.set(name, v);
+    return v;
+  }
+
+  function assign(e1:Expr, e2:Expr):Dynamic
+  {
+    var v = expr(e2);
+    switch (Tools.expr(e1))
+    {
+      case EIdent(id):
+        var l = locals.get(id);
+        if (l != null && l.isfinal && l.r != null) return error(EInvalidAccess(id));
+        if (l == null) setVar(id, v)
+        else
+          l.r = v;
+      case EField(e, f):
+        v = set(expr(e), f, v);
+      case EArray(e, index):
+        var arr:Dynamic = expr(e);
+        var index:Dynamic = expr(index);
+        if (isMap(arr))
+        {
+          setMapValue(arr, index, v);
+        }
+        else
+        {
+          arr[index] = v;
+        }
+
+      default:
+        error(EInvalidOp("="));
+    }
+    return v;
+  }
+
+  function assignOp(op, fop:Dynamic->Dynamic->Dynamic)
+  {
+    var me = this;
+    binops.set(op, function(e1, e2) return me.evalAssignOp(op, fop, e1, e2));
+  }
+
+  function evalAssignOp(op, fop, e1, e2):Dynamic
+  {
+    var v;
+    switch (Tools.expr(e1))
+    {
+      case EIdent(id):
+        var l = locals.get(id);
+        v = fop(expr(e1), expr(e2));
+        if (l != null && l.isfinal && l.r != null) return error(EInvalidAccess(id));
+        if (l == null) setVar(id, v)
+        else
+          l.r = v;
+      case EField(e, f):
+        var obj = expr(e);
+        v = fop(get(obj, f), expr(e2));
+        v = set(obj, f, v);
+      case EArray(e, index):
+        var arr:Dynamic = expr(e);
+        var index:Dynamic = expr(index);
+        if (isMap(arr))
+        {
+          v = fop(getMapValue(arr, index), expr(e2));
+          setMapValue(arr, index, v);
+        }
+        else
+        {
+          v = fop(arr[index], expr(e2));
+          arr[index] = v;
+        }
+      default:
+        return error(EInvalidOp(op));
+    }
+    return v;
+  }
+
+  function increment(e:Expr, prefix:Bool, delta:Int):Dynamic
+  {
+    #if hscriptPos
+    curExpr = e;
+    var e = e.e;
+    #end
+    switch (e)
+    {
+      case EIdent(id):
+        var l = locals.get(id);
+        var v:Dynamic = (l == null) ? resolve(id) : l.r;
+        if (l != null && l.isfinal && l.r != null) return error(EInvalidAccess(id));
+        if (prefix)
+        {
+          v += delta;
+          if (l == null) setVar(id, v)
+          else
+            l.r = v;
+        }
+        else if (l == null) setVar(id, v + delta)
+        else
+          l.r = v + delta;
+        return v;
+      case EField(e, f):
+        var obj = expr(e);
+        var v:Dynamic = get(obj, f);
+        if (prefix)
+        {
+          v += delta;
+          set(obj, f, v);
+        }
+        else
+          set(obj, f, v + delta);
+        return v;
+      case EArray(e, index):
+        var arr:Dynamic = expr(e);
+        var index:Dynamic = expr(index);
+        if (isMap(arr))
+        {
+          var v = getMapValue(arr, index);
+          if (prefix)
+          {
+            v += delta;
+            setMapValue(arr, index, v);
+          }
+          else
+          {
+            setMapValue(arr, index, v + delta);
+          }
+          return v;
+        }
+        else
+        {
+          var v = arr[index];
+          if (prefix)
+          {
+            v += delta;
+            arr[index] = v;
+          }
+          else
+            arr[index] = v + delta;
+          return v;
+        }
+      default:
+        return error(EInvalidOp((delta > 0) ? "++" : "--"));
+    }
+  }
+
+  public function execute(expr:Expr):Dynamic
+  {
+    depth = 0;
+    locals = new Map();
+    declared = new Array();
+    return exprReturn(expr);
+  }
+
+  function exprReturn(e):Dynamic
+  {
+    try
+    {
+      return expr(e);
+    }
+    catch (e:Stop)
+    {
+      switch (e)
+      {
+        case SBreak:
+          throw "Invalid break";
+        case SContinue:
+          throw "Invalid continue";
+        case SReturn:
+          var v = returnValue;
+          returnValue = null;
+          return v;
+      }
+    }
+    return null;
+  }
+
+  function duplicate<T>(h:Map<String, T>)
+  {
+    var h2 = new Map();
+    for (k in h.keys())
+      h2.set(k, h.get(k));
+    return h2;
+  }
+
+  function restore(old:Int)
+  {
+    while (declared.length > old)
+    {
+      var d = declared.pop();
+      locals.set(d.n, d.old);
+    }
+  }
+
+  inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Dynamic
+  {
+    #if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
+    if (rethrow) this.rethrow(e)
+    else
+      throw e;
+    return null;
+  }
+
+  inline function rethrow(e:Dynamic)
+  {
+    #if hl
+    hl.Api.rethrow(e);
+    #else
+    throw e;
+    #end
+  }
+
+  function resolve(id:String):Dynamic
+  {
+    var v = variables.get(id);
+    if (v == null && !variables.exists(id)) error(EUnknownVariable(id));
+    return v;
+  }
+
+  public function expr(e:Expr):Dynamic
+  {
+    #if hscriptPos
+    curExpr = e;
+    var e = e.e;
+    #end
+    switch (e)
+    {
+      case EConst(c):
+        switch (c)
+        {
+          case CInt(v): return v;
+          case CFloat(f): return f;
+          case CString(s): return s;
+        }
+      case EIdent(id):
+        var l = locals.get(id);
+        if (l != null) return l.r;
+        return resolve(id);
+      case EVar(n, _, e):
+        declared.push({n: n, old: locals.get(n)});
+        locals.set(n, {r: (e == null) ? null : expr(e)});
+        return null;
+      case EFinal(n, _, e):
+        declared.push({n: n, old: locals.get(n)});
+        locals.set(n, {r: (e == null) ? null : expr(e), isfinal: true});
+        return null;
+      case EParent(e):
+        return expr(e);
+      case EBlock(exprs):
+        var old = declared.length;
+        var v = null;
+        for (e in exprs)
+          v = expr(e);
+        restore(old);
+        return v;
+      case EField(e, f):
+        return get(expr(e), f);
+      case EBinop(op, e1, e2):
+        var fop = binops.get(op);
+        if (fop == null) error(EInvalidOp(op));
+        return fop(e1, e2);
+      case EUnop(op, prefix, e):
+        switch (op)
+        {
+          case "!":
+            return expr(e) != true;
+          case "-":
+            return -expr(e);
+          case "++":
+            return increment(e, prefix, 1);
+          case "--":
+            return increment(e, prefix, -1);
+          case "~":
+            return ~expr(e);
+          default:
+            error(EInvalidOp(op));
+        }
+      case ECall(e, params):
+        var args = new Array();
+        for (p in params)
+          args.push(expr(p));
+
+        switch (Tools.expr(e))
+        {
+          case EField(e, f):
+            var obj = expr(e);
+            if (obj == null) error(EInvalidAccess(f));
+            return fcall(obj, f, args);
+          default:
+            return call(null, expr(e), args);
+        }
+      case EIf(econd, e1, e2):
+        return if (expr(econd) == true) expr(e1) else if (e2 == null) null else expr(e2);
+      case EWhile(econd, e):
+        whileLoop(econd, e);
+        return null;
+      case EDoWhile(econd, e):
+        doWhileLoop(econd, e);
+        return null;
+      case EFor(v, it, e):
+        forLoop(v, it, e);
+        return null;
+      case EForGen(it, e):
+        Tools.getKeyIterator(it, function(vk, vv, it) {
+          if (vk == null)
+          {
+            #if hscriptPos
+            curExpr = it;
+            #end
+            error(ECustom("Invalid for expression"));
+            return;
+          }
+          forKeyValueLoop(vk, vv, it, e);
+        });
+        return null;
+      case EBreak:
+        throw SBreak;
+      case EContinue:
+        throw SContinue;
+      case EReturn(e):
+        returnValue = e == null ? null : expr(e);
+        throw SReturn;
+      case EFunction(params, fexpr, name, _):
+        var capturedLocals = duplicate(locals);
+        var me = this;
+        var hasOpt = false, minParams = 0;
+        for (p in params)
+          if (p.opt) hasOpt = true;
+          else
+            minParams++;
+        var f = function(args:Array<Dynamic>) {
+          if (((args == null) ? 0 : args.length) != params.length)
+          {
+            if (args.length < minParams)
+            {
+              var str = "Invalid number of parameters. Got " + args.length + ", required " + minParams;
+              if (name != null) str += " for function '" + name + "'";
+              error(ECustom(str));
+            }
+            // make sure mandatory args are forced
+            var args2 = [];
+            var extraParams = args.length - minParams;
+            var pos = 0;
+            for (p in params)
+              if (p.opt)
+              {
+                if (extraParams > 0)
+                {
+                  args2.push(args[pos++]);
+                  extraParams--;
+                }
+                else
+                  args2.push(null);
+              }
+              else
+                args2.push(args[pos++]);
+            args = args2;
+          }
+          var old = me.locals, depth = me.depth;
+          me.depth++;
+          me.locals = me.duplicate(capturedLocals);
+          for (i in 0...params.length)
+            me.locals.set(params[i].name, {r: args[i]});
+          var r = null;
+          var oldDecl = declared.length;
+          if (inTry) try
+          {
+            r = me.exprReturn(fexpr);
+          }
+          catch (e:Dynamic)
+          {
+            restore(oldDecl);
+            me.locals = old;
+            me.depth = depth;
+            #if neko
+            neko.Lib.rethrow(e);
+            #else
+            throw e;
+            #end
+          }
+          else
+            r = me.exprReturn(fexpr);
+          restore(oldDecl);
+          me.locals = old;
+          me.depth = depth;
+          return r;
+        };
+        var f = Reflect.makeVarArgs(f);
+        if (name != null)
+        {
+          if (depth == 0)
+          {
+            // global function
+            variables.set(name, f);
+          }
+          else
+          {
+            // function-in-function is a local function
+            declared.push({n: name, old: locals.get(name)});
+            var ref = {r: f};
+            locals.set(name, ref);
+            capturedLocals.set(name, ref); // allow self-recursion
+          }
+        }
+        return f;
+      case EArrayDecl(arr):
+        if (arr.length > 0 && Tools.expr(arr[0]).match(EBinop("=>", _)))
+        {
+          var keys = [];
+          var values = [];
+          for (e in arr)
+          {
+            switch (Tools.expr(e))
+            {
+              case EBinop("=>", eKey, eValue):
+                keys.push(expr(eKey));
+                values.push(expr(eValue));
+              default:
+                #if hscriptPos
+                curExpr = e;
+                #end
+                error(ECustom("Invalid map key=>value expression"));
+            }
+          }
+          return makeMap(keys, values);
+        }
+        else
+        {
+          var a = new Array();
+          for (e in arr)
+            a.push(expr(e));
+          return a;
+        }
+      case EArray(e, index):
+        var arr:Dynamic = expr(e);
+        var index:Dynamic = expr(index);
+        if (isMap(arr)) return getMapValue(arr, index);
+        return arr[index];
+      case ENew(cl, params):
+        var a = new Array();
+        for (e in params)
+          a.push(expr(e));
+        return cnew(cl, a);
+      case EThrow(e):
+        throw expr(e);
+      case ETry(e, n, _, ecatch):
+        var old = declared.length;
+        var oldTry = inTry;
+        try
+        {
+          inTry = true;
+          var v:Dynamic = expr(e);
+          restore(old);
+          inTry = oldTry;
+          return v;
+        }
+        catch (err:Stop)
+        {
+          inTry = oldTry;
+          throw err;
+        }
+        catch (err:Dynamic)
+        {
+          // restore vars
+          restore(old);
+          inTry = oldTry;
+          // declare 'v'
+          declared.push({n: n, old: locals.get(n)});
+          locals.set(n, {r: err});
+          var v:Dynamic = expr(ecatch);
+          restore(old);
+          return v;
+        }
+      case EObject(fl):
+        var o = {};
+        for (f in fl)
+          set(o, f.name, expr(f.e));
+        return o;
+      case ETernary(econd, e1, e2):
+        return if (expr(econd) == true) expr(e1) else expr(e2);
+      case ESwitch(e, cases, def):
+        var old:Int = declared.length;
+        var val:Dynamic = expr(e);
+        var match = false;
+        for (c in cases)
+        {
+          for (v in c.values)
+          {
+            switch (Tools.expr(v))
+            {
+              case ECall(e, params):
+                switch (Tools.expr(e))
+                {
+                  case EField(_, f):
+                    var valStr:String = cast val;
+                    valStr = valStr.substring(0, valStr.indexOf("("));
+                    if (valStr == f)
+                    {
+                      var valParams = Type.enumParameters(val);
+                      for (i => p in params)
+                      {
+                        switch (Tools.expr(p))
+                        {
+                          case EIdent(n):
+                            declared.push(
+                              {
+                                n: n,
+                                old: {r: locals.get(n)}
+                              });
+                            locals.set(n, {r: valParams[i]});
+                          default:
+                        }
+                      }
+                      match = true;
+                      break;
+                    }
+                  default:
+                }
+              default:
+                if (expr(v) == val)
+                {
+                  match = true;
+                  break;
+                }
+            }
+          }
+          if (match)
+          {
+            val = expr(c.expr);
+            break;
+          }
+        }
+        if (!match) val = def == null ? null : expr(def);
+        restore(old);
+        return val;
+      case EMeta(_, _, e):
+        return expr(e);
+      case ECheckType(e, _):
+        return expr(e);
+    }
+    return null;
+  }
+
+  function doWhileLoop(econd, e)
+  {
+    var old = declared.length;
+    do
+    {
+      if (!loopRun(() -> expr(e))) break;
+    }
+    while (expr(econd) == true);
+    restore(old);
+  }
+
+  function whileLoop(econd, e)
+  {
+    var old = declared.length;
+    while (expr(econd) == true)
+    {
+      if (!loopRun(() -> expr(e))) break;
+    }
+    restore(old);
+  }
+
+  function makeIterator(v:Dynamic):Iterator<Dynamic>
+  {
+    #if js
+    // don't use try/catch (very slow)
+    if (v is Array) return (v : Array<Dynamic>).iterator();
+    if (v.iterator != null) v = v.iterator();
+    #else
+    #if (cpp) if (v.iterator != null) #end
+    try
+      v = v.iterator()
+    catch (e:Dynamic) {};
+    #end
+    if (v.hasNext == null || v.next == null) error(EInvalidIterator(v));
+    return v;
+  }
+
+  function makeKeyValueIterator(v:Dynamic):KeyValueIterator<Dynamic, Dynamic>
+  {
+    #if js
+    // don't use try/catch (very slow)
+    if (v is Array) return (v : Array<Dynamic>).keyValueIterator();
+    if (v.keyValueIterator != null) v = v.keyValueIterator();
+    #else
+    try
+      v = v.keyValueIterator()
+    catch (e:Dynamic) {};
+    #end
+    if (v.hasNext == null || v.next == null) error(EInvalidIterator(v));
+    return v;
+  }
+
+  function forLoop(n, it, e)
+  {
+    var old = declared.length;
+    declared.push({n: n, old: locals.get(n)});
+    var it = makeIterator(expr(it));
+    while (it.hasNext())
+    {
+      locals.set(n, {r: it.next()});
+      if (!loopRun(() -> expr(e))) break;
+    }
+    restore(old);
+  }
+
+  function forKeyValueLoop(vk, vv, it, e)
+  {
+    var old = declared.length;
+    declared.push({n: vk, old: locals.get(vk)});
+    declared.push({n: vv, old: locals.get(vv)});
+    var it = makeKeyValueIterator(expr(it));
+    while (it.hasNext())
+    {
+      var v = it.next();
+      locals.set(vk, {r: v.key});
+      locals.set(vv, {r: v.value});
+      if (!loopRun(() -> expr(e))) break;
+    }
+    restore(old);
+  }
+
+  inline function loopRun(f:Void->Void)
+  {
+    var cont = true;
+    try
+    {
+      f();
+    }
+    catch (err:Stop)
+    {
+      switch (err)
+      {
+        case SContinue:
+        case SBreak:
+          cont = false;
+        case SReturn:
+          throw err;
+      }
+    }
+    return cont;
+  }
+
+  inline function isMap(o:Dynamic):Bool
+  {
+    return (o is IMap);
+  }
+
+  inline function getMapValue(map:Dynamic, key:Dynamic):Dynamic
+  {
+    return cast(map, haxe.Constraints.IMap<Dynamic, Dynamic>).get(key);
+  }
+
+  inline function setMapValue(map:Dynamic, key:Dynamic, value:Dynamic):Void
+  {
+    cast(map, haxe.Constraints.IMap<Dynamic, Dynamic>).set(key, value);
+  }
+
+  function makeMap(keys:Array<Dynamic>, values:Array<Dynamic>):Dynamic
+  {
+    var isAllString:Bool = true;
+    var isAllInt:Bool = true;
+    var isAllObject:Bool = true;
+    var isAllEnum:Bool = true;
+    for (key in keys)
+    {
+      isAllString = isAllString && (key is String);
+      isAllInt = isAllInt && (key is Int);
+      isAllObject = isAllObject && Reflect.isObject(key);
+      isAllEnum = isAllEnum && Reflect.isEnumValue(key);
+    }
+    if (isAllInt)
+    {
+      var m = new Map<Int, Dynamic>();
+      for (i => key in keys)
+        m.set(key, values[i]);
+      return m;
+    }
+    if (isAllString)
+    {
+      var m = new Map<String, Dynamic>();
+      for (i => key in keys)
+        m.set(key, values[i]);
+      return m;
+    }
+    if (isAllEnum)
+    {
+      var m = new haxe.ds.EnumValueMap<Dynamic, Dynamic>();
+      for (i => key in keys)
+        m.set(key, values[i]);
+      return m;
+    }
+    if (isAllObject)
+    {
+      var m = new Map<{}, Dynamic>();
+      for (i => key in keys)
+        m.set(key, values[i]);
+      return m;
+    }
+    error(ECustom("Invalid map keys " + keys));
+    return null;
+  }
+
+  function get(o:Dynamic, f:String):Dynamic
+  {
+    if (o == null) error(EInvalidAccess(f));
+    return
+    {
+      #if php
+      // https://github.com/HaxeFoundation/haxe/issues/4915
+      try
+      {
+        Reflect.getProperty(o, f);
+      }
+      catch (e:Dynamic)
+      {
+        Reflect.field(o, f);
+      }
+      #else
+      Reflect.getProperty(o, f);
+      #end
+    }
+  }
+
+  function set(o:Dynamic, f:String, v:Dynamic):Dynamic
+  {
+    if (o == null) error(EInvalidAccess(f));
+    Reflect.setProperty(o, f, v);
+    return v;
+  }
+
+  function fcall(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic
+  {
+    return call(o, get(o, f), args);
+  }
+
+  function call(o:Dynamic, f:Dynamic, args:Array<Dynamic>):Dynamic
+  {
+    return Reflect.callMethod(o, f, args);
+  }
+
+  function cnew(cl:String, args:Array<Dynamic>):Dynamic
+  {
+    var c = Type.resolveClass(cl);
+    if (c == null) c = resolve(cl);
+    return Type.createInstance(c, args);
+  }
+}

--- a/polymod/hscript/_internal/JsInterp.hx
+++ b/polymod/hscript/_internal/JsInterp.hx
@@ -1,0 +1,442 @@
+package polymod.hscript._internal;
+
+class JsInterp extends Interp
+{
+  /**
+    Variables declared in `ctx` are directly accessed without going through the `variables` map, which is faster
+  **/
+  public var ctx:{};
+
+  /**
+    If properties are defined, all calls to get/set are only done for fields accesses which are listed here.
+  **/
+  public var properties:Map<String, Bool>;
+
+  var localNames:Map<String, String>;
+
+  override function execute(expr:Expr):Dynamic
+  {
+    depth = 0;
+    localNames = new Map();
+    var str = '(($$i) => ${exprValue(expr)})';
+    var f:Dynamic->Dynamic = js.Lib.eval(str);
+    return f(this);
+  }
+
+  function escapeString(s:String)
+  {
+    return s.split("\\")
+      .join("\\\\")
+      .split("\r")
+      .join("\\r")
+      .split("\n")
+      .join("\\n")
+      .split('"')
+      .join('\\"');
+  }
+
+  function handleRBC(e:Expr)
+  {
+    // todo : return/break/continue inside expr here won't work !
+    return e;
+  }
+
+  function exprValue(expr:Expr)
+  {
+    switch (Tools.expr(expr))
+    {
+      case EBlock([]):
+        return "null";
+      case EIf(cond, e1, e2):
+        return exprJS(Tools.mk(ETernary(cond, e1, e2), expr));
+      case EBlock(el):
+        var el = [for (e in el) handleRBC(e)];
+        var last = el[el.length - 1];
+        switch (Tools.expr(last))
+        {
+          case EFunction(_, _, name, _) if (name != null): // don't return latest named function
+          default:
+            el[el.length - 1] = Tools.mk(EReturn(last), last);
+        }
+        var ebl = Tools.mk(EBlock(el), expr);
+        return '(() => ${exprJS(ebl)})()';
+      case ETry(e, v, t, ecatch):
+        e = handleRBC(e);
+        ecatch = handleRBC(ecatch);
+        var expr = Tools.mk(ETry(Tools.mk(EReturn(e), e), v, t, Tools.mk(EReturn(ecatch), ecatch)), expr);
+        return '(() => { ${exprJS(expr)} })()';
+      case EVar(_, _, e):
+        return e == null ? "null" : '(${exprValue(e)},null)';
+      case EWhile(_), EFor(_), EDoWhile(_), EThrow(_):
+        expr = handleRBC(expr);
+        return '(() => {${exprJS(expr)}})()';
+      case EMeta(_, _, e), ECheckType(e, _):
+        return exprValue(e);
+      case EFunction(_, _, name, _) if (name != null):
+        return '(() => {${exprJS(expr)}})()';
+      default:
+        return exprJS(expr);
+    }
+  }
+
+  function exprBlock(expr:Expr)
+  {
+    switch (Tools.expr(expr))
+    {
+      case EBlock(_):
+        return exprJS(expr);
+      default:
+        return '{${exprJS(expr)};}';
+    }
+  }
+
+  function addPos(estr:String)
+  {
+    #if hscriptPos
+    var expr = curExpr;
+    var p = '{pmin:,pmax:,origin:"",line:}';
+    return '($$i._p(${expr.pmin},${expr.pmax},"${expr.origin}",${expr.line}),$estr)';
+    #else
+    return estr;
+    #end
+  }
+
+  function isContext(v:String)
+  {
+    return ctx != null && Reflect.hasField(ctx, v);
+  }
+
+  function isProperty(f:String)
+  {
+    return properties == null || properties.get(f);
+  }
+
+  function exprCond(e:Expr)
+  {
+    return switch (Tools.expr(e))
+    {
+      case EBinop("==" | "!=" | ">=" | ">" | "<=" | "<" | "&&" | "||", _): exprValue(e);
+      default: '(${exprOp(e)} == true)';
+    }
+  }
+
+  function exprOp(e:Expr)
+  {
+    return switch (Tools.expr(e))
+    {
+      case EBinop(_), EUnop(_): '(${exprValue(e)})';
+      default: exprValue(e);
+    }
+  }
+
+  function declLocal(n:String)
+  {
+    if (!localNames.exists(n))
+    {
+      localNames.set(n, n);
+      return n;
+    }
+    var c = 2;
+    while (localNames.exists(n + c))
+      c++;
+    localNames.set(n, n + c);
+    return n + c;
+  }
+
+  function exprJS(expr:Expr):String
+  {
+    #if hscriptPos
+    curExpr = expr;
+    var expr = expr.e;
+    #end
+    switch (expr)
+    {
+      case EConst(c):
+        return switch c
+        {
+          case CInt(v): Std.string(v);
+          case CFloat(f): Std.string(f);
+          case CString(s): '"' + escapeString(s) + '"';
+        }
+      case EIdent(v):
+        var v2 = localNames.get(v);
+        if (v2 != null) return v2;
+        if (isContext(v)) return '$$i.ctx.$v';
+        switch (v)
+        {
+          case "null", "true", "false": return v;
+          default:
+        }
+        return '$$i.resolve("$v")';
+      case EVar(n, t, e):
+        n = declLocal(n);
+        return e == null ? 'let $n' : 'let $n = ${exprValue(e)}';
+      case EParent(e):
+        return '(${exprValue(e)})';
+      case EBlock(el):
+        var old = localNames.copy();
+        // pre define name functions
+        for (e in el)
+          switch (Tools.expr(e))
+          {
+            case EFunction(_, _, name, _): declLocal(name);
+            default:
+          }
+        var buf = new StringBuf();
+        buf.add('{');
+        for (e in el)
+        {
+          buf.add(exprJS(e));
+          buf.add(";");
+        }
+        buf.add('}');
+        localNames = old;
+        return buf.toString();
+      case EField(e, f) if (!isProperty(f)):
+        return exprValue(e) + "." + f;
+      case EField(e, f):
+        return '$$i.get(${exprValue(e)},"$f")';
+      case EBinop(op, e1, e2):
+        switch (op)
+        {
+          case "+", "-", "*", "/", "%", "&", "|", "^", ">>", "<<", ">>>", "==", "!=", ">=", "<=", ">", "<":
+            return '${exprOp(e1)} $op ${exprOp(e2)}';
+          case "||", "&&":
+            return '(${exprCond(e1)} $op ${exprCond(e2)})';
+          case "=":
+            switch (Tools.expr(e1))
+            {
+              case EIdent(id) if (localNames.exists(id)):
+                return localNames.get(id) + " = " + exprValue(e2);
+              case EIdent(id) if (isContext(id)):
+                return '$$i.ctx.$id = ${exprValue(e2)}';
+              case EIdent(id):
+                return '$$i.setVar("$id",${exprValue(e2)})';
+              case EField(e, f):
+                return addPos('$$i.set(${exprValue(e)},"$f")');
+              case EArray(e, index):
+                return '$$i.setArray(${exprValue(e)},${exprValue(index)},${exprValue(e2)})';
+              default:
+                error(EInvalidOp("="));
+            }
+          case "+=", "-=", "*=", "/=", "%=", "|=", "&=", "^=", "<<=", ">>=", ">>>=":
+            var aop = op.substr(0, op.length - 1);
+            switch (Tools.expr(e1))
+            {
+              case EIdent(id) if (localNames.exists(id)):
+                return localNames.get(id) + " " + op + " " + exprValue(e2);
+              case EIdent(id) if (isContext(id)):
+                return '$$i.ctx.$id $op ${exprValue(e2)}';
+              case EIdent(id):
+                return '$$i.setVar("$id",$$i.resolve("$id") $aop (${exprValue(e2)}))';
+              case EField(e, f):
+                return '(($$o,$$v) => $$i.set($$o,"$f",$$i.get($$o,"$f") $aop $$v)(${exprValue(e)},${exprValue(e2)})';
+              case EArray(e, index):
+                return '(($$a,$$idx,$$v) => $$i.setArray($$a,$$idx,$$i.getArray($$a,$$idx) $aop $$v))(${exprValue(e)},${exprValue(index)},${exprValue(e2)})';
+              default:
+                error(EInvalidOp(op));
+            }
+          case "...":
+            return '$$i.intIterator(${exprValue(e1)},${exprValue(e2)})';
+          case "is":
+            return '$$i.isOfType(${exprValue(e1)},${exprValue(e2)})';
+          default:
+            error(EInvalidOp(op));
+        }
+      case EUnop(op, prefix, e):
+        switch (op)
+        {
+          case "!":
+            return '${exprValue(e)} != true';
+          case "-", "~":
+            return op + exprOp(e);
+          case "++", "--":
+            switch (Tools.expr(e))
+            {
+              case EIdent(id) if (localNames.exists(id)):
+                id = localNames.get(id);
+                return prefix ? op + id : id + op;
+              case EIdent(id) if (isContext(id)):
+                return prefix ? op + "$i.ctx." + id : "$i.ctx." + id + op;
+              case _ if (prefix):
+                var one = Tools.mk(EConst(CInt(1)), e);
+                return exprJS(Tools.mk(EBinop(op.charAt(0) + "=", e, one), e));
+              case EIdent(id):
+                var op = op.charAt(1);
+                return '(($$v) => ($$i.setVar("$id",$$v $op 1),$$v))($$i.resolve("$id"))';
+              case EArray(e, index):
+                var op = op.charAt(0);
+                var v = declLocal("$v");
+                var str = '(($$a,$$idx) => { let $v = $$i.getArray($$a,$$idx); $$i.setArray($$a,$$idx,$v $op 1); return $v; })(${exprValue(e)},${exprValue(index)})';
+                localNames.remove(v);
+                return str;
+              case EField(e, f):
+                var v = declLocal("$v");
+                var str = '(($$o) => { let $v = $$i.get($$o,"$f"); $$i.set($$o,"$f",$$v $op 1); return $v; })(${exprValue(e)})';
+                localNames.remove(v);
+                return str;
+              default:
+                error(EInvalidOp(op));
+            }
+          default:
+            error(EInvalidOp(op));
+        }
+      case ECall(e, params):
+        var args = [for (p in params) exprValue(p)];
+        switch (Tools.expr(e))
+        {
+          case EField(eobj, f):
+            var isCtx = false;
+            var obj = eobj;
+            while (true)
+            {
+              switch (Tools.expr(obj))
+              {
+                case EField(o, _): obj = o;
+                case EIdent(i) if (isContext(i)):
+                  isCtx = true;
+                  break;
+                default: break;
+              }
+            }
+            if (isCtx) return '${exprValue(e)}(${args.join(',')})';
+            return addPos('$$i.fcall2(${exprValue(eobj)},"$f",[${args.join(',')}])');
+          case EIdent(id) if (localNames.exists(id)):
+            id = localNames.get(id);
+            return '$id(${args.join(',')})';
+          case EIdent(id) if (isContext(id)):
+            return '$$i.ctx.$id(${args.join(',')})';
+          default:
+            return '$$i.call(null,${exprValue(e)},[${args.join(',')}])';
+        }
+      case EIf(cond, e1, e2):
+        return 'if( ${exprCond(cond)} ) ${exprJS(e1)}' + (e2 == null ? "" : 'else ${exprJS(e2)}');
+      case ETernary(cond, e1, e2):
+        return '(${exprCond(cond)} ? ${exprValue(e1)} : ${exprValue(e2)})';
+      case EWhile(cond, e):
+        return 'while( ${exprValue(cond)} ) ${exprJS(e)}';
+      case EFor(v, it, e):
+        v = declLocal(v);
+        var block = exprJS(e);
+        localNames.remove(v);
+        var iter = '$$i.makeIterator(${exprValue(it)})';
+        var it = declLocal("$it");
+        var str = '{ let $it = ${addPos(iter)}; while( $it.hasNext() ) { let $v = $it.next(); $block; } }';
+        localNames.remove(it);
+        return str;
+      case EBreak:
+        return 'break';
+      case EContinue:
+        return 'continue';
+      case EReturn(null):
+        return 'return';
+      case EReturn(e):
+        return 'return ' + exprValue(e);
+      case EArray(e, index):
+        return '$$i.getArray(${exprValue(e)},${exprValue(index)})';
+      case EArrayDecl(arr):
+        if (arr.length > 0 && Tools.expr(arr[0]).match(EBinop("=>", _)))
+        {
+          var keys = [], values = [];
+          for (e in arr)
+          {
+            switch (Tools.expr(e))
+            {
+              case EBinop("=>", eKey, eValue):
+                keys.push(exprValue(eKey));
+                values.push(exprValue(eValue));
+              default:
+                #if hscriptPos
+                curExpr = e;
+                #end
+                error(ECustom("Invalid map key=>value expression"));
+            }
+          }
+          return '$$i.makeMap([${keys.join(',')}],[${values.join(',')}])';
+        }
+        return '[' + [for (e in arr) exprValue(e)].join(',') + ']';
+      case ENew(cl, params):
+        var args = [for (e in params) exprValue(e)];
+        return '$$i.cnew("$cl",[${args.join(',')}])';
+      case EThrow(e):
+        return "throw " + exprValue(e);
+      case ETry(e, v, t, ecatch):
+        v = declLocal(v);
+        var ec = exprBlock(ecatch);
+        localNames.remove(v);
+        return 'try ${exprBlock(e)} catch( $v ) $ec';
+      case EObject(fl):
+        var fields = [for (f in fl) f.name + ":" + exprValue(f.e)];
+        return '{${fields.join(',')}}'; // do not use 'set' here
+      case EDoWhile(cond, e):
+        return 'do ${exprBlock(e)} while( ${exprCond(cond)} )';
+      case EMeta(_, _, e), ECheckType(e, _):
+        return exprJS(e);
+      case EFunction(args, e, name, ret):
+        var prev = localNames.copy();
+        if (name != null && !localNames.exists(name)) declLocal(name);
+        for (a in args)
+          localNames.set(a.name, a.name);
+        var bl = exprBlock(e);
+        localNames = prev;
+        var fstr = 'function(${[for (a in args) a.name].join(",")}) $bl';
+        if (name != null) fstr = 'let $name = $$i.setVar("$name",$fstr)';
+        return fstr;
+      case ESwitch(e, cases, defaultExpr):
+        var checks = [
+          for (c in cases) 'if( ${[for( v in c.values ) '$$v == ${exprValue(v)}'].join(" || ")} ) return ${exprValue(handleRBC(c.expr))};'
+        ];
+        if (defaultExpr != null) checks.push('return ' + exprValue(defaultExpr));
+        return '(($$v) => { ${[for (c in checks) c + ";"].join(" ")} })(${exprValue(e)})';
+      default:
+        throw "TODO";
+    }
+  }
+
+  function fcall2(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic
+  {
+    if (o == null)
+    {
+      error(EInvalidAccess(f));
+      return null;
+    }
+    return fcall(o, f, args);
+  }
+
+  function getArray(arr:Dynamic, index:Dynamic)
+  {
+    return isMap(arr) ? getMapValue(arr, index) : arr[index];
+  }
+
+  function setArray(arr:Dynamic, index:Dynamic, v:Dynamic)
+  {
+    if (isMap(arr)) setMapValue(arr, index, v);
+    else
+      arr[index] = v;
+    return v;
+  }
+
+  function intIterator(v1, v2)
+  {
+    return new IntIterator(v1, v2);
+  }
+
+  function isOfType(v1, v2)
+  {
+    return Std.isOfType(v1, v2);
+  }
+
+  #if hscriptPos
+  function _p(pmin, pmax, origin, line)
+  {
+    curExpr =
+      {
+        e: null,
+        pmin: pmin,
+        pmax: pmax,
+        origin: origin,
+        line: line
+      };
+  }
+  #end
+}

--- a/polymod/hscript/_internal/Macro.hx
+++ b/polymod/hscript/_internal/Macro.hx
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package polymod.hscript._internal;
+
+import polymod.hscript._internal.Expr.Error;
+#if hscriptPos
+import polymod.hscript._internal.Expr.ErrorDef;
+#end
+import haxe.macro.Expr;
+
+class Macro
+{
+  var p:Position;
+  var binops:Map<String, Binop>;
+  var unops:Map<String, Unop>;
+
+  public function new(pos)
+  {
+    p = pos;
+    binops = new Map();
+    unops = new Map();
+    for (c in Type.getEnumConstructs(Binop))
+    {
+      if (c == "OpAssignOp") continue;
+      var op = Type.createEnum(Binop, c);
+      var assign = false;
+      var str = switch (op)
+      {
+        case OpAdd:
+          assign = true;
+          "+";
+        case OpMult:
+          assign = true;
+          "*";
+        case OpDiv:
+          assign = true;
+          "/";
+        case OpSub:
+          assign = true;
+          "-";
+        case OpAssign: "=";
+        case OpEq: "==";
+        case OpNotEq: "!=";
+        case OpGt: ">";
+        case OpGte: ">=";
+        case OpLt: "<";
+        case OpLte: "<=";
+        case OpAnd:
+          assign = true;
+          "&";
+        case OpOr:
+          assign = true;
+          "|";
+        case OpXor:
+          assign = true;
+          "^";
+        case OpBoolAnd: "&&";
+        case OpBoolOr: "||";
+        case OpShl:
+          assign = true;
+          "<<";
+        case OpShr:
+          assign = true;
+          ">>";
+        case OpUShr:
+          assign = true;
+          ">>>";
+        case OpMod:
+          assign = true;
+          "%";
+        case OpAssignOp(_): "";
+        case OpInterval: "...";
+        case OpArrow: "=>";
+        #if (haxe_ver >= 4)
+        case OpIn: "in";
+        #end
+        default:
+          continue;
+      };
+      binops.set(str, op);
+      if (assign) binops.set(str + "=", OpAssignOp(op));
+    }
+    for (c in Type.getEnumConstructs(Unop))
+    {
+      var op = Type.createEnum(Unop, c);
+      var str = switch (op)
+      {
+        case OpNot: "!";
+        case OpNeg: "-";
+        case OpNegBits: "~";
+        case OpIncrement: "++";
+        case OpDecrement: "--";
+        #if (haxe_ver >= 4.2)
+        case OpSpread: continue;
+        #end
+      }
+      unops.set(str, op);
+    }
+  }
+
+  function map<T, R>(a:Array<T>, f:T->R):Array<R>
+  {
+    var b = new Array();
+    for (x in a)
+      b.push(f(x));
+    return b;
+  }
+
+  function convertType(t:Expr.CType):ComplexType
+  {
+    return switch (t)
+    {
+      case CTOpt(t): TOptional(convertType(t));
+      case CTPath(pack, args):
+        var params = [];
+        if (args != null)
+        {
+          for (t in args)
+            params.push( switch (t)
+            {
+              case CTExpr(e): TPExpr(convert(e));
+              default: TPType(convertType(t));
+            });
+        }
+        TPath(
+          {
+            pack: pack,
+            name: pack.pop(),
+            params: params,
+            sub: null,
+          });
+      case CTParent(t): TParent(convertType(t));
+      case CTFun(args, ret):
+        TFunction(map(args, convertType), convertType(ret));
+      case CTNamed(name, convertType(_) => ct):
+        #if (haxe_ver >= 4)
+        TNamed(name, ct);
+        #else
+        ct;
+        #end
+      case CTAnon(fields):
+        var tf = [];
+        for (f in fields)
+        {
+          var meta = f.meta == null ? [] : [
+            for (m in f.meta) {name: m.name, params: m.params == null ? [] : [for (e in m.params) convert(e)], pos: p}
+          ];
+          tf.push(
+            {
+              name: f.name,
+              meta: meta,
+              doc: null,
+              access: [],
+              kind: FVar(convertType(f.t), null),
+              pos: p
+            });
+        }
+        TAnonymous(tf);
+      case CTExpr(_):
+        throw "assert";
+    };
+  }
+
+  public function convert(e:hscript.Expr):Expr
+  {
+    return {
+      expr: switch (#if hscriptPos e.e #else e #end)
+      {
+        case EConst(c):
+          EConst( switch (c)
+          {
+            case CInt(v): CInt(Std.string(v));
+            case CFloat(f): CFloat(Std.string(f));
+            case CString(s): CString(s);
+          });
+        case EIdent(v):
+          EConst(CIdent(v));
+        case EVar(n, t, e):
+          EVars([
+            {name: n, expr: if (e == null) null else convert(e), type: if (t == null) null else convertType(t)}
+          ]);
+        case EParent(e):
+          EParenthesis(convert(e));
+        case EBlock(el):
+          EBlock(map(el, convert));
+        case EField(e, f):
+          EField(convert(e), f);
+        case EBinop(op, e1, e2):
+          var b = binops.get(op);
+          if (b == null) throw EInvalidOp(op);
+          EBinop(b, convert(e1), convert(e2));
+        case EUnop(op, prefix, e):
+          var u = unops.get(op);
+          if (u == null) throw EInvalidOp(op);
+          EUnop(u, !prefix, convert(e));
+        case ECall(e, params):
+          ECall(convert(e), map(params, convert));
+        case EIf(c, e1, e2):
+          EIf(convert(c), convert(e1), e2 == null ? null : convert(e2));
+        case EWhile(c, e):
+          EWhile(convert(c), convert(e), true);
+        case EDoWhile(c, e):
+          EWhile(convert(c), convert(e), false);
+        case EFor(v, it, efor):
+          var p = #if (!macro && hscriptPos)
+            {file: p.file, min: e.pmin, max: e.pmax} #else p #end;
+          EFor({expr: EBinop(OpIn, {expr: EConst(CIdent(v)), pos: p}, convert(it)), pos: p}, convert(efor));
+        case EForGen(it, efor):
+          EFor(convert(it), convert(efor));
+        case EBreak:
+          EBreak;
+        case EContinue:
+          EContinue;
+        case EFunction(args, e, name, ret):
+          var targs = [];
+          for (a in args)
+            targs.push(
+              {
+                name: a.name,
+                type: a.t == null ? null : convertType(a.t),
+                opt: false,
+                value: null,
+              });
+          EFunction(#if haxe4 name != null ? FNamed(name, false) : FAnonymous #else name #end,
+            {
+              params: [],
+              args: targs,
+              expr: convert(e),
+              ret: ret == null ? null : convertType(ret),
+            });
+        case EReturn(e):
+          EReturn(e == null ? null : convert(e));
+        case EArray(e, index):
+          EArray(convert(e), convert(index));
+        case EArrayDecl(el):
+          EArrayDecl(map(el, convert));
+        case ENew(cl, params):
+          var pack = cl.split(".");
+          ENew(
+            {
+              pack: pack,
+              name: pack.pop(),
+              params: [],
+              sub: null
+            }, map(params, convert));
+        case EThrow(e):
+          EThrow(convert(e));
+        case ETry(e, v, t, ec):
+          ETry(convert(e), [
+            {type: convertType(t), name: v, expr: convert(ec)}]);
+        case EObject(fields):
+          var tf = [];
+          for (f in fields)
+            tf.push({field: f.name, expr: convert(f.e)});
+          EObjectDecl(tf);
+        case ETernary(cond, e1, e2):
+          ETernary(convert(cond), convert(e1), convert(e2));
+        case ESwitch(e, cases, edef):
+          ESwitch(convert(e), [
+            for (c in cases) {values: [for (v in c.values) convert(v)], expr: convert(c.expr)}
+          ], edef == null ? null : convert(edef));
+        case EMeta(m, params, esub):
+          var mpos = #if (!macro && hscriptPos)
+            {file: p.file, min: e.pmin, max: e.pmax} #else p #end;
+          EMeta({name: m, params: params == null ? [] : [for (p in params) convert(p)], pos: mpos}, convert(esub));
+        case ECheckType(e, t):
+          ECheckType(convert(e), convertType(t));
+      },
+      pos: #if (!macro && hscriptPos)
+      {file: p.file, min: e.pmin, max: e.pmax} #else p #end
+    }
+  }
+}

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1,0 +1,2107 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package polymod.hscript._internal;
+
+import polymod.hscript._internal.Expr;
+
+enum Token
+{
+  TEof;
+  TConst(c:Const);
+  TId(s:String);
+  TOp(s:String);
+  TPOpen;
+  TPClose;
+  TBrOpen;
+  TBrClose;
+  TDot;
+  TQuestionDot;
+  TComma;
+  TSemicolon;
+  TBkOpen;
+  TBkClose;
+  TQuestion;
+  TDoubleDot;
+  TMeta(s:String);
+  TPrepro(s:String);
+}
+
+class Parser
+{
+  // config / variables
+  public var line:Int;
+  public var opChars:String;
+  public var identChars:String;
+  public var opPriority:Map<String, Int>;
+  public var opRightAssoc:Map<String, Bool>;
+
+  /**
+    allows to check for #if / #else in code
+  **/
+  public var preprocesorValues:Map<String, Dynamic> = new Map();
+
+  /**
+    activate JSON compatiblity
+  **/
+  public var allowJSON:Bool;
+
+  /**
+    allow types declarations
+  **/
+  public var allowTypes:Bool;
+
+  /**
+    allow haxe metadata declarations
+  **/
+  public var allowMetadata:Bool;
+
+  /**
+    resume from parsing errors (when parsing incomplete code, during completion for example)
+  **/
+  public var resumeErrors:Bool;
+
+  // implementation
+  var input:String;
+  var readPos:Int;
+  var offset:Int;
+  var currentPos(get, never):Int;
+
+  var char:Int;
+  var ops:Array<Bool>;
+  var idents:Array<Bool>;
+  var uid:Int = 0;
+
+  #if hscriptPos
+  var origin:String;
+  var tokenMin:Int;
+  var tokenMax:Int;
+  var oldTokenMin:Int;
+  var oldTokenMax:Int;
+  var tokens:List<{min:Int, max:Int, t:Token}>;
+  #else
+  static inline var p1 = 0;
+  static inline var tokenMin = 0;
+  static inline var tokenMax = 0;
+
+  var tokens:haxe.ds.GenericStack<Token>;
+  #end
+
+  public function new()
+  {
+    line = 1;
+    opChars = "+*/-=!><&|^%~?";
+    identChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+    var priorities = [
+      ["%"],
+      ["*", "/"],
+      ["+", "-"],
+      ["<<", ">>", ">>>"],
+      ["|", "&", "^"],
+      ["==", "!=", ">", "<", ">=", "<="],
+      ["..."],
+      ["&&"],
+      ["||"],
+      ["??"],
+      [
+        "=",
+        "+=",
+        "-=",
+        "*=",
+        "/=",
+        "%=",
+        "<<=",
+        ">>=",
+        ">>>=",
+        "??" + "=",
+        "|=",
+        "&=",
+        "^=",
+        "=>"
+      ],
+      ["->"],
+      ["in", "is"]
+    ];
+    opPriority = new Map();
+    opRightAssoc = new Map();
+    for (i in 0...priorities.length)
+      for (x in priorities[i])
+      {
+        opPriority.set(x, i);
+        if (i == 10) opRightAssoc.set(x, true);
+      }
+    for (x in ["!", "++", "--", "~"]) // unary "-" handled in parser directly!
+      opPriority.set(x, x == "++" || x == "--" ? -1 : -2);
+  }
+
+  inline function get_currentPos()
+    return readPos + offset;
+
+  public inline function error(err, pmin, pmax)
+  {
+    if (!resumeErrors) #if hscriptPos
+      throw new Error(err, pmin, pmax, origin, line);
+    #else
+      throw err;
+    #end
+  }
+
+  public function invalidChar(c)
+  {
+    error(EInvalidChar(c), readPos - 1, readPos - 1);
+  }
+
+  function initParser(origin, pos)
+  {
+    // line=1 - don't reset line : it might be set manualy
+    preprocStack = [];
+    #if hscriptPos
+    this.origin = origin;
+    readPos = 0;
+    tokenMin = oldTokenMin = pos;
+    tokenMax = oldTokenMax = pos;
+    tokens = new List();
+    #else
+    tokens = new haxe.ds.GenericStack<Token>();
+    #end
+    offset = pos;
+    char = -1;
+    ops = new Array();
+    idents = new Array();
+    uid = 0;
+    for (i in 0...opChars.length)
+      ops[opChars.charCodeAt(i)] = true;
+    for (i in 0...identChars.length)
+      idents[identChars.charCodeAt(i)] = true;
+  }
+
+  public function parseString(s:String, ?origin:String = "hscript", ?position:Int = 0)
+  {
+    initParser(origin, position);
+    input = s;
+    readPos = 0;
+    var a = new Array();
+    while (true)
+    {
+      var tk = token();
+      if (tk == TEof) break;
+      push(tk);
+      parseFullExpr(a);
+    }
+    return if (a.length == 1) a[0] else mk(EBlock(a), 0);
+  }
+
+  function unexpected(tk):Dynamic
+  {
+    error(EUnexpected(tokenString(tk)), tokenMin, tokenMax);
+    return null;
+  }
+
+  inline function push(tk)
+  {
+    #if hscriptPos
+    tokens.push({t: tk, min: tokenMin, max: tokenMax});
+    tokenMin = oldTokenMin;
+    tokenMax = oldTokenMax;
+    #else
+    tokens.add(tk);
+    #end
+  }
+
+  inline function ensure(tk)
+  {
+    var t = token();
+    if (t != tk) unexpected(t);
+  }
+
+  inline function ensureToken(tk)
+  {
+    var t = token();
+    if (!Type.enumEq(t, tk)) unexpected(t);
+  }
+
+  function maybe(tk)
+  {
+    var t = token();
+    if (Type.enumEq(t, tk)) return true;
+    push(t);
+    return false;
+  }
+
+  function getIdent()
+  {
+    var tk = token();
+    switch (tk)
+    {
+      case TId(id):
+        return id;
+      default:
+        unexpected(tk);
+        return null;
+    }
+  }
+
+  inline function expr(e:Expr)
+  {
+    #if hscriptPos
+    return e.e;
+    #else
+    return e;
+    #end
+  }
+
+  inline function pmin(e:Expr)
+  {
+    #if hscriptPos
+    return e == null ? 0 : e.pmin;
+    #else
+    return 0;
+    #end
+  }
+
+  inline function pmax(e:Expr)
+  {
+    #if hscriptPos
+    return e == null ? 0 : e.pmax;
+    #else
+    return 0;
+    #end
+  }
+
+  inline function mk(e, ?pmin, ?pmax):Expr
+  {
+    #if hscriptPos
+    if (e == null) return null;
+    if (pmin == null) pmin = tokenMin;
+    if (pmax == null) pmax = tokenMax;
+    return {
+      e: e,
+      pmin: pmin,
+      pmax: pmax,
+      origin: origin,
+      line: line
+    };
+    #else
+    return e;
+    #end
+  }
+
+  function isBlock(e)
+  {
+    if (e == null) return false;
+    return switch (expr(e))
+    {
+      case EBlock(_), EObject(_), ESwitch(_): true;
+      case EFunction(_, e, _, _): isBlock(e);
+      case EVar(_, t, e) | EFinal(_, t, e): e != null ? isBlock(e) : t != null ? t.match(CTAnon(_)) : false;
+      case EIf(_, e1, e2): if (e2 != null) isBlock(e2) else isBlock(e1);
+      case EBinop(_, _, e): isBlock(e);
+      case EUnop(_, prefix, e): !prefix && isBlock(e);
+      case EWhile(_, e): isBlock(e);
+      case EDoWhile(_, e): isBlock(e);
+      case EFor(_, _, e), EForGen(_, e): isBlock(e);
+      case EReturn(e): e != null && isBlock(e);
+      case ETry(_, _, _, e): isBlock(e);
+      case EMeta(_, _, e): isBlock(e);
+      default: false;
+    }
+  }
+
+  function parseFullExpr(exprs:Array<Expr>)
+  {
+    var e = parseExpr();
+    exprs.push(e);
+
+    var tk = token();
+    // this is a hack to support var a,b,c; with a single EVar
+    while (tk == TComma && e != null && expr(e).match(EVar(_)))
+    {
+      e = parseStructure("var"); // next variable
+      exprs.push(e);
+      tk = token();
+    }
+
+    if (tk != TSemicolon && tk != TEof)
+    {
+      if (isBlock(e)) push(tk);
+      else
+        unexpected(tk);
+    }
+  }
+
+  function parseObject(p1)
+  {
+    // parse object
+    var fl = new Array();
+    while (true)
+    {
+      var tk = token();
+      var id = null;
+      switch (tk)
+      {
+        case TId(i):
+          id = i;
+        case TConst(c):
+          if (!allowJSON) unexpected(tk);
+          switch (c)
+          {
+            case CString(s): id = s;
+            default: unexpected(tk);
+          }
+        case TBrClose:
+          break;
+        default:
+          unexpected(tk);
+          break;
+      }
+      ensure(TDoubleDot);
+      fl.push({name: id, e: parseExpr()});
+      tk = token();
+      switch (tk)
+      {
+        case TBrClose:
+          break;
+        case TComma:
+        default:
+          unexpected(tk);
+      }
+    }
+    return parseExprNext(mk(EObject(fl), p1));
+  }
+
+  function parseExpr()
+  {
+    var tk = token();
+    #if hscriptPos
+    var p1 = tokenMin;
+    #end
+    switch (tk)
+    {
+      case TId(id):
+        var e = parseStructure(id);
+        if (e == null) e = mk(EIdent(id));
+        return parseExprNext(e);
+      case TConst(c):
+        return parseExprNext(mk(EConst(c)));
+      case TPOpen:
+        tk = token();
+        if (tk == TPClose)
+        {
+          ensureToken(TOp("->"));
+          var eret = parseExpr();
+          return mk(EFunction([], mk(EReturn(eret), p1)), p1);
+        }
+        push(tk);
+        var e = parseExpr();
+        tk = token();
+        switch (tk)
+        {
+          case TPClose:
+            return parseExprNext(mk(EParent(e), p1, tokenMax));
+          case TDoubleDot:
+            var t = parseType();
+            tk = token();
+            switch (tk)
+            {
+              case TPClose:
+                return parseExprNext(mk(ECheckType(e, t), p1, tokenMax));
+              case TComma:
+                switch (expr(e))
+                {
+                  case EIdent(v): return parseLambda([
+                      {name: v, t: t}], pmin(e));
+                  default:
+                }
+              default:
+            }
+          case TComma:
+            switch (expr(e))
+            {
+              case EIdent(v): return parseLambda([
+                  {name: v}], pmin(e));
+              default:
+            }
+          default:
+        }
+        return unexpected(tk);
+      case TBrOpen:
+        tk = token();
+        switch (tk)
+        {
+          case TBrClose:
+            return parseExprNext(mk(EObject([]), p1));
+          case TId(_):
+            var tk2 = token();
+            push(tk2);
+            push(tk);
+            switch (tk2)
+            {
+              case TDoubleDot:
+                return parseExprNext(parseObject(p1));
+              default:
+            }
+          case TConst(c):
+            if (allowJSON)
+            {
+              switch (c)
+              {
+                case CString(_):
+                  var tk2 = token();
+                  push(tk2);
+                  push(tk);
+                  switch (tk2)
+                  {
+                    case TDoubleDot:
+                      return parseExprNext(parseObject(p1));
+                    default:
+                  }
+                default:
+                  push(tk);
+              }
+            }
+            else push(tk);
+          default:
+            push(tk);
+        }
+        var a = new Array();
+        while (true)
+        {
+          parseFullExpr(a);
+          tk = token();
+          if (tk == TBrClose || (resumeErrors && tk == TEof)) break;
+          push(tk);
+        }
+        return mk(EBlock(a), p1);
+      case TOp(op):
+        if (op == "-")
+        {
+          var start = tokenMin;
+          var e = parseExpr();
+          if (e == null) return makeUnop(op, e);
+          switch (expr(e))
+          {
+            case EConst(CInt(i)):
+              return mk(EConst(CInt(-i)), start, pmax(e));
+            case EConst(CFloat(f)):
+              return mk(EConst(CFloat(-f)), start, pmax(e));
+            default:
+              return makeUnop(op, e);
+          }
+        }
+        if (opPriority.get(op) < 0) return makeUnop(op, parseExpr());
+        return unexpected(tk);
+      case TBkOpen:
+        var a = new Array();
+        tk = token();
+        var first = true;
+        while (tk != TBkClose && (!resumeErrors || tk != TEof))
+        {
+          if (!first)
+          {
+            if (tk != TComma) unexpected(tk);
+            else
+            {
+              tk = token();
+              if (tk == TBkClose) break;
+            }
+          }
+          first = false;
+          push(tk);
+          a.push(parseExpr());
+          tk = token();
+        }
+        if (a.length == 1 && a[0] != null) switch (expr(a[0]))
+        {
+          case EFor(_), EWhile(_), EDoWhile(_):
+            var tmp = "__a_" + (uid++);
+            var e = mk(EBlock([
+              mk(EVar(tmp, null, mk(EArrayDecl([]), p1)), p1),
+              mapCompr(tmp, a[0]),
+              mk(EIdent(tmp), p1),
+            ]), p1);
+            return parseExprNext(e);
+          default:
+        }
+        return parseExprNext(mk(EArrayDecl(a), p1));
+      case TMeta(id) if (allowMetadata):
+        var args = parseMetaArgs();
+        return mk(EMeta(id, args, parseExpr()), p1);
+      default:
+        return unexpected(tk);
+    }
+  }
+
+  function parseLambda(args:Array<Argument>, pmin)
+  {
+    while (true)
+    {
+      var id = getIdent();
+      var t = maybe(TDoubleDot) ? parseType() : null;
+      args.push({name: id, t: t});
+      var tk = token();
+      switch (tk)
+      {
+        case TComma:
+        case TPClose:
+          break;
+        default:
+          unexpected(tk);
+          break;
+      }
+    }
+    ensureToken(TOp("->"));
+    var eret = parseExpr();
+    return mk(EFunction(args, mk(EReturn(eret), pmin)), pmin);
+  }
+
+  function parseMetaArgs()
+  {
+    var tk = token();
+    if (tk != TPOpen)
+    {
+      push(tk);
+      return null;
+    }
+    var args = [];
+    tk = token();
+    if (tk != TPClose)
+    {
+      push(tk);
+      while (true)
+      {
+        args.push(parseExpr());
+        switch (token())
+        {
+          case TComma:
+          case TPClose:
+            break;
+          case tk:
+            unexpected(tk);
+        }
+      }
+    }
+    return args;
+  }
+
+  function mapCompr(tmp:String, e:Expr)
+  {
+    if (e == null) return null;
+    var edef = switch (expr(e))
+    {
+      case EFor(v, it, e2):
+        EFor(v, it, mapCompr(tmp, e2));
+      case EForGen(it, e2):
+        EForGen(it, mapCompr(tmp, e2));
+      case EWhile(cond, e2):
+        EWhile(cond, mapCompr(tmp, e2));
+      case EDoWhile(cond, e2):
+        EDoWhile(cond, mapCompr(tmp, e2));
+      case EIf(cond, e1, e2) if (e2 == null):
+        EIf(cond, mapCompr(tmp, e1), null);
+      case EBlock([e]):
+        EBlock([mapCompr(tmp, e)]);
+      case EParent(e2):
+        EParent(mapCompr(tmp, e2));
+      default:
+        ECall(mk(EField(mk(EIdent(tmp), pmin(e), pmax(e)), "push"), pmin(e), pmax(e)), [e]);
+    }
+    return mk(edef, pmin(e), pmax(e));
+  }
+
+  function makeUnop(op, e)
+  {
+    if (e == null && resumeErrors) return null;
+    return switch (expr(e))
+    {
+      case EBinop(bop, e1, e2): mk(EBinop(bop, makeUnop(op, e1), e2), pmin(e1), pmax(e2));
+      case ETernary(e1, e2, e3): mk(ETernary(makeUnop(op, e1), e2, e3), pmin(e1), pmax(e3));
+      default: mk(EUnop(op, true, e), pmin(e), pmax(e));
+    }
+  }
+
+  function makeBinop(op, e1, e)
+  {
+    if (e == null && resumeErrors) return mk(EBinop(op, e1, e), pmin(e1), pmax(e1));
+    return switch (expr(e))
+    {
+      case EBinop(op2, e2, e3):
+        var delta = opPriority.get(op) - opPriority.get(op2);
+        if (delta < 0
+          || (delta == 0 && !opRightAssoc.exists(op))) mk(EBinop(op2, makeBinop(op, e1, e2), e3), pmin(e1),
+            pmax(e3)); else mk(EBinop(op, e1, e), pmin(e1), pmax(e));
+      case ETernary(e2, e3, e4):
+        if (opRightAssoc.exists(op)) mk(EBinop(op, e1, e), pmin(e1), pmax(e)); else mk(ETernary(makeBinop(op, e1, e2), e3, e4), pmin(e1), pmax(e));
+      default:
+        mk(EBinop(op, e1, e), pmin(e1), pmax(e));
+    }
+  }
+
+  function parseStructure(id)
+  {
+    #if hscriptPos
+    var p1 = tokenMin;
+    #end
+    return switch (id)
+    {
+      case "if":
+        ensure(TPOpen);
+        var cond = parseExpr();
+        ensure(TPClose);
+        var e1 = parseExpr();
+        var e2 = null;
+        var semic = false;
+        var tk = token();
+        if (tk == TSemicolon)
+        {
+          semic = true;
+          tk = token();
+        }
+        if (Type.enumEq(tk, TId("else"))) e2 = parseExpr();
+        else
+        {
+          push(tk);
+          if (semic) push(TSemicolon);
+        }
+        mk(EIf(cond, e1, e2), p1, (e2 == null) ? tokenMax : pmax(e2));
+      case "var":
+        var ident = getIdent();
+        var tk = token();
+        var t = null;
+        if (tk == TDoubleDot && allowTypes)
+        {
+          t = parseType();
+          tk = token();
+        }
+        var e = null;
+
+        switch (tk)
+        {
+          case TOp("="): e = parseExpr();
+          case TOp(_): unexpected(tk);
+          case TComma | TSemicolon: push(tk);
+          // Above case should be enough but semicolon is not mandatory after }
+          case _ if (t != null): push(tk);
+          default: unexpected(tk);
+        }
+
+        mk(EVar(ident, t, e), p1, (e == null) ? tokenMax : pmax(e));
+      case "final":
+        var ident = getIdent();
+        var tk = token();
+        var t = null;
+        if (tk == TDoubleDot && allowTypes)
+        {
+          t = parseType();
+          tk = token();
+        }
+        var e = null;
+
+        switch (tk)
+        {
+          case TOp("="): e = parseExpr();
+          case TOp(_): unexpected(tk);
+          case TComma | TSemicolon: push(tk);
+          // Above case should be enough but semicolon is not mandatory after }
+          case _ if (t != null): push(tk);
+          default: unexpected(tk);
+        }
+
+        mk(EFinal(ident, t, e), p1, (e == null) ? tokenMax : pmax(e));
+      case "while":
+        var econd = parseExpr();
+        var e = parseExpr();
+        mk(EWhile(econd, e), p1, pmax(e));
+      case "do":
+        var e = parseExpr();
+        var tk = token();
+        switch (tk)
+        {
+          case TId("while"): // Valid
+          default: unexpected(tk);
+        }
+        var econd = parseExpr();
+        mk(EDoWhile(econd, e), p1, pmax(econd));
+      case "for":
+        ensure(TPOpen);
+        var eit = parseExpr();
+        ensure(TPClose);
+        var e = parseExpr();
+        switch (expr(eit))
+        {
+          case EBinop("in", ev, eit):
+            switch (expr(ev))
+            {
+              case EIdent(v):
+                return mk(EFor(v, eit, e), p1, pmax(e));
+              default:
+            }
+          default:
+        }
+        mk(EForGen(eit, e), p1, pmax(e));
+      case "break": mk(EBreak);
+      case "continue": mk(EContinue);
+      case "else": unexpected(TId(id));
+      case "inline":
+        if (!maybe(TId("function"))) unexpected(TId("inline"));
+        return parseStructure("function");
+      case "function":
+        var tk = token();
+        var name = null;
+        switch (tk)
+        {
+          case TId(id): name = id;
+          default: push(tk);
+        }
+        var inf = parseFunctionDecl();
+        mk(EFunction(inf.args, inf.body, name, inf.ret), p1, pmax(inf.body));
+      case "return":
+        var tk = token();
+        push(tk);
+        var e = if (tk == TSemicolon) null else parseExpr();
+        mk(EReturn(e), p1, if (e == null) tokenMax else pmax(e));
+      case "new":
+        var a = new Array();
+        a.push(getIdent());
+        while (true)
+        {
+          var tk = token();
+          switch (tk)
+          {
+            case TDot:
+              a.push(getIdent());
+            case TPOpen:
+              break;
+            default:
+              unexpected(tk);
+              break;
+          }
+        }
+        var args = parseExprList(TPClose);
+        mk(ENew(a.join("."), args), p1);
+      case "throw":
+        var e = parseExpr();
+        mk(EThrow(e), p1, pmax(e));
+      case "try":
+        var e = parseExpr();
+        ensureToken(TId("catch"));
+        ensure(TPOpen);
+        var vname = getIdent();
+        ensure(TDoubleDot);
+        var t = null;
+        if (allowTypes) t = parseType();
+        else
+          ensureToken(TId("Dynamic"));
+        ensure(TPClose);
+        var ec = parseExpr();
+        mk(ETry(e, vname, t, ec), p1, pmax(ec));
+      case "switch":
+        var e = parseExpr();
+        var def = null, cases = [];
+        ensure(TBrOpen);
+        while (true)
+        {
+          var tk = token();
+          switch (tk)
+          {
+            case TId("case"):
+              var c = {values: [], expr: null};
+              cases.push(c);
+              while (true)
+              {
+                var e = parseExpr();
+                c.values.push(e);
+                tk = token();
+                switch (tk)
+                {
+                  case TComma:
+                    // next expr
+                  case TDoubleDot:
+                    break;
+                  default:
+                    unexpected(tk);
+                    break;
+                }
+              }
+              var exprs = [];
+              while (true)
+              {
+                tk = token();
+                push(tk);
+                switch (tk)
+                {
+                  case TId("case"), TId("default"), TBrClose:
+                    break;
+                  case TEof if (resumeErrors):
+                    break;
+                  default:
+                    parseFullExpr(exprs);
+                }
+              }
+              c.expr = if (exprs.length == 1) exprs[0]; else if (exprs.length == 0) mk(EBlock([]), tokenMin,
+                tokenMin); else mk(EBlock(exprs), pmin(exprs[0]), pmax(exprs[exprs.length - 1]));
+            case TId("default"):
+              if (def != null) unexpected(tk);
+              ensure(TDoubleDot);
+              var exprs = [];
+              while (true)
+              {
+                tk = token();
+                push(tk);
+                switch (tk)
+                {
+                  case TId("case"), TId("default"), TBrClose:
+                    break;
+                  case TEof if (resumeErrors):
+                    break;
+                  default:
+                    parseFullExpr(exprs);
+                }
+              }
+              def = if (exprs.length == 1) exprs[0]; else if (exprs.length == 0) mk(EBlock([]), tokenMin,
+                tokenMin); else mk(EBlock(exprs), pmin(exprs[0]), pmax(exprs[exprs.length - 1]));
+            case TBrClose:
+              break;
+            default:
+              unexpected(tk);
+              break;
+          }
+        }
+        mk(ESwitch(e, cases, def), p1, tokenMax);
+      default:
+        null;
+    }
+  }
+
+  function parseExprNext(e1:Expr)
+  {
+    var tk = token();
+    switch (tk)
+    {
+      case TOp(op):
+        if (op == "->")
+        {
+          // single arg reinterpretation of `f -> e` , `(f) -> e` and `(f:T) -> e`
+          switch (expr(e1))
+          {
+            case EIdent(i), EParent(expr(_) => EIdent(i)):
+              var eret = parseExpr();
+              return mk(EFunction([
+                {name: i}], mk(EReturn(eret), pmin(eret))), pmin(e1));
+            case ECheckType(expr(_) => EIdent(i), t):
+              var eret = parseExpr();
+              return mk(EFunction([
+                {name: i, t: t}], mk(EReturn(eret), pmin(eret))), pmin(e1));
+            default:
+          }
+          unexpected(tk);
+        }
+
+        if (opPriority.get(op) == -1)
+        {
+          if (isBlock(e1) || switch (expr(e1))
+            {
+              case EParent(_): true;
+              default: false;
+            })
+          {
+            push(tk);
+            return e1;
+          }
+          return parseExprNext(mk(EUnop(op, false, e1), pmin(e1)));
+        }
+        return makeBinop(op, e1, parseExpr());
+      case TId(op) if (opPriority.exists(op)):
+        return parseExprNext(makeBinop(op, e1, parseExpr()));
+      case TDot:
+        var field = getIdent();
+        return parseExprNext(mk(EField(e1, field), pmin(e1)));
+      case TQuestionDot:
+        var field = getIdent();
+        var tmp = "__a_" + (uid++);
+        var t = token();
+        inline function pushBack()
+        {
+          push(t);
+          return null;
+        }
+        var eOp = switch (t)
+        {
+          case TOp(s): if (!opRightAssoc.exists(s)) pushBack(); else s;
+          case TPOpen: '';
+          default: pushBack();
+        }
+
+        if (eOp != null && eOp.length > 0)
+        {
+          var e2 = parseExpr();
+          var e = mk(EBlock([
+            mk(EVar(tmp, null, e1)),
+            mk(ETernary(mk(EBinop("!=", mk(EIdent(tmp), pmin(e1), pmax(e1)), mk(EIdent("null"), pmin(e1), pmax(e1))), pmin(e1), pmax(e1)),
+              mk(EBinop(eOp, mk(EField(mk(EIdent(tmp), pmin(e1), pmax(e1)), field), pmin(e1), pmax(e1)), e2), pmin(e1), pmax(e2)),
+              mk(EIdent("null"), pmin(e2), pmax(e2))),
+              pmin(e1), pmax(e2))
+          ]), pmin(e1));
+          return parseExprNext(e);
+        }
+
+        var e = mk(EBlock([
+          mk(EVar(tmp, null, e1), pmin(e1), pmax(e1)),
+          mk(ETernary(mk(EBinop("==", mk(EIdent(tmp), pmin(e1), pmax(e1)), mk(EIdent("null"), pmin(e1), pmax(e1)))), mk(EIdent("null"), pmin(e1), pmax(e1)),
+            (eOp != null && eOp.length == 0) ? mk(ECall(mk(EField(mk(EIdent(tmp), pmin(e1), pmax(e1)), field), pmin(e1)), parseExprList(TPClose)),
+              pmin(e1)) : mk(EField(mk(EIdent(tmp), pmin(e1), pmax(e1)), field), pmin(e1))))
+        ]), pmin(e1));
+
+        return parseExprNext(e);
+      case TPOpen:
+        return parseExprNext(mk(ECall(e1, parseExprList(TPClose)), pmin(e1)));
+      case TBkOpen:
+        var e2 = parseExpr();
+        ensure(TBkClose);
+        return parseExprNext(mk(EArray(e1, e2), pmin(e1)));
+      case TQuestion:
+        var e2 = parseExpr();
+        ensure(TDoubleDot);
+        var e3 = parseExpr();
+        return mk(ETernary(e1, e2, e3), pmin(e1), pmax(e3));
+      default:
+        push(tk);
+        return e1;
+    }
+  }
+
+  function parseFunctionArgs()
+  {
+    var args = new Array();
+    var tk = token();
+    if (tk != TPClose)
+    {
+      var done = false;
+      while (!done)
+      {
+        var name = null, opt = false;
+        switch (tk)
+        {
+          case TQuestion:
+            opt = true;
+            tk = token();
+          default:
+        }
+        switch (tk)
+        {
+          case TId(id):
+            name = id;
+          default:
+            unexpected(tk);
+            break;
+        }
+        var arg:Argument = {name: name};
+        args.push(arg);
+        if (opt) arg.opt = true;
+        if (allowTypes)
+        {
+          if (maybe(TDoubleDot)) arg.t = parseType();
+          if (maybe(TOp("="))) arg.value = parseExpr();
+        }
+        tk = token();
+        switch (tk)
+        {
+          case TComma:
+            tk = token();
+          case TPClose:
+            done = true;
+          default:
+            unexpected(tk);
+        }
+      }
+    }
+    return args;
+  }
+
+  function parseFunctionDecl()
+  {
+    ensure(TPOpen);
+    var args = parseFunctionArgs();
+    var ret = null;
+    if (allowTypes)
+    {
+      var tk = token();
+      if (tk != TDoubleDot) push(tk);
+      else
+        ret = parseType();
+    }
+    return {args: args, ret: ret, body: parseExpr()};
+  }
+
+  function parsePath()
+  {
+    var path = [getIdent()];
+    while (true)
+    {
+      var t = token();
+      if (t != TDot)
+      {
+        push(t);
+        break;
+      }
+      path.push(getIdent());
+    }
+    return path;
+  }
+
+  function parseType():CType
+  {
+    var t = token();
+    switch (t)
+    {
+      case TId(v):
+        push(t);
+        var path = parsePath();
+        var params = null;
+        t = token();
+        switch (t)
+        {
+          case TOp(op):
+            if (op == "<")
+            {
+              params = [];
+              while (true)
+              {
+                switch (token())
+                {
+                  case TConst(c):
+                    params.push(CTExpr(mk(EConst(c))));
+                  case tk:
+                    push(tk);
+                    params.push(parseType());
+                }
+                t = token();
+                switch (t)
+                {
+                  case TComma: continue;
+                  case TOp(op):
+                    if (op == ">") break;
+                    if (op.charCodeAt(0) == ">".code)
+                    {
+                      #if hscriptPos
+                      tokens.add({t: TOp(op.substr(1)), min: tokenMax - op.length - 1, max: tokenMax});
+                      #else
+                      tokens.add(TOp(op.substr(1)));
+                      #end
+                      break;
+                    }
+                  default:
+                }
+                unexpected(t);
+                break;
+              }
+            }
+            else push(t);
+          default:
+            push(t);
+        }
+        return parseTypeNext(CTPath(path, params));
+      case TPOpen:
+        var a = token();
+        var b = token();
+
+        push(b);
+        push(a);
+
+        function withReturn(args)
+        {
+          switch token()
+          { // I think it wouldn't hurt if ensure used enumEq
+            case TOp('->'):
+            case t:
+              unexpected(t);
+          }
+
+          return CTFun(args, parseType());
+        }
+
+        switch [a, b]
+        {
+          case [TPClose, _] | [TId(_), TDoubleDot]:
+            var args = [
+              for (arg in parseFunctionArgs())
+              {
+                switch arg.value
+                {
+                  case null:
+                  case v:
+                    error(ECustom('Default values not allowed in function types'), #if hscriptPos v.pmin, v.pmax #else 0, 0 #end);
+                }
+
+                CTNamed(arg.name, if (arg.opt) CTOpt(arg.t) else arg.t);
+              }
+            ];
+
+            return withReturn(args);
+          default:
+            var t = parseType();
+            return switch token()
+            {
+              case TComma:
+                var args = [t];
+
+                while (true)
+                {
+                  args.push(parseType());
+                  if (!maybe(TComma)) break;
+                }
+                ensure(TPClose);
+                withReturn(args);
+              case TPClose:
+                parseTypeNext(CTParent(t));
+              case t: unexpected(t);
+            }
+        }
+      case TBrOpen:
+        var fields = [];
+        var meta = null;
+        while (true)
+        {
+          t = token();
+          switch (t)
+          {
+            case TBrClose: break;
+            case TId("var"), TId("final"):
+              var name = getIdent();
+              ensure(TDoubleDot);
+              if (t.match(TId("final")))
+              {
+                if (meta == null) meta = [];
+                meta.push({name: ":final", params: []});
+              }
+              fields.push({name: name, t: parseType(), meta: meta});
+              meta = null;
+              ensure(TSemicolon);
+            case TId(name):
+              ensure(TDoubleDot);
+              fields.push({name: name, t: parseType(), meta: meta});
+              t = token();
+              switch (t)
+              {
+                case TComma:
+                case TBrClose: break;
+                default: unexpected(t);
+              }
+            case TMeta(name):
+              if (meta == null) meta = [];
+              meta.push({name: name, params: parseMetaArgs()});
+            default:
+              unexpected(t);
+              break;
+          }
+        }
+        return parseTypeNext(CTAnon(fields));
+      default:
+        return unexpected(t);
+    }
+  }
+
+  function parseTypeNext(t:CType)
+  {
+    var tk = token();
+    switch (tk)
+    {
+      case TOp(op):
+        if (op != "->")
+        {
+          push(tk);
+          return t;
+        }
+      default:
+        push(tk);
+        return t;
+    }
+    var t2 = parseType();
+    switch (t2)
+    {
+      case CTFun(args, _):
+        args.unshift(t);
+        return t2;
+      default:
+        return CTFun([t], t2);
+    }
+  }
+
+  function parseExprList(etk)
+  {
+    var args = new Array();
+    var tk = token();
+    if (tk == etk) return args;
+    push(tk);
+    while (true)
+    {
+      args.push(parseExpr());
+      tk = token();
+      switch (tk)
+      {
+        case TComma:
+        default:
+          if (tk == etk) break;
+          unexpected(tk);
+          break;
+      }
+    }
+    return args;
+  }
+
+  // ------------------------ module -------------------------------
+
+  public function parseModule(content:String, ?origin:String = "hscript", ?position = 0)
+  {
+    initParser(origin, position);
+    input = content;
+    readPos = 0;
+    allowTypes = true;
+    allowMetadata = true;
+    var decls = [];
+    while (true)
+    {
+      var tk = token();
+      if (tk == TEof) break;
+      push(tk);
+      decls.push(parseModuleDecl());
+    }
+    return decls;
+  }
+
+  function parseMetadata():Metadata
+  {
+    var meta = [];
+    while (true)
+    {
+      var tk = token();
+      switch (tk)
+      {
+        case TMeta(name):
+          meta.push({name: name, params: parseMetaArgs()});
+        default:
+          push(tk);
+          break;
+      }
+    }
+    return meta;
+  }
+
+  function parseParams()
+  {
+    if (maybe(TOp("<"))) error(EInvalidOp("Unsupported class type parameters"), currentPos, currentPos);
+    return {};
+  }
+
+  function parseModuleDecl():ModuleDecl
+  {
+    var meta = parseMetadata();
+    var ident = getIdent();
+    var isPrivate = false, isExtern = false;
+    while (true)
+    {
+      switch (ident)
+      {
+        case "private":
+          isPrivate = true;
+        case "extern":
+          isExtern = true;
+        default:
+          break;
+      }
+      ident = getIdent();
+    }
+    switch (ident)
+    {
+      case "package":
+        var path = parsePath();
+        ensure(TSemicolon);
+        return DPackage(path);
+      case "import":
+        var path = [getIdent()];
+        var star = false;
+        while (true)
+        {
+          var t = token();
+          if (t != TDot)
+          {
+            push(t);
+            break;
+          }
+          t = token();
+          switch (t)
+          {
+            case TId(id):
+              path.push(id);
+            case TOp("*"):
+              star = true;
+            default:
+              unexpected(t);
+          }
+        }
+        var name = null;
+        if (maybe(TId("as")) && !star)
+        {
+          var t = token();
+          switch (t)
+          {
+            case TId(id):
+              name = id;
+            default:
+              unexpected(t);
+          }
+        }
+        ensure(TSemicolon);
+        return DImport(path, star, name);
+      case "using":
+        var path = [getIdent()];
+        while (true)
+        {
+          var t = token();
+          if (t != TDot)
+          {
+            push(t);
+            break;
+          }
+          t = token();
+          switch (t)
+          {
+            case TId(id):
+              path.push(id);
+            default:
+              unexpected(t);
+          }
+        }
+        ensure(TSemicolon);
+        return DUsing(path);
+      case "class":
+        var name = getIdent();
+        var params = parseParams();
+        var extend = null;
+        var implement = [];
+
+        while (true)
+        {
+          var t = token();
+          switch (t)
+          {
+            case TId("extends"):
+              extend = parseType();
+            case TId("implements"):
+              implement.push(parseType());
+            default:
+              push(t);
+              break;
+          }
+        }
+
+        var fields = [];
+        ensure(TBrOpen);
+        while (!maybe(TBrClose))
+          fields.push(parseField());
+
+        return DClass(
+          {
+            name: name,
+            meta: meta,
+            params: params,
+            extend: extend,
+            implement: implement,
+            fields: fields,
+            isPrivate: isPrivate,
+            isExtern: isExtern,
+          });
+      case "typedef":
+        var name = getIdent();
+        var params = parseParams();
+        ensureToken(TOp("="));
+        var t = parseType();
+        return DTypedef(
+          {
+            name: name,
+            meta: meta,
+            params: params,
+            isPrivate: isPrivate,
+            t: t,
+          });
+      case "enum":
+        var name = getIdent();
+
+        var fields = [];
+        ensure(TBrOpen);
+        while (!maybe(TBrClose))
+        {
+          fields.push(parseEnumField());
+          ensure(TSemicolon);
+        }
+
+        return DEnum(
+          {
+            name: name,
+            fields: fields
+          });
+      default:
+        unexpected(TId(ident));
+    }
+    return null;
+  }
+
+  function parseField():FieldDecl
+  {
+    var meta = parseMetadata();
+    var access = [];
+    while (true)
+    {
+      var id = getIdent();
+      switch (id)
+      {
+        case "override":
+          access.push(AOverride);
+        case "public":
+          access.push(APublic);
+        case "private":
+          access.push(APrivate);
+        case "inline":
+          access.push(AInline);
+        case "static":
+          access.push(AStatic);
+        case "macro":
+          access.push(AMacro);
+        case "function":
+          var name = getIdent();
+          var inf = parseFunctionDecl();
+          return {
+            name: name,
+            meta: meta,
+            access: access,
+            kind: KFunction(
+              {
+                args: inf.args,
+                expr: inf.body,
+                ret: inf.ret,
+              }),
+          };
+        case "var", "final":
+          var name = getIdent();
+          var get = null, set = null;
+          if (maybe(TPOpen))
+          {
+            get = getIdent();
+            ensure(TComma);
+            set = getIdent();
+            ensure(TPClose);
+          }
+          var type = maybe(TDoubleDot) ? parseType() : null;
+          var expr = maybe(TOp("=")) ? parseExpr() : null;
+
+          if (expr != null)
+          {
+            if (isBlock(expr)) maybe(TSemicolon);
+            else
+              ensure(TSemicolon);
+          }
+          else if (type != null && type.match(CTAnon(_)))
+          {
+            maybe(TSemicolon);
+          }
+          else
+            ensure(TSemicolon);
+
+          return {
+            name: name,
+            meta: meta,
+            access: access,
+            kind: KVar(
+              {
+                get: get,
+                set: set,
+                type: type,
+                expr: expr,
+                isfinal: (id == "final")
+              }),
+          };
+        default:
+          unexpected(TId(id));
+          break;
+      }
+    }
+    return null;
+  }
+
+  function parseEnumField():EnumFieldDecl
+  {
+    var name = getIdent();
+
+    var args = [];
+    if (maybe(TPOpen))
+    {
+      while (!maybe(TPClose))
+        args.push(parseEnumArg());
+    }
+
+    return {
+      name: name,
+      args: args
+    };
+  }
+
+  function parseEnumArg():EnumArgDecl
+  {
+    var name = getIdent();
+    var type = maybe(TDoubleDot) ? parseType() : null;
+
+    return {
+      name: name,
+      type: type
+    };
+  }
+
+  // ------------------------ lexing -------------------------------
+
+  inline function readChar()
+  {
+    return StringTools.fastCodeAt(input, readPos++);
+  }
+
+  function readString(until)
+  {
+    var c = 0;
+    var b = new StringBuf();
+    var esc = false;
+    var old = line;
+    var s = input;
+    #if hscriptPos
+    var p1 = currentPos - 1;
+    #end
+    while (true)
+    {
+      var c = readChar();
+      if (StringTools.isEof(c))
+      {
+        line = old;
+        error(EUnterminatedString, p1, p1);
+        break;
+      }
+      if (esc)
+      {
+        esc = false;
+        switch (c)
+        {
+          case 'n'.code:
+            b.addChar('\n'.code);
+          case 'r'.code:
+            b.addChar('\r'.code);
+          case 't'.code:
+            b.addChar('\t'.code);
+          case "'".code, '"'.code, '\\'.code:
+            b.addChar(c);
+          case '/'.code:
+            if (allowJSON) b.addChar(c)
+            else
+              invalidChar(c);
+          case "u".code:
+            if (!allowJSON) invalidChar(c);
+            var k = 0;
+            for (i in 0...4)
+            {
+              k <<= 4;
+              var char = readChar();
+              switch (char)
+              {
+                case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57: // 0-9
+                  k += char - 48;
+                case 65, 66, 67, 68, 69, 70: // A-F
+                  k += char - 55;
+                case 97, 98, 99, 100, 101, 102: // a-f
+                  k += char - 87;
+                default:
+                  if (StringTools.isEof(char))
+                  {
+                    line = old;
+                    error(EUnterminatedString, p1, p1);
+                  }
+                  invalidChar(char);
+              }
+            }
+            b.addChar(k);
+          default:
+            invalidChar(c);
+        }
+      }
+      else if (c == 92) esc = true;
+      else if (c == until) break;
+      else
+      {
+        if (c == 10) line++;
+        b.addChar(c);
+      }
+    }
+    return b.toString();
+  }
+
+  function token()
+  {
+  #if hscriptPos
+  var t = tokens.pop();
+  if (t != null)
+  {
+    tokenMin = t.min;
+    tokenMax = t.max;
+    return t.t;
+  }
+  oldTokenMin = tokenMin;
+  oldTokenMax = tokenMax;
+  tokenMin = (this.char < 0) ? currentPos : currentPos - 1;
+  var t = _token();
+  tokenMax = (this.char < 0) ? currentPos - 1 : currentPos - 2;
+  return t;
+  } function _token()
+
+  {
+  #else
+  if (!tokens.isEmpty()) return tokens.pop();
+  #end
+    var char;
+    if (this.char < 0) char = readChar();
+    else
+    {
+      char = this.char;
+      this.char = -1;
+    }
+    while (true)
+    {
+      if (StringTools.isEof(char))
+      {
+        this.char = char;
+        return TEof;
+      }
+      switch (char)
+      {
+        case 0:
+          return TEof;
+        case 32, 9, 13: // space, tab, CR
+          #if hscriptPos
+          tokenMin++;
+          #end
+        case 10:
+          line++; // LF
+          #if hscriptPos
+          tokenMin++;
+          #end
+        case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57: // 0...9
+          var n = (char - 48) * 1.0;
+          var exp = 0.;
+          while (true)
+          {
+            char = readChar();
+            exp *= 10;
+            switch (char)
+            {
+              case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57:
+                n = n * 10 + (char - 48);
+              case "e".code, "E".code:
+                var tk = token();
+                var pow:Null<Int> = null;
+                switch (tk)
+                {
+                  case TConst(CInt(e)): pow = e;
+                  case TOp("-"):
+                    tk = token();
+                    switch (tk)
+                    {
+                      case TConst(CInt(e)): pow = -e;
+                      default: push(tk);
+                    }
+                  default:
+                    push(tk);
+                }
+                if (pow == null) invalidChar(char);
+                if (exp == 0) exp = 10;
+                return TConst(CFloat((Math.pow(10, pow) / exp) * n * 10));
+              case ".".code:
+                if (exp > 0)
+                {
+                  // in case of '0...'
+                  if (exp == 10 && readChar() == ".".code)
+                  {
+                    push(TOp("..."));
+                    var i = Std.int(n);
+                    return TConst((i == n) ? CInt(i) : CFloat(n));
+                  }
+                  invalidChar(char);
+                }
+                exp = 1.;
+              case "x".code:
+                if (n > 0 || exp > 0) invalidChar(char);
+                // read hexa
+                var n = 0;
+                while (true)
+                {
+                  char = readChar();
+                  switch (char)
+                  {
+                    case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57: // 0-9
+                      n = (n << 4) + char - 48;
+                    case 65, 66, 67, 68, 69, 70: // A-F
+                      n = (n << 4) + (char - 55);
+                    case 97, 98, 99, 100, 101, 102: // a-f
+                      n = (n << 4) + (char - 87);
+                    default:
+                      this.char = char;
+                      return TConst(CInt(n));
+                  }
+                }
+              default:
+                this.char = char;
+                var i = Std.int(n);
+                return TConst((exp > 0) ? CFloat(n * 10 / exp) : ((i == n) ? CInt(i) : CFloat(n)));
+            }
+          }
+        case ";".code:
+          return TSemicolon;
+        case "(".code:
+          return TPOpen;
+        case ")".code:
+          return TPClose;
+        case ",".code:
+          return TComma;
+        case ".".code:
+          char = readChar();
+          switch (char)
+          {
+            case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57:
+              var n = char - 48;
+              var exp = 1;
+              while (true)
+              {
+                char = readChar();
+                exp *= 10;
+                switch (char)
+                {
+                  case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57:
+                    n = n * 10 + (char - 48);
+                  default:
+                    this.char = char;
+                    return TConst(CFloat(n / exp));
+                }
+              }
+            case ".".code:
+              char = readChar();
+              if (char != ".".code) invalidChar(char);
+              return TOp("...");
+            default:
+              this.char = char;
+              return TDot;
+          }
+        case "{".code:
+          return TBrOpen;
+        case "}".code:
+          return TBrClose;
+        case "[".code:
+          return TBkOpen;
+        case "]".code:
+          return TBkClose;
+        case "'".code, '"'.code:
+          return TConst(CString(readString(char)));
+        case "?".code:
+          char = readChar();
+          if (char == ".".code) return TQuestionDot;
+          if (char == "?".code)
+          {
+            char = readChar();
+            if (char == "=".code) return TOp("??" + "=");
+            return TOp("??");
+          }
+          this.char = char;
+          return TQuestion;
+        case ":".code:
+          return TDoubleDot;
+        case '='.code:
+          char = readChar();
+          if (char == '='.code) return TOp("==");
+          else if (char == '>'.code) return TOp("=>");
+          this.char = char;
+          return TOp("=");
+        case '@'.code:
+          char = readChar();
+          if (idents[char] || char == ':'.code)
+          {
+            var id = String.fromCharCode(char);
+            while (true)
+            {
+              char = readChar();
+              if (!idents[char])
+              {
+                this.char = char;
+                return TMeta(id);
+              }
+              id += String.fromCharCode(char);
+            }
+          }
+          invalidChar(char);
+        case '#'.code:
+          char = readChar();
+          if (idents[char])
+          {
+            var id = String.fromCharCode(char);
+            while (true)
+            {
+              char = readChar();
+              if (!idents[char])
+              {
+                this.char = char;
+                return preprocess(id);
+              }
+              id += String.fromCharCode(char);
+            }
+          }
+          invalidChar(char);
+        default:
+          if (ops[char])
+          {
+            var op = String.fromCharCode(char);
+            while (true)
+            {
+              char = readChar();
+              if (StringTools.isEof(char)) char = 0;
+              if (!ops[char])
+              {
+                this.char = char;
+                return TOp(op);
+              }
+              var pop = op;
+              op += String.fromCharCode(char);
+              if (!opPriority.exists(op) && opPriority.exists(pop))
+              {
+                if (op == "//" || op == "/*") return tokenComment(op, char);
+                this.char = char;
+                return TOp(pop);
+              }
+            }
+          }
+          if (idents[char])
+          {
+            var id = String.fromCharCode(char);
+            while (true)
+            {
+              char = readChar();
+              if (StringTools.isEof(char)) char = 0;
+              if (!idents[char])
+              {
+                this.char = char;
+                return TId(id);
+              }
+              id += String.fromCharCode(char);
+            }
+          }
+          invalidChar(char);
+      }
+      char = readChar();
+    }
+    return null;
+  }
+
+  function preprocValue(id:String):Dynamic
+  {
+    return preprocesorValues.get(id);
+  }
+
+  var preprocStack:Array<{r:Bool}>;
+
+  function parsePreproCond()
+  {
+    var tk = token();
+    return switch (tk)
+    {
+      case TPOpen:
+        push(TPOpen);
+        parseExpr();
+      case TId(id):
+        mk(EIdent(id), tokenMin, tokenMax);
+      case TOp("!"):
+        mk(EUnop("!", true, parsePreproCond()), tokenMin, tokenMax);
+      default:
+        unexpected(tk);
+    }
+  }
+
+  function evalPreproCond(e:Expr)
+  {
+    switch (expr(e))
+    {
+      case EIdent(id):
+        return preprocValue(id) != null;
+      case EUnop("!", _, e):
+        return !evalPreproCond(e);
+      case EParent(e):
+        return evalPreproCond(e);
+      case EBinop("&&", e1, e2):
+        return evalPreproCond(e1) && evalPreproCond(e2);
+      case EBinop("||", e1, e2):
+        return evalPreproCond(e1) || evalPreproCond(e2);
+      default:
+        error(EInvalidPreprocessor("Can't eval " + expr(e).getName()), currentPos, currentPos);
+        return false;
+    }
+  }
+
+  function preprocess(id:String):Token
+  {
+    switch (id)
+    {
+      case "if":
+        var e = parsePreproCond();
+        if (evalPreproCond(e))
+        {
+          preprocStack.push({r: true});
+          return token();
+        }
+        preprocStack.push({r: false});
+        skipTokens();
+        return token();
+      case "else", "elseif" if (preprocStack.length > 0):
+        if (preprocStack[preprocStack.length - 1].r)
+        {
+          preprocStack[preprocStack.length - 1].r = false;
+          skipTokens();
+          return token();
+        }
+        else if (id == "else")
+        {
+          preprocStack.pop();
+          preprocStack.push({r: true});
+          return token();
+        }
+        else
+        {
+          // elseif
+          preprocStack.pop();
+          return preprocess("if");
+        }
+      case "end" if (preprocStack.length > 0):
+        preprocStack.pop();
+        return token();
+      default:
+        return TPrepro(id);
+    }
+  }
+
+  function skipTokens()
+  {
+    var spos = preprocStack.length - 1;
+    var obj = preprocStack[spos];
+    var pos = currentPos;
+    while (true)
+    {
+      var tk = token();
+      if (tk == TEof) error(EInvalidPreprocessor("Unclosed"), pos, pos);
+      if (preprocStack[spos] != obj)
+      {
+        push(tk);
+        break;
+      }
+    }
+  }
+
+  function tokenComment(op:String, char:Int)
+  {
+    var c = op.charCodeAt(1);
+    var s = input;
+    if (c == '/'.code)
+    { // comment
+      while (char != '\r'.code && char != '\n'.code)
+      {
+        char = readChar();
+        if (StringTools.isEof(char)) break;
+      }
+      this.char = char;
+      return token();
+    }
+    if (c == '*'.code)
+    {/* comment */
+      var old = line;
+      if (op == "/**/")
+      {
+        this.char = char;
+        return token();
+      }
+      while (true)
+      {
+        while (char != '*'.code)
+        {
+          if (char == '\n'.code) line++;
+          char = readChar();
+          if (StringTools.isEof(char))
+          {
+            line = old;
+            error(EUnterminatedComment, tokenMin, tokenMin);
+            break;
+          }
+        }
+        char = readChar();
+        if (StringTools.isEof(char))
+        {
+          line = old;
+          error(EUnterminatedComment, tokenMin, tokenMin);
+          break;
+        }
+        if (char == '/'.code) break;
+      }
+      return token();
+    }
+    this.char = char;
+    return TOp(op);
+  }
+
+  function constString(c)
+  {
+    return switch (c)
+    {
+      case CInt(v): Std.string(v);
+      case CFloat(f): Std.string(f);
+      case CString(s): s; // TODO : escape + quote
+    }
+  }
+
+  function tokenString(t)
+  {
+    return switch (t)
+    {
+      case TEof: "<eof>";
+      case TConst(c): constString(c);
+      case TId(s): s;
+      case TOp(s): s;
+      case TPOpen: "(";
+      case TPClose: ")";
+      case TBrOpen: "{";
+      case TBrClose: "}";
+      case TDot: ".";
+      case TQuestionDot: "?.";
+      case TComma: ",";
+      case TSemicolon: ";";
+      case TBkOpen: "[";
+      case TBkClose: "]";
+      case TQuestion: "?";
+      case TDoubleDot: ":";
+      case TMeta(id): "@" + id;
+      case TPrepro(id): "#" + id;
+    }
+  }
+}

--- a/polymod/hscript/_internal/PolymodClassDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodClassDeclEx.hx
@@ -1,7 +1,7 @@
 package polymod.hscript._internal;
 
-import hscript.Expr.ClassDecl;
-import hscript.Expr.FieldDecl;
+import polymod.hscript._internal.Expr.ClassDecl;
+import polymod.hscript._internal.Expr.FieldDecl;
 import polymod.hscript._internal.PolymodScriptClass;
 
 /**

--- a/polymod/hscript/_internal/PolymodEnum.hx
+++ b/polymod/hscript/_internal/PolymodEnum.hx
@@ -1,11 +1,10 @@
 package polymod.hscript._internal;
 
-#if hscript
-import hscript.Expr;
+import polymod.hscript._internal.Expr;
 
 @:access(hscript.Interp)
 @:allow(polymod.Polymod)
-class PolymodEnum 
+class PolymodEnum
 {
   private static final scriptInterp = new PolymodInterpEx(null, null);
 
@@ -15,13 +14,13 @@ class PolymodEnum
 
   private var _args:Array<Dynamic>;
 
-  public function new(e:PolymodEnumDeclEx, value:String, args:Array<Dynamic>) 
+  public function new(e:PolymodEnumDeclEx, value:String, args:Array<Dynamic>)
   {
     this._e = e;
 
     var field = getField(value);
 
-    if (field == null) 
+    if (field == null)
     {
       Polymod.error(SCRIPT_PARSE_ERROR, '${e.name}.${value} does not exist.');
       return;
@@ -29,7 +28,7 @@ class PolymodEnum
 
     this._value = value;
 
-    if (args.length != field.args.length) 
+    if (args.length != field.args.length)
     {
       Polymod.error(SCRIPT_PARSE_ERROR, '${e.name}.${value} got the wrong number of arguments.');
       return;
@@ -38,16 +37,16 @@ class PolymodEnum
     this._args = args;
   }
 
-  public static function clearScriptedEnums():Void 
+  public static function clearScriptedEnums():Void
   {
     scriptInterp.clearScriptEnumDescriptors();
   }
 
-  private function getField(name:String):Null<EnumFieldDecl> 
+  private function getField(name:String):Null<EnumFieldDecl>
   {
-    for (field in _e.fields) 
+    for (field in _e.fields)
       {
-        if (field.name == name) 
+        if (field.name == name)
         {
           return field;
         }
@@ -55,7 +54,7 @@ class PolymodEnum
       return null;
   }
 
-  public function toString():String 
+  public function toString():String
   {
     var result:String = '${_e.name}.${_value}';
     if(_args.length > 0)
@@ -63,4 +62,3 @@ class PolymodEnum
     return result;
   }
 }
-#end

--- a/polymod/hscript/_internal/PolymodEnumDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodEnumDeclEx.hx
@@ -1,13 +1,10 @@
 package polymod.hscript._internal;
 
-#if hscript
-import hscript.Expr;
+import polymod.hscript._internal.Expr;
 
-typedef PolymodEnumDeclEx = 
+typedef PolymodEnumDeclEx =
 {
     > EnumDecl,
-    
+
     @:optional var pkg:Array<String>;
 }
-
-#end

--- a/polymod/hscript/_internal/PolymodExprEx.hx
+++ b/polymod/hscript/_internal/PolymodExprEx.hx
@@ -68,7 +68,7 @@ EScriptCallThrow(v:Dynamic); // Script called a function which threw
 ECustom(msg:String);
 } class ErrorExUtil
 {
-	public static function toErrorEx(err:hscript.Expr.Error):ErrorEx
+	public static function toErrorEx(err:Expr.Error):ErrorEx
 	{
 		#if hscriptPos
 		switch (err.e)

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1,9 +1,7 @@
 package polymod.hscript._internal;
 
-#if hscript
-import hscript.Expr;
-import hscript.Interp;
-import hscript.Tools;
+import polymod.hscript._internal.Expr;
+import polymod.hscript._internal.Printer;
 import polymod.hscript._internal.PolymodExprEx;
 import polymod.hscript._internal.PolymodClassDeclEx.PolymodClassImport;
 import polymod.hscript._internal.PolymodClassDeclEx.PolymodStaticClassReference;
@@ -92,7 +90,7 @@ class PolymodInterpEx extends Interp
 			var packagedClass = getClassDecl().pkg.join(".") + "." + cl;
 			if (_scriptClassDescriptors.exists(packagedClass))
 			{
-				// OVERRIDE CHANGE: Create a PolymodScriptClass instead of a hscript.ScriptClass
+				// OVERRIDE CHANGE: Create a PolymodScriptClass instead of a ScriptClass
 				var proxy:PolymodAbstractScriptClass = new PolymodScriptClass(_scriptClassDescriptors.get(packagedClass), args);
 				return proxy;
 			}
@@ -104,7 +102,7 @@ class PolymodInterpEx extends Interp
 			var importedClass:PolymodClassImport = getClassDecl().imports.get(cl);
 			if (_scriptClassDescriptors.exists(importedClass.fullPath))
 			{
-				// OVERRIDE CHANGE: Create a PolymodScriptClass instead of a hscript.ScriptClass
+				// OVERRIDE CHANGE: Create a PolymodScriptClass instead of a ScriptClass
 				var proxy:PolymodAbstractScriptClass = new PolymodScriptClass(_scriptClassDescriptors.get(importedClass.fullPath), args);
 				return proxy;
 			}
@@ -313,7 +311,7 @@ class PolymodInterpEx extends Interp
 			// Check if the scripted classes extend the right type.
 			if (cls.extend == null) continue;
 
-			var superClassPath:String = new hscript.Printer().typeToString(cls.extend);
+			var superClassPath:String = new Printer().typeToString(cls.extend);
 			if (!cls.imports.exists(superClassPath))
 			{
 				switch (cls.extend)
@@ -706,7 +704,7 @@ class PolymodInterpEx extends Interp
 							PolymodScriptClass.reportErrorEx(err, getClassFullyQualifiedName(), name);
 							r = null;
 						}
-						catch (err:hscript.Expr.Error)
+						catch (err:Expr.Error)
 						{
 							PolymodScriptClass.reportError(err, getClassFullyQualifiedName(), name);
 							r = null;
@@ -931,7 +929,7 @@ class PolymodInterpEx extends Interp
 									#if hscriptPos
 									curExpr = e;
 									#end
-									var error = 'Invalid expression in map initialization (expected key=>value, got ${hscript.Printer.toString(e)})';
+									var error = 'Invalid expression in map initialization (expected key=>value, got ${Printer.toString(e)})';
 									errorEx(ECustom(error));
 								}
 							} else if (last == "Array") {
@@ -946,7 +944,7 @@ class PolymodInterpEx extends Interp
 									#if hscriptPos
 									curExpr = e;
 									#end
-									var error = 'Invalid expression in array initialization (expected no key=>value pairs, got ${hscript.Printer.toString(e)})';
+									var error = 'Invalid expression in array initialization (expected no key=>value pairs, got ${Printer.toString(e)})';
 									errorEx(ECustom(error));
 								}
 							} else {
@@ -982,7 +980,7 @@ class PolymodInterpEx extends Interp
 					#if hscriptPos
 					curExpr = e;
 					#end
-					var error = 'Invalid expression in map initialization (expected key=>value, got ${hscript.Printer.toString(e)})';
+					var error = 'Invalid expression in map initialization (expected key=>value, got ${Printer.toString(e)})';
 					errorEx(ECustom(error));
 			}
 		}
@@ -1007,7 +1005,7 @@ class PolymodInterpEx extends Interp
 				}
 			default:
 				// Whatever.
-				error(ECustom('Invalid key type for empty map initialization (${new hscript.Printer().typeToString(keyType)}).'));
+				error(ECustom('Invalid key type for empty map initialization (${new Printer().typeToString(keyType)}).'));
 		}
 		return super.makeMap([], []);
 	}
@@ -1099,7 +1097,7 @@ class PolymodInterpEx extends Interp
 			{
 				_nextCallObject = null;
 
-				if (Std.isOfType(e, PolymodExprEx.ErrorEx) || Std.isOfType(e, hscript.Expr.Error))
+				if (Std.isOfType(e, PolymodExprEx.ErrorEx) || Std.isOfType(e, polymod.hscript._internal.Expr.Error))
 				{
 					throw e;
 				}
@@ -1145,7 +1143,7 @@ class PolymodInterpEx extends Interp
 			this.declared = capturedDeclared;
 			this.depth = capturedDepth;
 
-			if (Std.isOfType(e, PolymodExprEx.ErrorEx) || Std.isOfType(e, hscript.Expr.Error))
+			if (Std.isOfType(e, PolymodExprEx.ErrorEx) || Std.isOfType(e, polymod.hscript._internal.Expr.Error))
 			{
 				throw e;
 			}
@@ -1171,7 +1169,7 @@ class PolymodInterpEx extends Interp
 			PolymodScriptClass.reportErrorEx(err, getClassFullyQualifiedName());
 			return null;
 		}
-		catch (err:hscript.Expr.Error)
+		catch (err:Expr.Error)
 		{
 			PolymodScriptClass.reportError(err, getClassFullyQualifiedName());
 			return null;
@@ -1370,7 +1368,7 @@ class PolymodInterpEx extends Interp
 	override function exprReturn(expr:Expr):Dynamic
 	{
 		return super.exprReturn(expr);
-		// catch (err:hscript.Expr.Error)
+		// catch (err:Expr.Error)
 		// {
 		// 	#if hscriptPos
 		// 	throw err;
@@ -1605,7 +1603,7 @@ class PolymodInterpEx extends Interp
 				// purgeStaticFunction(fnName);
 				return null;
 			}
-			catch (err:hscript.Expr.Error)
+			catch (err:Expr.Error)
 			{
 				PolymodScriptClass.reportError(err, clsName, fnName);
 				// A script error occurred while executing the script function.
@@ -1989,4 +1987,3 @@ private class ArrayIterator<T>
 		return a[pos++];
 	}
 }
-#end

--- a/polymod/hscript/_internal/PolymodParserEx.hx
+++ b/polymod/hscript/_internal/PolymodParserEx.hx
@@ -1,25 +1,16 @@
 package polymod.hscript._internal;
 
-#if hscript
-import hscript.Parser;
-import hscript.Expr;
+import polymod.hscript._internal.Parser;
+import polymod.hscript._internal.Expr;
 
 #if hscript_typer
 @:access(polymod.hscript._internal.PolymodTyperEx)
 #end
 class PolymodParserEx extends Parser
 {
-	#if (hscript > "2.5.0")
-	public override function parseModule(content:String, ?origin:String = "hscript", ?position = 0)
-	#else
-	public override function parseModule(content:String, ?origin:String = "hscript")
-	#end
+  public override function parseModule(content:String, ?origin:String = "hscript", ?position = 0)
 	{
-		#if (hscript > "2.5.0")
 		var decls:Array<ModuleDecl> = super.parseModule(content, origin, position);
-		#else
-		var decls:Array<ModuleDecl> = super.parseModule(content, origin);
-		#end
 		#if hscript_typer
 		PolymodTyperEx.allModules.push({
 			decls: decls,
@@ -30,4 +21,3 @@ class PolymodParserEx extends Parser
 		return decls;
 	}
 }
-#end

--- a/polymod/hscript/_internal/PolymodPrinterEx.hx
+++ b/polymod/hscript/_internal/PolymodPrinterEx.hx
@@ -1,6 +1,6 @@
 package polymod.hscript._internal;
 
-import hscript.Printer;
+import polymod.hscript._internal.Printer;
 
 class PolymodPrinterEx extends Printer
 {

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -1,11 +1,10 @@
 package polymod.hscript._internal;
 
-#if hscript
 import haxe.ds.ObjectMap;
-import hscript.Expr.FieldDecl;
-import hscript.Expr.FunctionDecl;
-import hscript.Expr.VarDecl;
-import hscript.Printer;
+import polymod.hscript._internal.Expr.FieldDecl;
+import polymod.hscript._internal.Expr.FunctionDecl;
+import polymod.hscript._internal.Expr.VarDecl;
+import polymod.hscript._internal.Printer;
 import polymod.hscript._internal.PolymodClassDeclEx;
 import polymod.util.Util;
 
@@ -16,7 +15,7 @@ using StringTools;
  * Based on code by Ian Harrigan
  * @see https://github.com/ianharrigan/hscript-ex
  */
-@:access(hscript.Interp)
+@:access(polymod.hscript._internal.Interp)
 @:allow(polymod.Polymod)
 class PolymodScriptClass
 {
@@ -159,7 +158,7 @@ class PolymodScriptClass
 					default:
 						Polymod.error(SCRIPT_PARSE_ERROR, 'Error while executing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}');
 				}
-			} catch (err:hscript.Expr.Error) {
+			} catch (err:Expr.Error) {
 				var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
 				#if hscriptPos
 				switch (err.e)
@@ -288,7 +287,7 @@ class PolymodScriptClass
 		}
 
 		// Get the super class name.
-		var fullSuperClsName = (new hscript.Printer()).typeToString(classDecl.extend);
+		var fullSuperClsName = (new Printer()).typeToString(classDecl.extend);
 		var baseSuperClsName = switch(classDecl.extend) {
 			case CTPath(pth, params):
 				pth[pth.length - 1];
@@ -467,7 +466,7 @@ class PolymodScriptClass
 			args = [];
 		}
 
-		var fullExtendString = new hscript.Printer().typeToString(_c.extend);
+		var fullExtendString = new Printer().typeToString(_c.extend);
 
 		// Templates are ignored completely since there's no type checking in HScript.
 		if (fullExtendString.indexOf('<') != -1)
@@ -526,7 +525,7 @@ class PolymodScriptClass
 		}
 	}
 
-	public static function reportError(err:hscript.Expr.Error, className:String = null, fnName:String = null)
+	public static function reportError(err:Expr.Error, className:String = null, fnName:String = null)
 	{
 		var errEx = PolymodExprEx.ErrorExUtil.toErrorEx(err);
 		reportErrorEx(errEx, className, fnName);
@@ -678,7 +677,7 @@ class PolymodScriptClass
 				// Purge the function from the cache so it is not called again.
 				purgeFunction(fnName);
 			}
-			catch (err:hscript.Expr.Error)
+			catch (err:Expr.Error)
 			{
 				reportError(err, fullyQualifiedName, fnName);
 				// A script error occurred while executing the script function.
@@ -997,4 +996,3 @@ class PolymodScriptClass
 		return 'PolymodScriptClass<$fullyQualifiedName>';
 	}
 }
-#end

--- a/polymod/hscript/_internal/PolymodTyperEx.hx
+++ b/polymod/hscript/_internal/PolymodTyperEx.hx
@@ -1,11 +1,11 @@
 package polymod.hscript._internal;
 
 #if hscript_typer
-import hscript.Expr;
+import polymod.hscript._internal.Expr;
 import hscript.typer.Typer;
 import hscript.typer.TypedExpr;
 
-class PolymodTyperEx extends Typer 
+class PolymodTyperEx extends Typer
 {
   static var allModules:Array<TyperModule> = [];
 
@@ -13,36 +13,36 @@ class PolymodTyperEx extends Typer
   var aliasPaths:Map<String, String>;
   var defaultImports:Map<String, CType>;
 
-  public static function clearAllModules():Void 
+  public static function clearAllModules():Void
   {
     allModules = [];
   }
 
-  public static function typeAllModules():Array<TypedModuleDecl> 
+  public static function typeAllModules():Array<TypedModuleDecl>
   {
     return new PolymodTyperEx(new PolymodInterpEx(null, null)).typeModules(allModules);
   }
 
-  public function new(interp:PolymodInterpEx) 
+  public function new(interp:PolymodInterpEx)
   {
     super(interp);
 
     blacklistImports = [];
     aliasPaths = new Map<String, String>();
-    for (k => imp in PolymodScriptClass.importOverrides) 
+    for (k => imp in PolymodScriptClass.importOverrides)
     {
-      if (imp == null) 
+      if (imp == null)
         blacklistImports.push(k);
       else
         aliasPaths.set(k, Type.getClassName(imp));
     }
-    for (k => imp in PolymodScriptClass.abstractClassImpls) 
+    for (k => imp in PolymodScriptClass.abstractClassImpls)
     {
 			aliasPaths.set(k, Type.getClassName(imp));
     }
 
     defaultImports = new Map<String, CType>();
-    for (k => imp in PolymodScriptClass.defaultImports) 
+    for (k => imp in PolymodScriptClass.defaultImports)
     {
       defaultImports.set(k, CTPath([Type.getClassName(imp)], null));
     }

--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -1,0 +1,448 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package polymod.hscript._internal;
+
+import polymod.hscript._internal.Expr;
+
+class Printer
+{
+  var buf:StringBuf;
+  var tabs:String;
+
+  public function new() {}
+
+  public function exprToString(e:Expr)
+  {
+    buf = new StringBuf();
+    tabs = "";
+    expr(e);
+    return buf.toString();
+  }
+
+  public function typeToString(t:CType)
+  {
+    buf = new StringBuf();
+    tabs = "";
+    type(t);
+    return buf.toString();
+  }
+
+  inline function add<T>(s:T)
+    buf.add(s);
+
+  function type(t:CType)
+  {
+    switch (t)
+    {
+      case CTOpt(t):
+        add('?');
+        type(t);
+      case CTPath(path, params):
+        add(path.join("."));
+        if (params != null)
+        {
+          add("<");
+          var first = true;
+          for (p in params)
+          {
+            if (first) first = false
+            else
+              add(", ");
+            type(p);
+          }
+          add(">");
+        }
+      case CTNamed(name, t):
+        add(name);
+        add(':');
+        type(t);
+      case CTFun(args, ret) if (Lambda.exists(args, function(a) return a.match(CTNamed(_, _)))):
+        add('(');
+        for (a in args)
+          switch a
+          {
+            case CTNamed(_, _): type(a);
+            default: type(CTNamed('_', a));
+          }
+        add(')->');
+        type(ret);
+      case CTFun(args, ret):
+        if (args.length == 0) add("Void -> ");
+        else
+        {
+          for (a in args)
+          {
+            type(a);
+            add(" -> ");
+          }
+        }
+        type(ret);
+      case CTAnon(fields):
+        add("{");
+        var first = true;
+        for (f in fields)
+        {
+          if (first)
+          {
+            first = false;
+            add(" ");
+          }
+          else
+            add(", ");
+          add(f.name + " : ");
+          type(f.t);
+        }
+        add(first ? "}" : " }");
+      case CTParent(t):
+        add("(");
+        type(t);
+        add(")");
+      case CTExpr(e):
+        expr(e);
+    }
+  }
+
+  function addType(t:CType)
+  {
+    if (t != null)
+    {
+      add(" : ");
+      type(t);
+    }
+  }
+
+  function addConst(c:Const)
+  {
+    switch (c)
+    {
+      case CInt(i):
+        add(i);
+      case CFloat(f):
+        add(f);
+      case CString(s):
+        add('"');
+        add(s.split('"')
+          .join('\\"')
+          .split("\n")
+          .join("\\n")
+          .split("\r")
+          .join("\\r")
+          .split("\t")
+          .join("\\t"));
+        add('"');
+    }
+  }
+
+  function expr(e:Expr)
+  {
+    if (e == null)
+    {
+      add("??NULL??");
+      return;
+    }
+    switch (#if hscriptPos e.e #else e #end)
+    {
+      case EConst(c):
+        addConst(c);
+      case EIdent(v):
+        add(v);
+      case EVar(n, t, e):
+        add("var " + n);
+        addType(t);
+        if (e != null)
+        {
+          add(" = ");
+          expr(e);
+        }
+      case EFinal(n, t, e):
+        add("final " + n);
+        addType(t);
+        if (e != null)
+        {
+          add(" = ");
+          expr(e);
+        }
+      case EParent(e):
+        add("(");
+        expr(e);
+        add(")");
+      case EBlock(el):
+        if (el.length == 0)
+        {
+          add("{}");
+        }
+        else
+        {
+          tabs += "\t";
+          add("{\n");
+          for (e in el)
+          {
+            add(tabs);
+            expr(e);
+            add(";\n");
+          }
+          tabs = tabs.substr(1);
+          add("}");
+        }
+      case EField(e, f):
+        expr(e);
+        add("." + f);
+      case EBinop(op, e1, e2):
+        expr(e1);
+        add(" " + op + " ");
+        expr(e2);
+      case EUnop(op, pre, e):
+        if (pre)
+        {
+          add(op);
+          expr(e);
+        }
+        else
+        {
+          expr(e);
+          add(op);
+        }
+      case ECall(e, args):
+        if (e == null) expr(e);
+        else
+          switch (#if hscriptPos e.e #else e #end)
+          {
+            case EField(_), EIdent(_), EConst(_):
+              expr(e);
+            default:
+              add("(");
+              expr(e);
+              add(")");
+          }
+        add("(");
+        var first = true;
+        for (a in args)
+        {
+          if (first) first = false
+          else
+            add(", ");
+          expr(a);
+        }
+        add(")");
+      case EIf(cond, e1, e2):
+        add("if( ");
+        expr(cond);
+        add(" ) ");
+        expr(e1);
+        if (e2 != null)
+        {
+          add(" else ");
+          expr(e2);
+        }
+      case EWhile(cond, e):
+        add("while( ");
+        expr(cond);
+        add(" ) ");
+        expr(e);
+      case EDoWhile(cond, e):
+        add("do ");
+        expr(e);
+        add(" while ( ");
+        expr(cond);
+        add(" )");
+      case EFor(v, it, e):
+        add("for( " + v + " in ");
+        expr(it);
+        add(" ) ");
+        expr(e);
+      case EForGen(it, e):
+        add("for( ");
+        expr(it);
+        add(" ) ");
+        expr(e);
+      case EBreak:
+        add("break");
+      case EContinue:
+        add("continue");
+      case EFunction(params, e, name, ret):
+        add("function");
+        if (name != null) add(" " + name);
+        add("(");
+        var first = true;
+        for (a in params)
+        {
+          if (first) first = false
+          else
+            add(", ");
+          if (a.opt) add("?");
+          add(a.name);
+          addType(a.t);
+        }
+        add(")");
+        addType(ret);
+        add(" ");
+        expr(e);
+      case EReturn(e):
+        add("return");
+        if (e != null)
+        {
+          add(" ");
+          expr(e);
+        }
+      case EArray(e, index):
+        expr(e);
+        add("[");
+        expr(index);
+        add("]");
+      case EArrayDecl(el):
+        add("[");
+        var first = true;
+        for (e in el)
+        {
+          if (first) first = false
+          else
+            add(", ");
+          expr(e);
+        }
+        add("]");
+      case ENew(cl, args):
+        add("new " + cl + "(");
+        var first = true;
+        for (e in args)
+        {
+          if (first) first = false
+          else
+            add(", ");
+          expr(e);
+        }
+        add(")");
+      case EThrow(e):
+        add("throw ");
+        expr(e);
+      case ETry(e, v, t, ecatch):
+        add("try ");
+        expr(e);
+        add(" catch( " + v);
+        addType(t);
+        add(") ");
+        expr(ecatch);
+      case EObject(fl):
+        if (fl.length == 0)
+        {
+          add("{}");
+        }
+        else
+        {
+          tabs += "\t";
+          add("{\n");
+          for (f in fl)
+          {
+            add(tabs);
+            add(f.name + " : ");
+            expr(f.e);
+            add(",\n");
+          }
+          tabs = tabs.substr(1);
+          add("}");
+        }
+      case ETernary(c, e1, e2):
+        expr(c);
+        add(" ? ");
+        expr(e1);
+        add(" : ");
+        expr(e2);
+      case ESwitch(e, cases, def):
+        add("switch( ");
+        expr(e);
+        add(") {");
+        for (c in cases)
+        {
+          add("case ");
+          var first = true;
+          for (v in c.values)
+          {
+            if (first) first = false
+            else
+              add(", ");
+            expr(v);
+          }
+          add(": ");
+          expr(c.expr);
+          add(";\n");
+        }
+        if (def != null)
+        {
+          add("default: ");
+          expr(def);
+          add(";\n");
+        }
+        add("}");
+      case EMeta(name, args, e):
+        add("@");
+        add(name);
+        if (args != null && args.length > 0)
+        {
+          add("(");
+          var first = true;
+          for (a in args)
+          {
+            if (first) first = false
+            else
+              add(", ");
+            expr(e);
+          }
+          add(")");
+        }
+        add(" ");
+        expr(e);
+      case ECheckType(e, t):
+        add("(");
+        expr(e);
+        add(" : ");
+        addType(t);
+        add(")");
+    }
+  }
+
+  public static function toString(e:Expr)
+  {
+    return new Printer().exprToString(e);
+  }
+
+  public static function errorToString(e:Expr.Error)
+  {
+    var message = switch (#if hscriptPos e.e #else e #end)
+    {
+      case EInvalidChar(c): "Invalid character: '" + (StringTools.isEof(c) ? "EOF" : String.fromCharCode(c)) + "' (" + c + ")";
+      case EUnexpected(s): "Unexpected token: \"" + s + "\"";
+      case EUnterminatedString: "Unterminated string";
+      case EUnterminatedComment: "Unterminated comment";
+      case EInvalidPreprocessor(str): "Invalid preprocessor (" + str + ")";
+      case EUnknownVariable(v): "Unknown variable: " + v;
+      case EInvalidIterator(v): "Invalid iterator: " + v;
+      case EInvalidOp(op): "Invalid operator: " + op;
+      case EInvalidAccess(f): "Invalid access to field " + f;
+      case ECustom(msg): msg;
+    };
+    #if hscriptPos
+    return e.origin + ":" + e.line + ": " + message;
+    #else
+    return message;
+    #end
+  }
+}

--- a/polymod/hscript/_internal/Tools.hx
+++ b/polymod/hscript/_internal/Tools.hx
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C)2008-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package polymod.hscript._internal;
+
+import polymod.hscript._internal.Expr;
+
+class Tools
+{
+  public static function iter(e:Expr, f:Expr->Void)
+  {
+    switch (expr(e))
+    {
+      case EConst(_), EIdent(_):
+      case EVar(_, _, e) | EFinal(_, _, e):
+        if (e != null) f(e);
+      case EParent(e):
+        f(e);
+      case EBlock(el):
+        for (e in el)
+          f(e);
+      case EField(e, _):
+        f(e);
+      case EBinop(_, e1, e2):
+        f(e1);
+        f(e2);
+      case EUnop(_, _, e):
+        f(e);
+      case ECall(e, args):
+        f(e);
+        for (a in args)
+          f(a);
+      case EIf(c, e1, e2):
+        f(c);
+        f(e1);
+        if (e2 != null) f(e2);
+      case EWhile(c, e):
+        f(c);
+        f(e);
+      case EDoWhile(c, e):
+        f(c);
+        f(e);
+      case EFor(_, it, e):
+        f(it);
+        f(e);
+      case EForGen(it, e):
+        f(it);
+        f(e);
+      case EBreak, EContinue:
+      case EFunction(_, e, _, _):
+        f(e);
+      case EReturn(e):
+        if (e != null) f(e);
+      case EArray(e, i):
+        f(e);
+        f(i);
+      case EArrayDecl(el):
+        for (e in el)
+          f(e);
+      case ENew(_, el):
+        for (e in el)
+          f(e);
+      case EThrow(e):
+        f(e);
+      case ETry(e, _, _, c):
+        f(e);
+        f(c);
+      case EObject(fl):
+        for (fi in fl)
+          f(fi.e);
+      case ETernary(c, e1, e2):
+        f(c);
+        f(e1);
+        f(e2);
+      case ESwitch(e, cases, def):
+        f(e);
+        for (c in cases)
+        {
+          for (v in c.values)
+            f(v);
+          f(c.expr);
+        }
+        if (def != null) f(def);
+      case EMeta(name, args, e):
+        if (args != null) for (a in args)
+          f(a);
+        f(e);
+      case ECheckType(e, _):
+        f(e);
+    }
+  }
+
+  public static function map(e:Expr, f:Expr->Expr)
+  {
+    var edef = switch (expr(e))
+    {
+      case EConst(_), EIdent(_), EBreak, EContinue: expr(e);
+      case EVar(n, t, e): EVar(n, t, if (e != null) f(e) else null);
+      case EFinal(n, t, e): EFinal(n, t, if (e != null) f(e) else null);
+      case EParent(e): EParent(f(e));
+      case EBlock(el): EBlock([for (e in el) f(e)]);
+      case EField(e, fi): EField(f(e), fi);
+      case EBinop(op, e1, e2): EBinop(op, f(e1), f(e2));
+      case EUnop(op, pre, e): EUnop(op, pre, f(e));
+      case ECall(e, args): ECall(f(e), [for (a in args) f(a)]);
+      case EIf(c, e1, e2): EIf(f(c), f(e1), if (e2 != null) f(e2) else null);
+      case EWhile(c, e): EWhile(f(c), f(e));
+      case EDoWhile(c, e): EDoWhile(f(c), f(e));
+      case EFor(v, it, e): EFor(v, f(it), f(e));
+      case EForGen(it, e): EForGen(f(it), f(e));
+      case EFunction(args, e, name, t): EFunction(args, f(e), name, t);
+      case EReturn(e): EReturn(if (e != null) f(e) else null);
+      case EArray(e, i): EArray(f(e), f(i));
+      case EArrayDecl(el): EArrayDecl([for (e in el) f(e)]);
+      case ENew(cl, el): ENew(cl, [for (e in el) f(e)]);
+      case EThrow(e): EThrow(f(e));
+      case ETry(e, v, t, c): ETry(f(e), v, t, f(c));
+      case EObject(fl): EObject([for (fi in fl) {name: fi.name, e: f(fi.e)}]);
+      case ETernary(c, e1, e2): ETernary(f(c), f(e1), f(e2));
+      case ESwitch(e, cases, def): ESwitch(f(e), [for (c in cases) {values: [for (v in c.values) f(v)], expr: f(c.expr)}], def == null ? null : f(def));
+      case EMeta(name, args, e): EMeta(name, args == null ? null : [for (a in args) f(a)], f(e));
+      case ECheckType(e, t): ECheckType(f(e), t);
+    }
+    return mk(edef, e);
+  }
+
+  public static inline function expr(e:Expr):ExprDef
+  {
+    #if hscriptPos
+    return e.e;
+    #else
+    return e;
+    #end
+  }
+
+  public static inline function mk(e:ExprDef, p:Expr)
+  {
+    #if hscriptPos
+    return {
+      e: e,
+      pmin: p.pmin,
+      pmax: p.pmax,
+      origin: p.origin,
+      line: p.line
+    };
+    #else
+    return e;
+    #end
+  }
+
+  public static inline function getKeyIterator<T>(e:Expr, callb:String->String->Expr->T)
+  {
+    var key = null, value = null, it = e;
+    switch (expr(it))
+    {
+      case EBinop("in", ekv, eiter):
+        switch (expr(ekv))
+        {
+          case EBinop("=>", v1, v2):
+            switch ([expr(v1), expr(v2)])
+            {
+              case [EIdent(v1), EIdent(v2)]:
+                key = v1;
+                value = v2;
+                it = eiter;
+              default:
+            }
+          default:
+        }
+      default:
+    }
+    return callb(key, value, it);
+  }
+}

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -12,9 +12,7 @@ import polymod.format.ParseRules.CSVParseFormat;
 import polymod.format.ParseRules.TextFileFormat;
 import polymod.format.ParseRules;
 import polymod.fs.PolymodFileSystem.IFileSystem;
-#if hscript
 import polymod.hscript._internal.PolymodClassDeclEx;
-#end
 #if unifill
 import unifill.Unifill;
 #end
@@ -718,7 +716,6 @@ class Util
 		}
 	}
 
-	#if hscript
 	/**
 	 * Retrieves the full qualified name of a class declaration.
 	 * @param clsDecl The class declaration.
@@ -728,5 +725,4 @@ class Util
 	{
 		return (clsDecl.pkg != null ? (clsDecl.pkg.join(".") + ".") : "") + clsDecl.name;
 	}
-	#end
 }


### PR DESCRIPTION
No longer will the library depend on a specific fork of a haxelib to work. This also means improvements to Polymod no longer require pull requests to a separate repo.

This (along with fixing up static fields in scripted classes, and fixing up abstract access) is one of my goals before finally packaging up and updating the Haxelib.

In the future, I'd like to eventually combine the code from stuff like `PolymodInterpEx` into the base classes from HScript to make it a concise re-implementation of HScript without the weird chain of overridden methods it has currently.