### PR TITLE
[BUGFIX] Fix globals getting removed after calling a function with the same argument name

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -616,6 +616,9 @@ class PolymodScriptClass
         }
         else
         {
+          // We don't want to remove variables that were defined as globals in the script.
+          if (this.findVar(a.name, true) != null) continue;
+
           _interp.variables.remove(a.name);
         }
       }


### PR DESCRIPTION
Minimal reproduction method:
```
import funkin.modding.module.Module;

class TestModule extends Module
{
  var thing:String;

  public function onCreate(event:ScriptEvent)
  {
    super.onCreate(event);

    this.test("goomba");
    trace(thing); // Should trace "goomba" but traces null
  }

  function test(thing:String)
  {
    this.thing = thing;
  }
}
```
This is because in PolymodScriptClass' `callFunction` function, every variable from interp that wasn't a previously defined variable gets removed, which includes function arguments. Pair that with naming a global variable the same as the function argument, and the result is that the global variable gets its value reset after exiting the function.