### PR TITLE
[FIX] Fix scripted classes being uninstantiable if the package is empty

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -74,7 +74,7 @@ class PolymodScriptClassMacro {
 			  // Class instances
 			  case TInst(t, _params):
 			    var classType:ClassType = t.get();
-				var classPath:String = '${classType.pack.join(".")}.${classType.name}';
+				var classPath:String = '${classType.pack.concat([classType.name]).join(".")}';
 
 			    if (classType.isInterface) {
     				// Ignore interfaces.
@@ -85,7 +85,7 @@ class PolymodScriptClassMacro {
 
 					if (superClass == null) throw 'No superclass for ' + classPath;
 
-					var superClassPath:String = '${superClass.pack.join(".")}.${superClass.name}';
+					var superClassPath:String = '${superClass.pack.concat([superClass.name]).join(".")}';
 					var entryData = [
 						macro $v{superClassPath},
 						// TODO: How do we do reification to get a class?


### PR DESCRIPTION
example:
```haxe
package;

@:hscriptClass
class ScriptedFlxBasic extends flixel.FlxBasic implements polymod.hscript.HScriptedClass {}
```

before: `hscriptedClasses` metadata contains `.ScriptedFlxBasic`
after: `hscriptedClasses` metadata contains `ScriptedFlxBasic`

this makes `Type.resolveClass` now work correctly