### PR TITLE
[FIX] Properly parse conjoined string interpolation

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -2037,6 +2037,11 @@ class Parser
           if (!idents[c])
           {
             pushBufId(i);
+            if (c == '$'.code)
+            {
+              state = Interp;
+              continue;
+            }
             state = Literal;
           }
       }


### PR DESCRIPTION
Fixes the parsing of `"$a$b"`