### PR TITLE
[FIX] Fix crash due to the new param count validation.

### DIFF
--- a/polymod/hscript/_internal/PolymodExprEx.hx
+++ b/polymod/hscript/_internal/PolymodExprEx.hx
@@ -48,6 +48,7 @@ enum ErrorEx
   EBlacklistedModule(m:String);
   EBlacklistedField(f:String);
   EPurgedFunction(f:String); // Function can't be called because it previously threw an uncaught exception
+  EInvalidArgCount(f:String, expected:Int, given:Int); // Given arguments count don't match the minimum required parameters
   ENullObjectReference(f:String); // Accessing a field of "null"
   EInvalidScriptedFnAccess(f:String);
   EInvalidScriptedVarGet(v:String);

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1755,6 +1755,9 @@ class PolymodInterpEx extends Interp
    */
   public function validateArgumentCount(params:Array<Argument>, args:Array<Dynamic>, name:Null<String>)
   {
+    // getters/setters have null given arguments it seems, so we return early
+    if (args == null) return;
+
     var minParams = 0;
     for (i in 0...params.length)
     {
@@ -1764,7 +1767,7 @@ class PolymodInterpEx extends Interp
 
     if (args.length < minParams)
     {
-      errorEx(ECustom('Invalid number of parameters. Got ${args.length}, required $minParams${(name != null) ? " for function '" + name + "'" : ""}.'));
+      errorEx(EInvalidArgCount((name != null) ? " for function '" + name + "'" : "", minParams, args.length));
     }
   }
 

--- a/polymod/hscript/_internal/PolymodPrinterEx.hx
+++ b/polymod/hscript/_internal/PolymodPrinterEx.hx
@@ -23,6 +23,7 @@ class PolymodPrinterEx extends Printer
       case EInvalidModule(m): "Invalid module: " + m;
       case EBlacklistedModule(m): "Blacklisted module: " + m;
       case EBlacklistedField(m): "Blacklisted field: " + m;
+      case EInvalidArgCount(f, expected, given): 'Invalid number of given arguments. Got $given, required $expected' + f;
       case EPurgedFunction(f): "Invalid access to purged function (did it throw an uncaught exception earlier?): " + f;
       case ENullObjectReference(f): "Invalid reference to field of a null object: " + f;
       case EInvalidInStaticContext(v): "Invalid field access from static context: " + v;


### PR DESCRIPTION
This PR fixes a crash introduced in my PR #279 which crashed the game if getters/setters functions are used.

It also adds a custom Error for invalid arguments count.