### PR TITLE
Fix persistence of named local functions

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -768,19 +768,11 @@ class PolymodInterpEx extends Interp
         newFun = Reflect.makeVarArgs(newFun);
         if (name != null)
         {
-          if (depth == 0)
-          {
-            // Store the function as a global.
-            variables.set(name, newFun);
-          }
-          else
-          {
-            // function-in-function is a local function
-            declared.push({n: name, old: locals.get(name)});
-            var ref = {r: newFun};
-            locals.set(name, ref);
-            clone.locals.set(name, ref); // allow self-recursion
-          }
+          // function-in-function is a local function
+          declared.push({n: name, old: locals.get(name)});
+          var ref = {r: newFun};
+          locals.set(name, ref);
+          clone.locals.set(name, ref); // allow self-recursion
         }
         return newFun;
       case EArrayDecl(arr):


### PR DESCRIPTION
Fixes https://github.com/FunkinCrew/polymod/issues/322

This came from the original Interp code, which never really had a class design in mind.