### PR TITLE
[REFACTOR] Fold PolymodClassDeclEx into ClassDecl

### DIFF
--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -157,13 +157,95 @@ typedef ModuleType =
   var isPrivate:Bool;
 }
 
+/**
+ * A scripted class declaration, with a package declaration, imports, and potentially static fields.
+ */
 typedef ClassDecl =
 {
   > ModuleType,
+  /**
+   * The type being extended by the scripted class
+   */
   var extend:Null<CType>;
+
+  /**
+   * The interfaces being implemented by the scripted class
+   */
   var implement:Array<CType>;
+
+  /**
+   * The static fields of the scripted class
+   */
+  var staticFields:Array<FieldDecl>;
+
+  /**
+   * The instance fields of the scripted class
+   */
   var fields:Array<FieldDecl>;
+
+  /**
+   * Whether the class was declared with the `extern` keyword
+   */
   var isExtern:Bool;
+
+  /**
+   * The package that the scripted class belongs to
+   */
+  var pkg:Array<String>;
+
+  /**
+   * The classes imported by the scripted class
+   * This gets resolved at interpretation time to save performance and improve sandboxing
+   */
+  var imports:Map<String, ClassImport>;
+
+  /**
+   * The static extensions used by the scripted class
+   * For example, `using StringTools` lets you call `String.replace` on a string directly.
+   */
+  var usings:Map<String, ClassImport>;
+
+  /**
+   * A list of imports that have yet to be validated
+   *
+   * Scripted classes that import other scripted classes might be parsed before the class they import,
+   * so imports have to be done in two passes.
+   */
+  var importsToValidate:Map<String, ClassImport>;
+}
+
+/**
+ * An imported class or enumeration.
+ */
+typedef ClassImport =
+{
+  /**
+   * The name of the imported class
+   */
+  var name:String;
+
+  /**
+   * The package that the imported class belongs to
+   */
+  var pkg:Array<String>;
+
+  /**
+   * The full path of the imported class, including the package
+   */
+  var fullPath:String; // pkg.pkg.pkg.name
+
+  /**
+   * The underlying class that was imported.
+   * Will be `null` if this is an enum instead (see `enm`),
+   * or the class the script tried to import was BLACKLISTED.
+   */
+  var ?cls:Class<Dynamic>;
+
+  /**
+   * The underlying enum that was imported.
+   * Will be `null` if this is an enum instead (see `enm`).
+   */
+  var ?enm:Enum<Dynamic>;
 }
 
 typedef EnumDecl =

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -190,7 +190,7 @@ class HScriptedClassMacro
             ret: Context.toComplexType(Context.getType(clsTypeName)),
             expr: macro
             {
-              var clsRef = polymod.hscript._internal.PolymodClassDeclEx.PolymodStaticClassReference.tryBuild(clsName);
+              var clsRef = polymod.hscript._internal.PolymodStaticClassReference.tryBuild(clsName);
 
               if (clsRef == null)
               {

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1445,6 +1445,12 @@ class Parser
             fields: fields,
             isPrivate: isPrivate,
             isExtern: isExtern,
+
+            pkg: [],
+            imports: [],
+            importsToValidate: [],
+            usings: [],
+            staticFields: [],
           });
       case "typedef":
         var name = getIdent();

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1,8 +1,9 @@
 package polymod.hscript._internal;
 
 import polymod.hscript._internal.Expr;
-import polymod.hscript._internal.PolymodClassDeclEx.PolymodClassImport;
-import polymod.hscript._internal.PolymodClassDeclEx.PolymodStaticClassReference;
+import polymod.hscript._internal.Expr.ClassDecl;
+import polymod.hscript._internal.Expr.ClassImport;
+import polymod.hscript._internal.PolymodStaticClassReference;
 import polymod.hscript._internal.PolymodExprEx;
 import polymod.hscript._internal.Printer;
 import polymod.util.Util;
@@ -22,11 +23,11 @@ class PolymodInterpEx extends Interp
 
   private var _proxy:PolymodAbstractScriptClass = null;
 
-  var _classDeclOverride:PolymodClassDeclEx = null;
+  var _classDeclOverride:ClassDecl = null;
 
   var _propTrack:Map<String, Bool> = [];
 
-  function getClassDecl():PolymodClassDeclEx
+  function getClassDecl():ClassDecl
   {
     if (_classDeclOverride != null)
     {
@@ -103,7 +104,7 @@ class PolymodInterpEx extends Interp
     @:privateAccess
     if (getClassDecl()?.imports != null && getClassDecl().imports.exists(cl))
     {
-      var importedClass:PolymodClassImport = getClassDecl().imports.get(cl);
+      var importedClass:ClassImport = getClassDecl().imports.get(cl);
       if (_scriptClassDescriptors.exists(importedClass.fullPath))
       {
         // OVERRIDE CHANGE: Create a PolymodScriptClass instead of a ScriptClass
@@ -213,9 +214,9 @@ class PolymodInterpEx extends Interp
     }
   }
 
-  private static var _scriptClassDescriptors:Map<String, PolymodClassDeclEx> = new Map<String, PolymodClassDeclEx>();
+  private static var _scriptClassDescriptors:Map<String, ClassDecl> = new Map<String, ClassDecl>();
 
-  private static function registerScriptClass(c:PolymodClassDeclEx)
+  private static function registerScriptClass(c:ClassDecl)
   {
     var name = Util.getFullClassName(c);
 
@@ -1515,7 +1516,7 @@ class PolymodInterpEx extends Interp
     {
       // This scripted class has imports.
 
-      var importedClass:PolymodClassImport = getClassDecl().imports.get(id);
+      var importedClass:ClassImport = getClassDecl().imports.get(id);
       if (importedClass != null)
       {
         if (importedClass.cls != null) return importedClass.cls;
@@ -1630,9 +1631,9 @@ class PolymodInterpEx extends Interp
   public function callScriptClassStaticFunction(clsName:String, fnName:String, args:Array<Dynamic> = null):Dynamic
   {
     var fn:Null<FunctionDecl> = null;
-    var imports:Map<String, PolymodClassImport> = [];
+    var imports:Map<String, ClassImport> = [];
 
-    var cls:Null<PolymodClassDeclEx> = _scriptClassDescriptors.get(clsName);
+    var cls:Null<ClassDecl> = _scriptClassDescriptors.get(clsName);
     if (cls != null)
     {
       imports = cls.imports;
@@ -1738,9 +1739,9 @@ class PolymodInterpEx extends Interp
 
   public function hasScriptClassStaticFunction(clsName:String, fnName:String):Bool
   {
-    var imports:Map<String, PolymodClassImport> = [];
+    var imports:Map<String, ClassImport> = [];
 
-    var cls:Null<PolymodClassDeclEx> = _scriptClassDescriptors.get(clsName);
+    var cls:Null<ClassDecl> = _scriptClassDescriptors.get(clsName);
     if (cls != null)
     {
       imports = cls.imports;
@@ -1928,9 +1929,9 @@ class PolymodInterpEx extends Interp
   public function registerModules(module:Array<ModuleDecl>, ?origin:String = "hscript")
   {
     var pkg:Array<String> = null;
-    var imports:Map<String, PolymodClassImport> = [];
-    var importsToValidate:Map<String, PolymodClassImport> = [];
-    var usings:Map<String, PolymodClassImport> = [];
+    var imports:Map<String, ClassImport> = [];
+    var importsToValidate:Map<String, ClassImport> = [];
+    var usings:Map<String, ClassImport> = [];
 
     for (importPath in PolymodScriptClass.defaultImports.keys())
     {
@@ -1969,7 +1970,7 @@ class PolymodInterpEx extends Interp
             continue;
           }
 
-          var importedClass:PolymodClassImport =
+          var importedClass:ClassImport =
             {
               name: clsName,
               pkg: path.slice(0, path.length - 1),
@@ -2040,7 +2041,7 @@ class PolymodInterpEx extends Interp
             continue;
           }
 
-          var importedClass:PolymodClassImport =
+          var importedClass:ClassImport =
             {
               name: clsName,
               pkg: path.slice(0, path.length - 1),
@@ -2102,7 +2103,7 @@ class PolymodInterpEx extends Interp
             }
           }
 
-          var classDecl:PolymodClassDeclEx =
+          var classDecl:ClassDecl =
             {
               imports: imports,
               importsToValidate: importsToValidate,

--- a/polymod/hscript/_internal/PolymodParserEx.hx
+++ b/polymod/hscript/_internal/PolymodParserEx.hx
@@ -11,6 +11,7 @@ class PolymodParserEx extends Parser
   public override function parseModule(content:String, ?origin:String = "hscript", ?position = 0)
   {
     var decls:Array<ModuleDecl> = super.parseModule(content, origin, position);
+
     #if hscript_typer
     PolymodTyperEx.allModules.push(
       {
@@ -19,6 +20,7 @@ class PolymodParserEx extends Parser
         origin: origin,
       });
     #end
+
     return decls;
   }
 }

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -1,11 +1,12 @@
 package polymod.hscript._internal;
 
 import haxe.ds.ObjectMap;
+import polymod.hscript._internal.Expr.ClassDecl;
+import polymod.hscript._internal.Expr.ClassImport;
 import polymod.hscript._internal.Expr.FieldDecl;
 import polymod.hscript._internal.Expr.FunctionDecl;
 import polymod.hscript._internal.Expr.VarDecl;
 import polymod.hscript._internal.Printer;
-import polymod.hscript._internal.PolymodClassDeclEx;
 import polymod.util.Util;
 
 using StringTools;
@@ -291,7 +292,7 @@ class PolymodScriptClass
     return listScriptClassesExtending(Type.getClassName(cls));
   }
 
-  static function getSuperClasses(classDecl:PolymodClassDeclEx):Array<String>
+  static function getSuperClasses(classDecl:ClassDecl):Array<String>
   {
     if (classDecl.extend == null)
     {
@@ -310,7 +311,7 @@ class PolymodScriptClass
     };
 
     // Check if the superclass is a scripted class.
-    var classDescriptor:PolymodClassDeclEx = PolymodInterpEx.findScriptClassDescriptor(fullSuperClsName);
+    var classDescriptor:ClassDecl = PolymodInterpEx.findScriptClassDescriptor(fullSuperClsName);
 
     if (classDescriptor != null)
     {
@@ -332,7 +333,7 @@ class PolymodScriptClass
 
       if (classDecl.imports.exists(baseSuperClsName))
       {
-        var importedClass:PolymodClassImport = classDecl.imports.get(baseSuperClsName);
+        var importedClass:ClassImport = classDecl.imports.get(baseSuperClsName);
         if (importedClass != null && importedClass.cls == null)
         {
           // importedClass was defined but `cls` was null. This class must have been blacklisted.
@@ -395,7 +396,7 @@ class PolymodScriptClass
   /**
    * INSTANCE METHODS
    */
-  public function new(c:PolymodClassDeclEx, args:Array<Dynamic>)
+  public function new(c:ClassDecl, args:Array<Dynamic>)
   {
     var targetClass:Class<Dynamic> = null;
     switch (c.extend)
@@ -414,7 +415,7 @@ class PolymodScriptClass
         }
         else if (c.imports.exists(clsName))
         {
-          var importedClass:PolymodClassImport = c.imports.get(clsName);
+          var importedClass:ClassImport = c.imports.get(clsName);
           if (importedClass != null && importedClass.cls != null)
           {
             targetClass = importedClass.cls;
@@ -809,7 +810,7 @@ class PolymodScriptClass
     return fn != null;
   }
 
-  private var _c:PolymodClassDeclEx;
+  private var _c:ClassDecl;
   private var _interp:PolymodInterpEx;
 
   public var superClass:Dynamic = null;
@@ -1023,7 +1024,7 @@ class PolymodScriptClass
    * @param clsDecl The class to retrieve functions from.
    * @param usingCache The map to populate.
    */
-  public static function buildExtensionFunctionCache(clsDecl:PolymodClassDeclEx, usingCache:Map<String, Array<Dynamic>->Dynamic>):Void
+  public static function buildExtensionFunctionCache(clsDecl:ClassDecl, usingCache:Map<String, Array<Dynamic>->Dynamic>):Void
   {
     for (_ => u in clsDecl.usings)
     {

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -77,8 +77,9 @@ class PolymodScriptClassMacro
     {
       switch (type)
       {
-        // Class instances
         case TInst(t, _params):
+          // Check classes to see if they implement `HScriptedClass`, and do additional processing.
+
           var classType:ClassType = t.get();
           var classPath:String = '${classType.pack.concat([classType.name]).join(".")}';
 
@@ -88,8 +89,6 @@ class PolymodScriptClassMacro
           }
           else if (MacroUtil.implementsInterface(classType, hscriptedClassType))
           {
-            // Context.info('${classPath} implements HScriptedClass? YEAH', Context.currentPos());
-            // TODO: Do we need to parameterize?
             var superClass:Null<ClassType> = classType.superClass != null ? classType.superClass.t.get() : null;
 
             if (superClass == null) throw 'No superclass for ' + classPath;
@@ -97,13 +96,14 @@ class PolymodScriptClassMacro
             var superClassPath:String = '${superClass.pack.concat([superClass.name]).join(".")}';
             var entryData = [
               macro $v{superClassPath},
-              // TODO: How do we do reification to get a class?
               macro $v{classPath}
             ];
             hscriptedClassEntries.push(macro $a{entryData});
           }
-          else {}
+
         case TAbstract(t, _params):
+          // Perform additional processing on abstracts classes to ensure they can be accessed at runtime.
+
           var abstractPath:String = t.toString();
           if (abstractPath == 'flixel.util.FlxColor')
           {

--- a/polymod/hscript/_internal/PolymodStaticClassReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticClassReference.hx
@@ -1,49 +1,29 @@
 package polymod.hscript._internal;
 
 import polymod.hscript._internal.Expr.ClassDecl;
-import polymod.hscript._internal.Expr.FieldDecl;
-import polymod.hscript._internal.PolymodScriptClass;
 
 /**
- * A scripted class declaration, with a package declaration, imports, and potentially static fields.
+ * A class which holds a reference to another scripted class,
+ * for use in a static context. This allows for instantiation,
+ * or for accessing static fields or methods.
  */
-typedef PolymodClassDeclEx =
-{
-  > ClassDecl,
-
-  /**
-   * Save performance and improve sandboxing by resolving imports at interpretation time.
-   */
-  @:optional var imports:Map<String, PolymodClassImport>;
-
-  @:optional var importsToValidate:Map<String, PolymodClassImport>;
-  @:optional var pkg:Array<String>;
-
-  @:optional var staticFields:Array<FieldDecl>;
-  @:optional var usings:Map<String, PolymodClassImport>;
-}
-
-/**
- * An imported class or enumeration.
- */
-typedef PolymodClassImport =
-{
-  @:optional var name:String;
-  @:optional var pkg:Array<String>;
-  @:optional var fullPath:String; // pkg.pkg.pkg.name
-  @:optional var cls:Class<Dynamic>;
-  @:optional var enm:Enum<Dynamic>;
-}
-
 class PolymodStaticClassReference
 {
-  public var cls:PolymodClassDeclEx;
+  /**
+   * The underlying class declaration, as parsed from the script
+   */
+  public var cls:ClassDecl;
 
-  public function new(cls:PolymodClassDeclEx)
+  public function new(cls:ClassDecl)
   {
     this.cls = cls;
   }
 
+  /**
+   * Build a static class reference for the given scripted class name, if it exists
+   * @param clsName The name of the scripted class
+   * @return The static class reference, or `null` if the scripted class doesn't exist
+   */
   public static function tryBuild(clsName:String):Null<PolymodStaticClassReference>
   {
     @:privateAccess {
@@ -59,9 +39,9 @@ class PolymodStaticClassReference
   }
 
   /**
-   * Return a scripted instance of this script class.
-   * @param args
-   * @return Dynamic
+   * Return an instance of this scripted class.
+   * @param args The arguments to pass to the constructor
+   * @return The resulting instance
    */
   public function instantiate(?args:Array<Dynamic>):Dynamic
   {
@@ -91,26 +71,52 @@ class PolymodStaticClassReference
     return scriptedObj;
   }
 
+  /**
+   * Build a PolymodAbstractScriptClass for this class
+   * @param args The arguments to pass to the constructor
+   * @return The resulting PolymodAbstractScriptClass
+   */
   public function buildASC(?args:Array<Dynamic>):PolymodAbstractScriptClass
   {
     return new PolymodScriptClass(cls, args);
   }
 
+  /**
+   * Call a static function of the scripted class
+   * @param funcName The name of the function to call
+   * @param args The arguments to pass into the function
+   * @return The return value of the function
+   */
   public function callFunction(funcName:String, ?args:Array<Dynamic>):Dynamic
   {
     return PolymodScriptClass.callScriptClassStaticFunction(getFullyQualifiedName(), funcName, args);
   }
 
+  /**
+   * Retrieve a static field of the scripted class
+   * @param fieldName The name of the field to retrieve
+   * @return The value of the field
+   */
   public function getField(fieldName:String):Dynamic
   {
     return PolymodScriptClass.getScriptClassStaticField(getFullyQualifiedName(), fieldName);
   }
 
+  /**
+   * Assign a static field of the scripted class
+   * @param fieldName The name of the field to retrieve
+   * @param fieldValue The value to assign to the field
+   * @return The value of the field
+   */
   public function setField(fieldName:String, fieldValue:Dynamic):Dynamic
   {
     return PolymodScriptClass.setScriptClassStaticField(getFullyQualifiedName(), fieldName, fieldValue);
   }
 
+  /**
+   * Retrieve the fully qualified name of the scripted class, prefixed by its package
+   * @return The fully qualified name
+   */
   public function getFullyQualifiedName():String
   {
     if (this.cls.pkg != null && this.cls.pkg.length > 0)

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -12,7 +12,7 @@ import polymod.format.ParseRules.CSVParseFormat;
 import polymod.format.ParseRules.TextFileFormat;
 import polymod.format.ParseRules;
 import polymod.fs.PolymodFileSystem.IFileSystem;
-import polymod.hscript._internal.PolymodClassDeclEx;
+import polymod.hscript._internal.Expr.ClassDecl;
 #if unifill
 import unifill.Unifill;
 #end
@@ -726,7 +726,7 @@ class Util
    * @param clsDecl The class declaration.
    * @return String
    */
-  public static function getFullClassName(clsDecl:PolymodClassDeclEx):String
+  public static function getFullClassName(clsDecl:ClassDecl):String
   {
     return (clsDecl.pkg != null ? (clsDecl.pkg.join(".") + ".") : "") + clsDecl.name;
   }


### PR DESCRIPTION
This refactor removes the `PolymodClassDeclEx` typedef, and folds it into the `ClassDecl` typedef, then refactors the rest of the codebase to point to it.

There should be no functional changes or regressions in this PR, this is just one step of a cleanup mentioned in #287.