### PR TITLE
[FIX] Prevent argument loss in local functions

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -27,6 +27,8 @@ class PolymodInterpEx extends Interp
 
   var _propTrack:Map<String, Bool> = [];
 
+  var _root:Null<PolymodInterpEx>;
+
   function getClassDecl():ClassDecl
   {
     if (_classDeclOverride != null)
@@ -696,6 +698,13 @@ class PolymodInterpEx extends Interp
           }
           args = args2;
 
+          // Apply changes from the root again in the case another clone has already messed with them.
+          for (k => v in _root.variables)
+          {
+            if (k == "trace") continue;
+            clone.variables.set(k, v);
+          }
+
           clone.depth++;
 
           for (i in 0...params.length)
@@ -740,6 +749,17 @@ class PolymodInterpEx extends Interp
             catch (err:Dynamic)
             {
               throw err;
+            }
+          }
+
+          // Re-apply any changes to the root Interpreter
+          for (k => v in clone.variables)
+          {
+            if (k == 'trace') continue;
+
+            if (variables[k] != v)
+            {
+              _root.variables.set(k, v);
             }
           }
           return r;
@@ -2185,19 +2205,21 @@ class PolymodInterpEx extends Interp
   {
     var _clone = new PolymodInterpEx(this.targetCls, this._proxy);
 
-    // Pass the variables by reference
-    _clone.variables = this.variables;
-
-    for (k => v in this.locals)
+    for (k => v in this.variables)
     {
-      _clone.locals.set(k, v);
+      if (k != 'trace') _clone.variables.set(k, v);
     }
+
+    _clone.locals = duplicate(this.locals);
 
     for (v in this.declared)
     {
       if (!_clone.declared.contains(v)) _clone.declared.push(v);
     }
 
+    if (depth == 0) _root = this;
+
+    _clone._root = this._root;
     _clone._nextCallObject = this._nextCallObject;
     _clone._classDeclOverride = this._classDeclOverride;
     _clone.depth = this.depth;


### PR DESCRIPTION
> [!NOTE]
> #279 introduced a crash which may happen when testing this PR. 

There was already a PR that had addressed this, but it introduced a bug where variables of a class returned to their previous value after a local function ended. I made another PR that fixed that, but at the cost of a regression.

So this is the ultimate fix for this issue, which is as jank as ever. <img src="https://files.catbox.moe/bbduf4.png" width=24 height=24 />

Here's a repro code snippet which demonstrates both of the issues addressed.
```haxe
import funkin.modding.module.Module;
import funkin.modding.module.ModuleHandler;
import flixel.util.FlxTimer;
import flixel.FlxG;


class Test extends Module
{
  function new()
  {
    super("test", -99999);
  }

  var test = 0;

  public override function onUpdate(event:ScriptEvent):Void
  {
    super.onUpdate(event);
    
    if (FlxG.keys.justPressed.ONE)
    {
      example1(() -> {
      	trace("Callback called!");
      }, 474);

      function example2()
      {
        FlxTimer.wait(0, () -> {
          test ++;
          trace('test ${test}');
        });
      }
      example2();

      // Bug: "test" is unaffected by local functions.
      trace('test again: $test');
    }
  }

  // Regression: arguments are lost in native function callbacks
  public function example1(callback:() -> Void, obj:Dynamic):Void
  {
    FlxTimer.wait(1, function():Void {
      callback(); // errors saying it cant find "callback"
      trace(Std.string(obj)); // will also error saying it cant find "obj"
    });
  }
}
```
