### PR TITLE
Fix another compiler error when `hscriptPos` is not defined

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -408,11 +408,11 @@ class Parser
     return switch (expr(e)) {
       case EIdent(v):
         {name: v, t: null, opt: false, value: null};
-      case ECheckType({e: EIdent(v)}, t):
+      case ECheckType(expr(_) => EIdent(v), t):
         {name: v, t: t, opt: false, value: null};
-      case EBinop("=", {e: EIdent(v)}, def):
+      case EBinop("=", expr(_) => EIdent(v), def):
         {name: v, t: null, opt: false, value: def};
-      case EBinop("=", {e: ECheckType({e: EIdent(v)}, t)}, def):
+      case EBinop("=", expr(_) => ECheckType(expr(_) => EIdent(v), t), def):
         {name: v, t: t, opt: false, value: def};
       default:
         null;


### PR DESCRIPTION
> [!NOTE]
> This PR will not fully solve the error because the fix from https://github.com/FunkinCrew/polymod/pull/314 went to `experimental-abstracts` instead, and I don't wanna apply the fix that was already done there.

It is important to know that `Expr` changes depending of if `hscriptPos` is enabled; this PR fixes a function not accounting for that.

P.S: This file needs another reformat :obese_cat: