### PR TITLE
[FIX] Fix compiler error when hscriptPos is not defined

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1800,8 +1800,10 @@ class Parser
               input = oldInput;
               readPos = oldPos;
               offset = oldOffset;
+              #if hscriptPos
               tokenMin = oldTokenMin;
               tokenMax = oldTokenMax;
+              #end
               char = -1;
 
               b = new StringBuf();

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -2190,7 +2190,9 @@ class PolymodInterpEx extends Interp
     _clone._nextCallObject = this._nextCallObject;
     _clone._classDeclOverride = this._classDeclOverride;
     _clone.depth = this.depth;
+    #if hscriptPos
     _clone.curExpr = this.curExpr;
+    #end
     _clone.inTry = this.inTry;
     return _clone;
   }


### PR DESCRIPTION
We just add some preprocessor checks to ensure variables, that do not exist when hscriptPos is not defined, aren't being assigned to