### PR TITLE
[FEATURE] Allow ModMetadata to have an `id` field

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -253,15 +253,15 @@ class Polymod
     {
       if (dirs[i] != null)
       {
-        var modId = dirs[i];
-        var meta:ModMetadata = fileSystem.getMetadata(modId);
+        var dir = dirs[i];
+        var meta:ModMetadata = fileSystem.getMetadataByDir(dir);
 
         if (meta != null)
         {
           if (!VersionUtil.match(meta.apiVersion, params.apiVersionRule))
           {
             error(MOD_API_VERSION_MISMATCH,
-              'Mod "${modId}" was built for incompatible API version ${meta.apiVersion.toString()}, expected "${params.apiVersionRule.toString()}"', INIT);
+              'Mod "${dir}" was built for incompatible API version ${meta.apiVersion.toString()}, expected "${params.apiVersionRule.toString()}"', INIT);
           }
 
           // API version matches
@@ -341,7 +341,7 @@ class Polymod
     return sortedModsToLoad;
   }
 
-  public static function getLoadedModIds():Array<String>
+  public static function getLoadedModDirs():Array<String>
   {
     return assetLibrary.dirs;
   }
@@ -369,18 +369,18 @@ class Polymod
    *
    * @return A list of all mods that were successfully loaded.
    */
-  public static function loadMod(modId:String):Array<ModMetadata>
+  public static function loadMod(dir:String):Array<ModMetadata>
   {
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modId".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$dir".', INIT);
       return [];
     }
 
     var newParams = Reflect.copy(prevParams);
     // Add the mod to the list of mods to load.
-    newParams.dirs = newParams.dirs.concat([modId]);
+    newParams.dirs = newParams.dirs.concat([dir]);
     // Keep the same file system between reloads.
     newParams.customFilesystem = assetLibrary.fileSystem;
 
@@ -396,18 +396,18 @@ class Polymod
    *
    * @return A list of all mods that were successfully loaded.
    */
-  public static function loadMods(modIds:Array<String>):Array<ModMetadata>
+  public static function loadMods(modDirs:Array<String>):Array<ModMetadata>
   {
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modDirs".', INIT);
       return [];
     }
 
     var newParams = Reflect.copy(prevParams);
     // Add the mods to the list of mods to load.
-    newParams.dirs = newParams.dirs.concat(modIds);
+    newParams.dirs = newParams.dirs.concat(modDirs);
     // Keep the same file system between reloads.
     newParams.customFilesystem = assetLibrary.fileSystem;
 
@@ -423,18 +423,18 @@ class Polymod
    *
    * @return A list of all mods that were successfully loaded.
    */
-  public static function loadOnlyMods(modIds:Array<String>):Array<ModMetadata>
+  public static function loadOnlyMods(modDirs:Array<String>):Array<ModMetadata>
   {
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modDirs".', INIT);
       return [];
     }
 
     var newParams = Reflect.copy(prevParams);
     // Set the list of mods to load.
-    newParams.dirs = modIds;
+    newParams.dirs = modDirs;
     // Keep the same file system between reloads.
     newParams.customFilesystem = assetLibrary.fileSystem;
 
@@ -469,18 +469,18 @@ class Polymod
    *
    * @return A list of all mods that were successfully loaded.
    */
-  public static function unloadMod(modId:String):Array<ModMetadata>
+  public static function unloadMod(dir:String):Array<ModMetadata>
   {
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modId".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$dir".', INIT);
       return [];
     }
 
     var newParams = Reflect.copy(prevParams);
     // Add the mod to the list of mods to load.
-    newParams.dirs.remove(modId);
+    newParams.dirs.remove(dir);
     // Keep the same file system between reloads.
     newParams.customFilesystem = assetLibrary.fileSystem;
 
@@ -498,20 +498,20 @@ class Polymod
    *
    * @return A list of all mods that were successfully loaded.
    */
-  public static function unloadMods(modIds:Array<String>):Array<ModMetadata>
+  public static function unloadMods(modDirs:Array<String>):Array<ModMetadata>
   {
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modDirs".', INIT);
       return [];
     }
 
     var newParams = Reflect.copy(prevParams);
     // Add the mod to the list of mods to load.
-    for (modId in modIds)
+    for (dir in modDirs)
     {
-      newParams.dirs.remove(modId);
+      newParams.dirs.remove(dir);
     }
     // Keep the same file system between reloads.
     newParams.customFilesystem = assetLibrary.fileSystem;
@@ -1228,10 +1228,16 @@ enum abstract PolymodErrorCode(String) from String to String
 
   /**
    * You requested a mod to be loaded but that mod was not installed.
-   * - Make sure a mod with that ID is installed.
-   * - Make sure to run Polymod.scan to get the list of valid mod IDs.
+   * - Make sure a mod with that directory is installed.
+   * - Make sure to run Polymod.scan to get the list of valid mod directories.
    */
   public var MOD_MISSING_DIRECTORY:String = 'mod_missing_directory';
+
+  /**
+   * You requested a mod to be loaded but that mod was not installed.
+   * - Make sure a mod with that ID is installed.
+   */
+  public var MOD_MISSING_ID:String = 'mod_missing_id';
 
   /**
    * You requested a mod to be loaded but its mod folder is missing a metadata file.

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -946,6 +946,11 @@ class ModMetadata
   public var modPath:String;
 
   /**
+   * The directory name of the mod.
+   */
+  public var dirName:String;
+
+  /**
    * `metadata` provides an optional list of keys.
    * These can provide additional information about the mod, specific to your application.
    */
@@ -1058,6 +1063,7 @@ class ModMetadata
     }
 
     var m = new ModMetadata();
+    m.id = JsonHelp.str(json, 'id');
     m.title = JsonHelp.str(json, 'title');
     m.description = JsonHelp.str(json, 'description');
     m._author = JsonHelp.str(json, 'author');

--- a/polymod/fs/MemoryFileSystem.hx
+++ b/polymod/fs/MemoryFileSystem.hx
@@ -188,9 +188,9 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
     return result;
   }
 
-  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
-    var modpath = Util.pathJoin(modRoot, modId);
+    var modpath = Util.pathJoin(modRoot, dirName);
     if (exists(modpath))
     {
       var meta:ModMetadata = null;
@@ -209,7 +209,8 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
         meta = ModMetadata.fromJsonStr(metaText, origin);
         if (meta == null) return null;
 
-        meta.id = modId;
+        meta.id = meta.id == '' ? dirName : meta.id;
+        meta.dirName = dirName;
         meta.modPath = modpath;
       }
 
@@ -227,7 +228,7 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
     }
     else
     {
-      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $modpath', origin);
+      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $dirName', origin);
     }
     return null;
   }

--- a/polymod/fs/MemoryFileSystem.hx
+++ b/polymod/fs/MemoryFileSystem.hx
@@ -20,7 +20,7 @@ import thx.semver.VersionRule;
  * Using this file system directly is not recommended, as it is not optimized for native platforms.
  * If you can use a native file system, use `SysFileSystem` or `ZipFileSystem` instead.
  */
-class MemoryFileSystem implements PolymodFileSystem.IFileSystem
+class MemoryFileSystem implements IFileSystem
 {
   var files = new Map<String, Bytes>();
   var directories:Array<String> = [];
@@ -176,7 +176,7 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
 
       if (!isDirectory(testDir)) continue;
 
-      var meta:ModMetadata = getMetadata(dir);
+      var meta:ModMetadata = getMetadataByDir(dir, PolymodErrorOrigin.SCAN);
 
       if (meta == null) continue;
 
@@ -188,7 +188,7 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
     return result;
   }
 
-  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  public function getMetadataByDir(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     var modpath = Util.pathJoin(modRoot, dirName);
     if (exists(modpath))
@@ -230,6 +230,11 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
     {
       Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $dirName', origin);
     }
+    return null;
+  }
+
+  public function getMetadataById(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
     return null;
   }
 }

--- a/polymod/fs/MemoryZipFileSystem.hx
+++ b/polymod/fs/MemoryZipFileSystem.hx
@@ -1,17 +1,14 @@
 package polymod.fs;
 
 // import format.zip.Reader;
-import haxe.ds.StringMap;
+import polymod.Polymod;
+import polymod.fs.ZipFileSystem.ZipFileSystemParams;
+import polymod.util.Util;
 import haxe.io.Bytes;
 import haxe.io.BytesInput;
 import haxe.io.Path;
 import haxe.zip.Entry;
 import haxe.zip.InflateImpl;
-import polymod.fs.PolymodFileSystem.IFileSystem;
-import polymod.fs.PolymodFileSystem.PolymodFileSystemParams;
-import polymod.fs.ZipFileSystem.ZipFileSystemParams;
-import polymod.util.Util;
-import polymod.Polymod;
 
 #if !html5
 class MemoryZipFileSystem extends StubFileSystem
@@ -69,7 +66,7 @@ class MemoryZipFileSystem extends MemoryFileSystem
    */
   public function addZipFile(zipName:String, zipBytes:Bytes)
   {
-    var bytesInput = new haxe.io.BytesInput(zipBytes);
+    var bytesInput = new BytesInput(zipBytes);
     var reader = new haxe.zip.Reader(bytesInput);
 
     var modId = Path.withoutExtension(zipName);
@@ -102,9 +99,14 @@ class MemoryZipFileSystem extends MemoryFileSystem
     return compressedBytes; // if it wasn't actually compressed
   }
 
-  public override function getMetadata(modId:String, ?origin:PolymodErrorOrigin)
+  public override function getMetadataByDir(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
-    return super.getMetadata(modId, origin);
+    return super.getMetadataByDir(dirName, origin);
+  }
+
+  public override function getMetadataById(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
+    return super.getMetadataById(modId, origin);
   }
 }
 #end

--- a/polymod/fs/NodeFileSystem.hx
+++ b/polymod/fs/NodeFileSystem.hx
@@ -168,14 +168,41 @@ class NodeFileSystem implements IFileSystem
   }
 
   // -----------------------------------------------------------------------------------------------
-  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Void
+  // -----------------------------------------------------------------------------------------------
+  public function scanMods(?apiVersionRule:VersionRule):Array<ModMetadata>
   {
-    if (exists(modId))
+    if (apiVersionRule == null) apiVersionRule = VersionUtil.DEFAULT_VERSION_RULE;
+
+    var dirs = readDirectory(modRoot);
+    var result:Array<ModMetadata> = [];
+    for (dir in dirs)
+    {
+      var testDir = Util.pathJoin(modRoot, dir);
+
+      if (!exists(testDir)) continue;
+
+      if (!isDirectory(testDir)) continue;
+
+      var meta:ModMetadata = this.getMetadataByDir(dir, PolymodErrorOrigin.SCAN);
+
+      if (meta == null) continue;
+
+      if (!VersionUtil.match(meta.apiVersion, apiVersionRule)) continue;
+
+      result.push(meta);
+    }
+
+    return result;
+  }
+
+  public function getMetadataByDir(dir:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
+    if (exists(dir))
     {
       var meta:ModMetadata = null;
 
-      var metaFile = Util.pathJoin(modId, PolymodConfig.modMetadataFile);
-      var iconFile = Util.pathJoin(modId, PolymodConfig.modIconFile);
+      var metaFile = Util.pathJoin(dir, PolymodConfig.modMetadataFile);
+      var iconFile = Util.pathJoin(dir, PolymodConfig.modIconFile);
 
       if (!exists(metaFile))
       {
@@ -200,35 +227,13 @@ class NodeFileSystem implements IFileSystem
     }
     else
     {
-      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: "$modId"', origin);
+      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: "$dir"', origin);
     }
     return null;
   }
 
-  // -----------------------------------------------------------------------------------------------
-  public function scanMods(?apiVersionRule:VersionRule):Array<ModMetadata>
+  public function getMetadataById(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
-    if (apiVersionRule == null) apiVersionRule = VersionUtil.DEFAULT_VERSION_RULE;
-
-    var dirs = readDirectory(modRoot);
-    var result:Array<ModMetadata> = [];
-    for (dir in dirs)
-    {
-      var testDir = Util.pathJoin(modRoot, dir);
-
-      if (!exists(testDir)) continue;
-
-      if (!isDirectory(testDir)) continue;
-
-      var meta:ModMetadata = this.getMetadata(dir, PolymodErrorOrigin.SCAN);
-
-      if (meta == null) continue;
-
-      if (!VersionUtil.match(meta.apiVersion, apiVersionRule)) continue;
-
-      result.push(meta);
-    }
-
-    return result;
+    return null;
   }
 }

--- a/polymod/fs/PolymodFileSystem.hx
+++ b/polymod/fs/PolymodFileSystem.hx
@@ -132,10 +132,19 @@ interface IFileSystem
 
   /**
    * Provides the metadata for a given mod. Returns null if the mod does not exist.
+   * @param modId The directory of the mod.
+   * @param origin The context the error occurred in (while scanning for mods, while initializing mods, etc).
+   *   Used for error reporting.
+   * @return The mod metadata.
+   */
+  public function getMetadataByDir(dir:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>;
+
+  /**
+   * Provides the metadata for a given mod. Returns null if the mod does not exist.
    * @param modId The ID of the mod.
    * @param origin The context the error occurred in (while scanning for mods, while initializing mods, etc).
    *   Used for error reporting.
    * @return The mod metadata.
    */
-  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>;
+  public function getMetadataById(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>;
 }

--- a/polymod/fs/StubFileSystem.hx
+++ b/polymod/fs/StubFileSystem.hx
@@ -11,7 +11,7 @@ import thx.semver.VersionRule;
  *
  * Your program won't crash, but mods WILL NOT LOAD if this is used.
  */
-class StubFileSystem implements PolymodFileSystem.IFileSystem
+class StubFileSystem implements IFileSystem
 {
   public function new(params:PolymodFileSystem.PolymodFileSystemParams) {}
 
@@ -36,6 +36,9 @@ class StubFileSystem implements PolymodFileSystem.IFileSystem
   public inline function scanMods(?apiVersionRule:VersionRule):Array<ModMetadata>
     return [];
 
-  public inline function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  public inline function getMetadataByDir(dir:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+    return null;
+
+  public inline function getMetadataById(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
     return null;
 }

--- a/polymod/fs/SysFileSystem.hx
+++ b/polymod/fs/SysFileSystem.hx
@@ -88,7 +88,7 @@ class SysFileSystem implements IFileSystem
       var fullDir = Util.pathJoin(modRoot, dir);
       if (!isDirectory(fullDir)) continue;
 
-      var meta:ModMetadata = this.getMetadata(dir, PolymodErrorOrigin.SCAN);
+      var meta:ModMetadata = this.getMetadataByDir(dir, PolymodErrorOrigin.SCAN);
 
       if (meta == null) continue;
 
@@ -106,7 +106,7 @@ class SysFileSystem implements IFileSystem
     return result;
   }
 
-  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  public function getMetadataByDir(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     var modPath = Util.pathJoin(modRoot, dirName);
     if (exists(modPath))
@@ -149,6 +149,35 @@ class SysFileSystem implements IFileSystem
     {
       Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $dirName', origin);
     }
+    return null;
+  }
+
+  public function getMetadataById(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
+    for (dir in readDirectory(modRoot))
+    {
+      var modPath = Util.pathJoin(modRoot, dir);
+      if (exists(modPath))
+      {
+        var meta:ModMetadata = null;
+
+        var metaFile = Util.pathJoin(modPath, PolymodConfig.modMetadataFile);
+
+        if (!exists(metaFile)) continue;
+        else
+        {
+          var metaText = getFileContent(metaFile);
+          meta = ModMetadata.fromJsonStr(metaText, origin);
+        }
+
+        if (meta == null) continue;
+
+        if (meta.id != modId && dir != modId) continue;
+
+        return meta;
+      }
+    }
+    Polymod.error(MOD_MISSING_ID, 'Could not find mod with ID: $modId', origin);
     return null;
   }
 

--- a/polymod/fs/SysFileSystem.hx
+++ b/polymod/fs/SysFileSystem.hx
@@ -106,9 +106,9 @@ class SysFileSystem implements IFileSystem
     return result;
   }
 
-  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
-    var modPath = Util.pathJoin(modRoot, modId);
+    var modPath = Util.pathJoin(modRoot, dirName);
     if (exists(modPath))
     {
       var meta:ModMetadata = null;
@@ -129,7 +129,8 @@ class SysFileSystem implements IFileSystem
 
       if (meta == null) return null;
 
-      meta.id = modId;
+      meta.id = meta.id == '' ? dirName : meta.id;
+      meta.dirName = dirName;
       meta.modPath = modPath;
 
       if (!exists(iconFile))
@@ -146,7 +147,7 @@ class SysFileSystem implements IFileSystem
     }
     else
     {
-      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $modId', origin);
+      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $dirName', origin);
     }
     return null;
   }

--- a/polymod/fs/SysZipFileSystem.hx
+++ b/polymod/fs/SysZipFileSystem.hx
@@ -15,7 +15,6 @@ import haxe.Constraints.IMap;
 import haxe.ds.StringMap;
 import haxe.io.Bytes;
 import haxe.io.Path;
-import polymod.Polymod.ModMetadata;
 import polymod.util.Util;
 import polymod.util.InsensitiveMap;
 import polymod.util.zip.ZipParser;


### PR DESCRIPTION
This PR adds aims to replace the mod ID system to allow custom IDs for mods instead.
It won't break mods that don't have an `id` field in their metadata, nor their dependencies, because if the id is empty it will default to the directory name like it was in the old behavior. 

> [!IMPORTANT]
> If this PR is accepted, games like Friday Night Funkin' that use the polymod framework should change from `meta.id` to `meta.dirName` when loading mods.

### Old Problem
With the old system mods could ship zips with different names other than the dependency name other mods are using, for example if the dependent mod's metadata had:
```json
{
  "dependencies": {
    "Mod": "0.0.0"
  }
}
```

Polymod would check for the folder name `Mod`, but a user, the modder or some platform could ship the mod folder name differently like `Mod-main` or `Mod-b010349` instead inside the archive, and some people extract archives without the archive's name and then need to create one for the mod and then extract the contents there.

### New Problem
A mod id can be used between multiple mods, so a conflict check should be added in the environment that loads mods. But the chance of that happening is very low.

### Extra
This PR also adds a new function in `FileSystem` named `getMetadataById(modId:String)`, which allows the recieving of metadatas based on the ID of a mod. Also renames the `getMetadata(modId:String)` to `getMetadataByDir(dir:String)`. **(only for SysFileSystem at the moment!)**

<img width="1714" height="369" alt="image" src="https://github.com/user-attachments/assets/f56b5d0f-c545-4c5f-857c-6002bc5839ce" />
