### PR TITLE
[FIX] Call actual constructor of abstract

### DIFF
--- a/polymod/hscript/_internal/PolymodClassDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodClassDeclEx.hx
@@ -177,7 +177,12 @@ class PolymodStaticAbstractReference {
       throw 'Could not resolve abstract class ${absName}.';
     }
 
-    return Type.createInstance(this.absImpl, args);
+    var ctor = Reflect.field(this.absImpl, '_new');
+    if (ctor == null) {
+      throw 'Could not find constructor for abstract class ${absName}';
+    }
+
+    return Reflect.callMethod(this.absImpl, ctor, args);
   }
 
   /**


### PR DESCRIPTION
Before, `PolymodStaticAbstractReference.instantiate` would create an instance of the abstract implementation
Now, it calls the defined constructor from the abstract