### PR TITLE
[ENHANCEMENT] Add the Ability to Get Scripted Super Classes to `PolymodScriptClass.getSuperClasses`

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -329,7 +329,7 @@ class PolymodScriptClass
         baseSuperClsName = baseSuperClsName.split('<')[0];
       }
 
-      var superCls:Class<Dynamic> = null;
+      var superCls:Dynamic = null;
 
       if (classDecl.imports.exists(baseSuperClsName))
       {
@@ -356,10 +356,14 @@ class PolymodScriptClass
         while (superCls != null)
         {
           // Recursively add this class's superclasses.
-          result.push(Type.getClassName(superCls));
+          if (Std.isOfType(superCls, PolymodScriptClass)) result.push(superCls.fullyQualifiedName);
+          else
+            result.push(Type.getClassName(superCls));
 
           // This returns null when the class has no superclass.
-          superCls = Type.getSuperClass(superCls);
+          if (Std.isOfType(superCls, PolymodScriptClass)) superCls = superCls.superClass;
+          else
+            superCls = Type.getSuperClass(superCls);
         }
         return result;
       }


### PR DESCRIPTION
With the extension of scripted classes being available now, I thought it would be nice if the `getSuperClasses` function of `PolymodScriptClass` could get super classes that are scripted, so here we are. Instead of returning `poylmod.hscript._internal.PolymodScriptClass` when using `getSuperClasses` with a scripted class that extends a scripted class, it will return the scripted class' name.