### PR TITLE
[FIX] Pass variables by reference to local function clone 

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -2145,11 +2145,8 @@ public function clone():PolymodInterpEx
 {
   var _clone = new PolymodInterpEx(this.targetCls, this._proxy);
 
-  // Copy over the values, but exclude the trace function.
-  for (k => v in this.variables)
-  {
-    if (k != "trace") _clone.variables.set(k, v);
-  }
+  // Pass the variables by reference
+  _clone.variables = this.variables;
 
   for (k => v in this.locals)
   {


### PR DESCRIPTION
Instead of copying each variable to the clone, we pass them by reference. This fixes an issue where they are unaffected by local functions.