### PR TITLE
Teeny optimization for `experimental-abstracts`

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -185,6 +185,7 @@ class PolymodScriptClassMacro {
 									 for (f in abstractImplType.statics.get()) {
 										if (f.name == 'get_${field.name}'){
 											getter = f;
+											break;
 										}
 									}
 
@@ -209,6 +210,7 @@ class PolymodScriptClassMacro {
 									 for (f in abstractImplType.statics.get()){
 										if (f.name == 'set_${field.name}'){
 											setter = f;
+											break;
 										}
 									}
 


### PR DESCRIPTION
We break the loop once we find the getter/setter instead of letting it unnecessarily iterate through all the fields