### PR TITLE
[FIX] Also add the abstract static field if it can be set

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -346,7 +346,7 @@ class PolymodScriptClassMacro
                     canSet = true;
                   }
 
-                  if (canGet) {
+                  if (canGet || canSet) {
                     var fieldName:String = '${abstractImplPath.replace('.', '_')}_${field.name}';
 
                     fields.push(


### PR DESCRIPTION
This pr just adds an or statement to the check whether we should add the static field of an abstract to the abstractStatics


before, it would ignore these fields: `static var foo(never, set):Float`
it would only add them if there is a way for the to be retrieved, e.g `static var foo(get, set):Float`

now, it is also added if it cannot be gotten