### PR TITLE
Fix error on HTML5

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -52,7 +52,9 @@ class Interp
   public function new()
   {
     locals = new Map();
-    declared = new Array();
+    declared = [];
+    depth = 0;
+    inTry = false;
     resetVariables();
     initOps();
   }


### PR DESCRIPTION
This fixes an error with local functions in HTML5 because, unlike in other targets, any value is initialized as `null`, even numeric variables. So what was happening was that `depth` is null, which caused `clone` to not set the `_root` correctly.