### PR TITLE
[FIX] Allow multiple arguments in enums

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1553,7 +1553,10 @@ class Parser
     if (maybe(TPOpen))
     {
       while (!maybe(TPClose))
+      {
+        if (args.length > 0) ensure(TComma);
         args.push(parseEnumArg());
+      }
     }
 
     return {


### PR DESCRIPTION
This PR fixes the enums being allowed only to have one argument.

Before polymod's interp would show this:

<img width="1055" height="339" alt="image" src="https://github.com/user-attachments/assets/a2e7a029-a1ee-4824-8c82-b9495b790804" />


After this PR:

<img width="717" height="323" alt="image" src="https://github.com/user-attachments/assets/435475fe-c33f-47a9-814d-dd4032f79adf" />
