### PR TITLE
[DOCS] Fix wrong parse error

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -166,7 +166,7 @@ class PolymodScriptClass
             Polymod.error(SCRIPT_PARSE_ERROR,
               'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}');
           default:
-            Polymod.error(SCRIPT_PARSE_ERROR, 'Error while executing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}');
+            Polymod.error(SCRIPT_PARSE_ERROR, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}');
         }
       }
     }


### PR DESCRIPTION
Fixes a parse error saying it's "executing" the script.