### PR TITLE
[FEATURE] Allow polymod to parse `.hx` files as well as `.hxc`.

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -14,6 +14,7 @@ import polymod.util.VersionUtil;
 import thx.semver.Version;
 import thx.semver.VersionRule;
 
+using Lambda;
 using StringTools;
 
 #if firetongue
@@ -660,7 +661,7 @@ class Polymod
 
       for (textPath in potentialScripts)
       {
-        if (textPath.endsWith(PolymodConfig.scriptClassExt))
+        if (PolymodConfig.scriptClassExt.exists(ext -> textPath.endsWith(ext)))
         {
           var path = textPath;
           if (!Polymod.assetLibrary.exists(path))
@@ -703,7 +704,7 @@ class Polymod
     var futures:Array<lime.app.Future<Bool>> = [];
     for (textPath in potentialScripts)
     {
-      if (textPath.endsWith(PolymodConfig.scriptClassExt))
+      if (PolymodConfig.scriptClassExt.exists(ext -> textPath.endsWith(ext)))
       {
         var path = textPath;
         if (!Polymod.assetLibrary.exists(path))

--- a/polymod/PolymodConfig.hx
+++ b/polymod/PolymodConfig.hx
@@ -87,12 +87,12 @@ class PolymodConfig
    *
    * @default `.hxc`
    */
-  public static var scriptClassExt(get, default):String;
+  public static var scriptClassExt(get, default):Array<String>;
 
-  static function get_scriptClassExt():String
+  static function get_scriptClassExt():Array<String>
   {
     // If the value is null, retrieve the value as a Haxe define.
-    if (scriptClassExt == null) scriptClassExt = DefineUtil.getDefineString('POLYMOD_SCRIPT_CLASS_EXT', '.hxc');
+    if (scriptClassExt == null) scriptClassExt = DefineUtil.getDefineStringArray('POLYMOD_SCRIPT_CLASS_EXT', [".hxc", ".hx"]);
     return scriptClassExt;
   }
 


### PR DESCRIPTION
## Linked Issues
- Closes https://github.com/FunkinCrew/Funkin/issues/6185

## Description
This PR allows the polymod to parse the `.hx` files from mods alongside the `.hxc` files.
No clue why someone would want this but yea

<sub>Even tho I am against this 😬</sub>