### PR TITLE
[ENHANCEMENT/FIX] Add extensions and optional fields parsing and fix class syntax parsing for typedefs.

### DIFF
--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -187,6 +187,7 @@ typedef EnumArgDecl =
 typedef TypeDecl =
 {
   > ModuleType,
+  var extensions:Array<CType>;
   var t:CType;
 }
 

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1201,16 +1201,31 @@ class Parser
           {
             case TBrClose: break;
             case TId("var"), TId("final"):
+              var isOpt = maybe(TQuestion);
               var name = getIdent();
               ensure(TDoubleDot);
+              var type = parseType();
+              if (isOpt) type = CTOpt(type);
               if (t.match(TId("final")))
               {
                 if (meta == null) meta = [];
                 meta.push({name: ":final", params: []});
               }
-              fields.push({name: name, t: parseType(), meta: meta});
+              fields.push({name: name, t: type, meta: meta});
               meta = null;
               ensure(TSemicolon);
+            case TQuestion:
+              var name = getIdent();
+              ensure(TDoubleDot);
+              fields.push({name: name, t: CTOpt(parseType()), meta: meta});
+              meta = null;
+              t = token();
+              switch (t)
+              {
+                case TComma:
+                case TBrClose: break;
+                default: unexpected(t);
+              }
             case TId(name):
               ensure(TDoubleDot);
               fields.push({name: name, t: parseType(), meta: meta});
@@ -1450,6 +1465,18 @@ class Parser
         var name = getIdent();
         var params = parseParams();
         ensureToken(TOp("="));
+
+        var extensions = [];
+        if (maybe(TBrOpen))
+        {
+          while (maybe(TOp(">")))
+          {
+            extensions.push(parseType());
+            maybe(TComma);
+          }
+          push(TBrOpen);
+        }
+
         var t = parseType();
         return DTypedef(
           {
@@ -1457,6 +1484,7 @@ class Parser
             meta: meta,
             params: params,
             isPrivate: isPrivate,
+            extensions: extensions,
             t: t,
           });
       case "enum":

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1197,6 +1197,16 @@ class Parser
         while (true)
         {
           t = token();
+
+          // Skip modifiers to allow vars in typedefs to be parsed without issues
+          // Only handle field access when it gets implemented
+          switch(t)
+          {
+            case TId("public"), TId("private"):
+              t = token();
+            default:
+          }
+
           switch (t)
           {
             case TBrClose: break;


### PR DESCRIPTION
This PR adds correct parsing for optional and extensions in typedefs.

For example this snippet:
```haxe
typedef TestTypedef = {
	var id:Int;
	var data:T;
	var ?version:Float;
}

typedef ExtendedTypedef = {
	> TestTypedef,
	var description:String;
}
```

The ~~hscript~~polymod parser would complain (images below) about the unexpected `>` and `?` symbols before, but now it parses correctly the extensions and optional fields like `version`.

<img width="996" height="38" alt="image" src="https://github.com/user-attachments/assets/45bb18a8-97a6-4eae-a9ba-79e9ebc6e5ab" />

<img width="1010" height="37" alt="image" src="https://github.com/user-attachments/assets/dc5c1ac9-3994-45a0-ac6c-6d1946c3af3a" />

## Extra
Also fixes the class syntax parsing of typedefs

The example code:
```haxe
typedef TypedefData = {
  public var artist:String;
  private var privates:String;
  //static var renders:Array<String>;
  var strings:Array<String>;
  final finals:Array<String>;
}
```

Before:

<img width="1009" height="229" alt="image" src="https://github.com/user-attachments/assets/302bdbe3-24b1-4fb9-8d46-3b1ccc9dc375" />

After:

<img width="1016" height="507" alt="image" src="https://github.com/user-attachments/assets/ce4df714-f9ed-44c1-86c0-f285fec2035b" />

<sub>static context doesnt work in typedefs so I didn't allow it to get parsed<sub>