### PR TITLE
PolymodErrorCode refactor

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -259,7 +259,7 @@ class Polymod
         {
           if (!VersionUtil.match(meta.apiVersion, params.apiVersionRule))
           {
-            error(VERSION_CONFLICT_API,
+            error(MOD_API_VERSION_MISMATCH,
               'Mod "${modId}" was built for incompatible API version ${meta.apiVersion.toString()}, expected "${params.apiVersionRule.toString()}"', INIT);
           }
 
@@ -282,7 +282,7 @@ class Polymod
     }
     else
     {
-      Polymod.warning(DEPENDENCY_CHECK_SKIPPED, "Dependency checks were skipped.");
+      Polymod.warning(MOD_DEPENDENCY_CHECK_SKIPPED, "Dependency checks were skipped.", INIT);
     }
 
     // Get the file path for each mod to load, in order.
@@ -321,7 +321,7 @@ class Polymod
     // Do scripted class initialization now that the assetLibrary is loaded.
     if (params.useScriptedClasses)
     {
-      Polymod.notice(PolymodErrorCode.SCRIPT_PARSING, 'Parsing script classes...');
+      Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes...');
       Polymod.clearScripts();
 
       if (params.loadScriptsAsync)
@@ -333,7 +333,7 @@ class Polymod
         Polymod.registerAllScriptClasses();
 
         var classList = polymod.hscript._internal.PolymodScriptClass.listScriptClasses();
-        Polymod.notice(PolymodErrorCode.SCRIPT_PARSED, 'Parsed and registered ${classList.length} scripted classes.');
+        Polymod.info(SCRIPT_PARSE_DONE, 'Parsed and registered ${classList.length} scripted classes.');
       }
     }
 
@@ -353,7 +353,7 @@ class Polymod
   {
     if (assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot return file system.', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot return file system.', INIT);
       return null;
     }
     return assetLibrary.fileSystem;
@@ -373,7 +373,7 @@ class Polymod
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot load mod "$modId".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modId".', INIT);
       return [];
     }
 
@@ -400,7 +400,7 @@ class Polymod
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
       return [];
     }
 
@@ -427,7 +427,7 @@ class Polymod
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
       return [];
     }
 
@@ -473,7 +473,7 @@ class Polymod
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot load mod "$modId".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modId".', INIT);
       return [];
     }
 
@@ -502,7 +502,7 @@ class Polymod
     // Check if Polymod is loaded.
     if (prevParams == null || assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot load mod "$modIds".', INIT);
       return [];
     }
 
@@ -530,7 +530,7 @@ class Polymod
     // Check if Polymod is loaded.
     if (assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot clear mods.', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot clear mods.', INIT);
       return;
     }
 
@@ -554,7 +554,7 @@ class Polymod
     // Check if Polymod is loaded.
     if (assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot clear mods.', INIT);
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot clear mods.', INIT);
       return;
     }
 
@@ -589,7 +589,7 @@ class Polymod
       // Scan using assetLibrary's file system.
       if (assetLibrary == null)
       {
-        Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot scan for mods.', INIT);
+        Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot scan for mods.', INIT);
         return [];
       }
 
@@ -625,7 +625,7 @@ class Polymod
   {
     if (assetLibrary == null)
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot clear cache.');
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot clear cache.', INIT);
       return;
     }
 
@@ -665,19 +665,17 @@ class Polymod
           var path = textPath;
           if (!Polymod.assetLibrary.exists(path))
           {
-            trace('Trying libraries: ${libraryIds}');
             for (libraryId in libraryIds)
             {
               if (Polymod.assetLibrary.exists('$libraryId:$textPath'))
               {
-                trace('Found file in library: $libraryId');
                 path = '$libraryId:$textPath';
                 break;
               }
             }
             if (!Polymod.assetLibrary.exists(path)) throw 'Couldn\'t find file "$textPath"';
           }
-          Polymod.debug('Registering script class "$path"');
+          Polymod.debug('Registering scripted class "$path"');
           polymod.hscript._internal.PolymodScriptClass.registerScriptClassByPath(path);
         }
       }
@@ -714,14 +712,13 @@ class Polymod
           {
             if (Polymod.assetLibrary.exists('$libraryId:$textPath'))
             {
-              trace('Found file in library: $libraryId');
               path = '$libraryId:$textPath';
               break;
             }
           }
           if (!Polymod.assetLibrary.exists(path)) throw 'Couldn\'t find file "$textPath" (tried libraries ${libraryIds})';
         }
-        Polymod.debug('Fetching script class "$path"');
+        Polymod.debug('Fetching scripted class "$path"');
         var future = polymod.hscript._internal.PolymodScriptClass.registerScriptClassByPathAsync(path);
         if (future != null) futures.push(future);
       }
@@ -732,6 +729,13 @@ class Polymod
     return futures;
   }
 
+  /**
+   * Dispatch an error message with the severity `PolymodErrorType.ERROR`.
+   * Use this for severe errors that the user should be notified about.
+   * @param code The error code.
+   * @param message The message to display.
+   * @param origin The context the error occurred in (while scanning for mods, while initializing mods, etc).
+   */
   public static function error(code:PolymodErrorCode, message:String, origin:PolymodErrorOrigin = UNKNOWN):Void
   {
     if (onError != null)
@@ -740,6 +744,13 @@ class Polymod
     }
   }
 
+  /**
+   * Dispatch an error message with the severity `PolymodErrorType.WARNING`.
+   * Use this for issues that the user might want to know about.
+   * @param code The error code.
+   * @param message The message to display.
+   * @param origin The context the error occurred in (while scanning for mods, while initializing mods, etc).
+   */
   public static function warning(code:PolymodErrorCode, message:String, origin:PolymodErrorOrigin = UNKNOWN):Void
   {
     if (onError != null)
@@ -748,21 +759,32 @@ class Polymod
     }
   }
 
-  public static function notice(code:PolymodErrorCode, message:String, origin:PolymodErrorOrigin = UNKNOWN):Void
+  /**
+   * Dispatch an error message with the severity `PolymodErrorType.INFO`.
+   * Use this for information developers would likely want to know about.
+   * @param code The error code.
+   * @param message The message to display.
+   * @param origin The context the error occurred in (while scanning for mods, while initializing mods, etc).
+   */
+  public static function info(code:PolymodErrorCode, message:String, origin:PolymodErrorOrigin = UNKNOWN):Void
   {
     if (onError != null)
     {
-      onError(new PolymodError(PolymodErrorType.NOTICE, code, message, origin));
+      onError(new PolymodError(PolymodErrorType.INFO, code, message, origin));
     }
   }
 
+  /**
+   * Dispatch an error message with the severity `PolymodErrorType.DEBUG`.
+   * Debug messages are only dispatched if `PolymodConfig.debug` is `true`, and have no error code.
+   * @param message The message to display.
+   * @param posInfo The position the function was called from.
+   */
   public static function debug(message:String, ?posInfo:haxe.PosInfos):Void
   {
     if (PolymodConfig.debug)
     {
-      if (posInfo != null) trace('[POLYMOD] (${posInfo.fileName}#${posInfo.lineNumber}): $message');
-      else
-        trace('[POLYMOD] $message');
+      onError(new PolymodError(PolymodErrorType.DEBUG, null, message, UNKNOWN));
     }
   }
 
@@ -771,7 +793,7 @@ class Polymod
    * @param type the type of asset you want (lime.utils.PolymodAssetType)
    * @return Array<String> a list of assets of the matching type
    */
-  public static function listModFiles(type:PolymodAssetType = null):Array<String>
+  public static function listModFiles(?type:PolymodAssetType):Array<String>
   {
     if (assetLibrary != null)
     {
@@ -779,7 +801,7 @@ class Polymod
     }
     else
     {
-      Polymod.warning(POLYMOD_NOT_LOADED, 'Polymod is not loaded yet, cannot list files.');
+      Polymod.warning(POLYMOD_NOT_INITIALIZED, 'Polymod is not loaded yet, cannot list files.', INIT);
       return [];
     }
   }
@@ -794,6 +816,10 @@ class Polymod
     PolymodScriptClass.importOverrides.set(importAlias, importClass);
   }
 
+  /**
+   * Remove an import alias previously defined by `addImportAlias()`.
+   * @param importAlias The full import class to use as an alias, to be removed.
+   */
   public static function removeImportAlias(importAlias:String):Void
   {
     PolymodScriptClass.importOverrides.remove(importAlias);
@@ -981,6 +1007,10 @@ class ModMetadata
     // No-op constructor.
   }
 
+  /**
+   * Converts a ModMetadata object to a JSON string.
+   * @return The JSON string.
+   */
   public function toJsonStr():String
   {
     var json = {};
@@ -1001,11 +1031,17 @@ class ModMetadata
     return Json.stringify(json, null, '    ');
   }
 
-  public static function fromJsonStr(str:String)
+  /**
+   * Constructs a ModMetadata object from a JSON string.
+   * @param str The JSON string.
+   * @param origin The context we are calling this from (for error reporting).
+   * @return The ModMetadata object, or `null` if it could not be loaded.
+   */
+  public static function fromJsonStr(str:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     if (str == null || str == '')
     {
-      Polymod.error(PARSE_MOD_META, 'Error parsing mod metadata file, was null or empty.');
+      Polymod.error(MOD_METADATA_PARSE_FAILED, 'Error parsing mod metadata file: Contents were null or empty.', origin);
       return null;
     }
 
@@ -1016,7 +1052,7 @@ class ModMetadata
     }
     catch (msg:Dynamic)
     {
-      Polymod.error(PARSE_MOD_META, 'Error parsing mod metadata file: (${msg})');
+      Polymod.error(MOD_METADATA_PARSE_FAILED, 'Error parsing mod metadata file: (${msg})', origin);
       return null;
     }
 
@@ -1034,7 +1070,7 @@ class ModMetadata
     }
     catch (msg:Dynamic)
     {
-      Polymod.error(PARSE_MOD_API_VERSION, 'Error parsing API version: (${msg}) ${PolymodConfig.modMetadataFile} was ${str}');
+      Polymod.error(MOD_API_VERSION_PARSE_FAILED, 'Error parsing API version from metadata: ${msg}', origin);
       return null;
     }
     try
@@ -1043,7 +1079,7 @@ class ModMetadata
     }
     catch (msg:Dynamic)
     {
-      Polymod.error(PARSE_MOD_VERSION, 'Error parsing mod version: (${msg}) ${PolymodConfig.modMetadataFile} was ${str}');
+      Polymod.error(MOD_VERSION_PARSE_FAILED, 'Error parsing mod version from metadata: ${msg}', origin);
       return null;
     }
     m.license = JsonHelp.str(json, 'license');
@@ -1101,29 +1137,40 @@ enum abstract PolymodErrorOrigin(String) from String to String
   /**
    * This error occurred while scanning for mods.
    */
-  var SCAN:String = 'scan';
+  public var SCAN:String = 'scan';
 
   /**
    * This error occurred while initializing Polymod.
    */
-  var INIT:String = 'init';
+  public var INIT:String = 'init';
+
+  /**
+   * This error occurred before or during the execution of a script.
+   */
+  public var SCRIPT_RUNTIME:String = 'script_runtime';
 
   /**
    * This error occurred in an undefined location.
    */
-  var UNKNOWN:String = 'unknown';
+  public var UNKNOWN:String = 'unknown';
 }
 
 /**
- * Represents the severity level of a given error.
+ * Represents the severity level of a given message.
  */
 enum PolymodErrorType
 {
   /**
    * This message is merely an informational notice.
+   * You can simply ignore it.
+   */
+  DEBUG;
+
+  /**
+   * This message is merely an informational notice.
    * You can handle it with a popup, log it, or simply ignore it.
    */
-  NOTICE;
+  INFO;
 
   /**
    * This message is a warning.
@@ -1144,29 +1191,98 @@ enum PolymodErrorType
  */
 enum abstract PolymodErrorCode(String) from String to String
 {
+  //
+  // General Errors
+  //
+
+  /**
+   * You attempted to use a functionality of Polymod that is not fully implemented, or not implemented for the current framework.
+   * - Report the issue here, and describe your setup and provide the error message:
+   *   https://github.com/FunkinCrew/Polymod/issues
+   */
+  public var POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED:String = 'polymod_functionality_not_implemented';
+
+  /**
+   * You attempted to use a functionality of Polymod that has been deprecated and has/will be significantly reworked or altered.
+   * - New features and their associated documentation will be provided in future updates.
+   */
+  public var POLYMOD_FUNCTIONALITY_DEPRECATED:String = 'polymod_functionality_deprecated';
+
+  /**
+   * The app attempted to use a functionality of Polymod that requires Polymod to be initialized,
+   * but Polymod has not been initialized yet.
+   * - Make sure you call `Polymod.init()` before attempting to call this function.
+   */
+  public var POLYMOD_NOT_INITIALIZED:String = 'app_polymod_not_initialized';
+
+  //
+  // Mod Metadata Parsing Errors
+  //
+
+  /**
+   * You requested a mod to be loaded but that mod was not installed.
+   * - Make sure a mod with that ID is installed.
+   * - Make sure to run Polymod.scan to get the list of valid mod IDs.
+   */
+  public var MOD_MISSING_DIRECTORY:String = 'mod_missing_directory';
+
+  /**
+   * You requested a mod to be loaded but its mod folder is missing a metadata file.
+   * - Make sure the mod folder contains a metadata JSON file. Polymod won't recognize the mod without it.
+   */
+  public var MOD_MISSING_METADATA:String = 'mod_missing_metadata';
+
   /**
    * The mod's metadata file could not be parsed.
    * - Make sure the file contains valid JSON.
    */
-  var PARSE_MOD_META:String = 'parse_mod_meta';
+  public var MOD_METADATA_PARSE_FAILED:String = 'mod_metadata_parse_failed';
 
   /**
    * The mod's version string could not be parsed.
    * - Make sure the metadata JSON contains a valid Semantic Version string.
    */
-  var PARSE_MOD_VERSION:String = 'parse_mod_version';
+  public var MOD_VERSION_PARSE_FAILED:String = 'mod_version_parse_failed';
 
   /**
    * The mod's API version string could not be parsed.
    * - Make sure the metadata JSON contains a valid Semantic Version string.
    */
-  var PARSE_MOD_API_VERSION:String = 'parse_mod_api_version';
+  public var MOD_API_VERSION_PARSE_FAILED:String = 'mod_api_version_parse_failed';
 
   /**
-   * The app's API version string (passed to Polymod.init) could not be parsed.
-   * - Make sure the string is a valid Semantic Version string.
+   * A mod with the given ID is missing an icon file.
+   * - This is a warning and can be ignored. Polymod will still load your mod, but it looks better if you add an icon.
+   * - The default location for icons is `_polymod_icon.png`.
    */
-  var PARSE_API_VERSION:String = 'parse_api_version';
+  public var MOD_MISSING_ICON:String = 'mod_missing_icon';
+
+  //
+  // Mod Loading Errors
+  //
+
+  /**
+   * Polymod is preparing to load a particular mod.
+   * - This is an info message. You can log it or ignore it if you like.
+   */
+  public var MOD_LOAD_START:String = 'mod_load_start';
+
+  /**
+   * Polymod attempted to load a particular mod, but failed.
+   * - There will generally be another warning or error before this indicating the reason for the error.
+   */
+  public var MOD_LOAD_FAILED:String = 'mod_load_failed';
+
+  /**
+   * Polymod has successfully loaded a particular mod.
+   * - This is an info message. You can log it or ignore it if you like.
+   * - This is also a good trigger for a UI indicator like a toast notification.
+   */
+  public var MOD_LOAD_DONE:String = 'mod_load_done';
+
+  //
+  // Mod Dependency Errors
+  //
 
   /**
    * Polymod attempted to load a mod, but one or more of its dependencies were missing.
@@ -1174,7 +1290,7 @@ enum abstract PolymodErrorCode(String) from String to String
    * - This is an error if `skipDependencyErrors` is false, no mods will be loaded.
    * - Make sure to inform the user that the required mods are missing.
    */
-  var DEPENDENCY_UNMET:String = 'dependency_unmet';
+  public var MOD_DEPENDENCY_UNMET:String = 'mod_dependency_unmet';
 
   /**
    * Polymod attempted to load a mod, and its dependency was found,
@@ -1183,7 +1299,7 @@ enum abstract PolymodErrorCode(String) from String to String
    * - This is an error if `skipDependencyErrors` is false, no mods will be loaded.
    * - Make sure to inform the user that the required mods have a mismatched version.
    */
-  var DEPENDENCY_VERSION_MISMATCH:String = 'dependency_version_mismatch';
+  public var MOD_DEPENDENCY_VERSION_MISMATCH:String = 'mod_dependency_version_mismatch';
 
   /**
    * Polymod attempted to load a mod, but one of its dependencies created a loop.
@@ -1192,252 +1308,98 @@ enum abstract PolymodErrorCode(String) from String to String
    * - This is an error if `skipDependencyErrors` is false, no mods will be loaded.
    * - Inform the mod authors that the dependency issue exists and must be resolved.
    */
-  var DEPENDENCY_CYCLICAL:String = 'dependency_cyclical';
+  public var MOD_DEPENDENCY_CYCLICAL:String = 'mod_dependency_cyclical';
 
   /**
    * Polymod was configured to skip dependency checks when loading mods, and that mod order should not be checked.
    * - Make sure you are certain this behavior is correct and that you have properly configured Polymod.
    * - This is a warning and can be ignored.
    */
-  var DEPENDENCY_CHECK_SKIPPED:String = 'dependency_check_skipped';
+  public var MOD_DEPENDENCY_CHECK_SKIPPED:String = 'dependency_check_skipped';
+
+  //
+  // Mod Compatibility Errors
+  //
 
   /**
    * The given mod's API version does not match the version rule passed to Polymod.init.
    * - This generally indicates the mod is outdated and should be updated by the author.
    * - Depending on the changes made between API versions, it may be that the only necessary change is editing the version string in the metadata file.
    */
-  var MOD_API_VERSION_MISMATCH:String = 'mod_api_version_mismatch';
+  public var MOD_API_VERSION_MISMATCH:String = 'mod_api_version_mismatch';
+
+  //
+  // Polymod App Configuration Errors
+  //
 
   /**
-   * Polymod tried to access a file that was not found.
-   * - Make sure the file exists before attempting to access it.
+   * The app's API version string (passed to Polymod.init) could not be parsed.
+   * - Make sure the string is a valid Semantic Version string.
    */
-  var FILE_MISSING:String = "file_missing";
+  public var APP_API_VERSION_PARSE_FAILED:String = 'app_api_version_parse_failed';
 
   /**
-   * Polymod tried to access a directory that was not found.
-   * - Make sure the directory exists before attempting to access it.
+   * A bad `customFilesystem` argument was passed to `Polymod.init()`.
+   * - Ensure the input is either an `IFileSystem` or a `Class<IFileSystem>`.
    */
-  var DIRECTORY_MISSING:String = "directory_missing";
+  public var APP_BAD_CUSTOM_FILESYSTEM:String = 'app_bad_custom_filesystem';
+
+  //
+  // Polymod Framework and Backend Errors
+  //
 
   /**
-   * You requested a mod to be loaded but that mod was not installed.
-   * - Make sure a mod with that ID is installed.
-   * - Make sure to run Polymod.scan to get the list of valid mod IDs.
-   */
-  var MISSING_MOD:String = 'missing_mod';
-
-  /**
-   * You requested a mod to be loaded but its mod folder is missing a metadata file.
-   * - Make sure the mod folder contains a metadata JSON file. Polymod won't recognize the mod without it.
-   */
-  var MISSING_META:String = 'missing_meta';
-
-  /**
-   * A mod with the given ID is missing an icon file.
-   * - This is a warning and can be ignored. Polymod will still load your mod, but it looks better if you add an icon.
-   * - The default location for icons is `_polymod_icon.png`.
-   */
-  var MISSING_ICON:String = 'missing_icon';
-
-  /**
-   * We are preparing to load a particular mod.
-   * - This is an info message. You can log it or ignore it if you like.
-   */
-  var MOD_LOAD_PREPARE:String = 'mod_load_prepare';
-
-  /**
-   * We couldn't load a particular mod.
-   * - There will generally be a warning or error before this indicating the reason for the error.
-   */
-  var MOD_LOAD_FAILED:String = 'mod_load_failed';
-
-  /**
-   * We have successfully completed loading a particular mod.
-   * - This is an info message. You can log it or ignore it if you like.
-   * - This is also a good trigger for a UI indicator like a toast notification.
-   */
-  var MOD_LOAD_DONE:String = 'mod_load_done';
-
-  /**
-   * You passed a bad argument to Polymod.init({customFilesystem}).
-   * - Ensure the input is either an IFileSystem or a Class<IFileSystem>.
-   */
-  var BAD_CUSTOM_FILESYSTEM:String = 'bad_custom_filesystem';
-
-  /**
-   * You attempted to perform an operation that requires Polymod to be initialized.
-   * - Make sure you call Polymod.init before attempting to call this function.
-   */
-  var POLYMOD_NOT_LOADED:String = 'polymod_not_loaded';
-
-  /**
-   * A script file of the given name could not be found.
-   * - This happens when calling annotated functions in an HScriptable class when no script file exists.
-   * - Make sure the script file exists in the proper location in your assets folder.
-   * - Alternatively, you can expand your annotation to `@:hscript({optional: true})` to disable the error message,
-   *     if your function can resolve properly without a script.
-   */
-  var SCRIPT_NOT_FOUND:String = 'script_not_found';
-
-  /**
-   * The scripted class does not import an `Assets` class to handle script loading.
-   * - When loading scripts, the target of the HScriptable interface will call `Assets.getText` to read the relevant script file.
-   * - You will need to import `openfl.util.Assets` on the HScriptable class, even if you don't otherwise use it.
-   */
-  var SCRIPT_NO_ASSET_HANDLER:String = 'script_no_asset_handler';
-
-  /**
-   * You attempted to instantiate a scripted class that was not registered.
-   * - Make sure your script is in the assets folder.
-   * - Make sure that `useScriptedClasses` in your Polymod.init parameters is set to true.
-   * - If your scripted class extends another class, make sure that class exists as well.
-   */
-  var SCRIPT_CLASS_NOT_REGISTERED:String = 'script_class_not_registered';
-
-  /**
-   * You attempted to register a new scripted class with a name that is already in use.
-   * - Rename the scripted class to one that is unique and will not conflict with other scripted classes.
-   * - You can also use a package name to avoid conflicts, although you may have to refer to the class by its full name in some places.
-   * - If you need to clear all existing class descriptors, call `Polymod.clearScripts()`.
-   */
-  var SCRIPT_CLASS_ALREADY_REGISTERED:String = 'script_class_already_registered';
-
-  /**
-   * Your script file attempted to import a class that was already imported.
-   * - This is a warning and can be ignored.
-   * - Remove the duplicate import statement to remove the warning.
-   */
-  var SCRIPT_CLASS_MODULE_ALREADY_IMPORTED:String = 'script_class_module_already_imported';
-
-  /**
-   * Your script file attempted to import a class that could not be resolved.
-   * - Check the syntax of the import statement, and check for any typos.
-   */
-  var SCRIPT_CLASS_MODULE_NOT_FOUND:String = 'script_class_module_not_found';
-
-  /**
-   * Your script file attempted to import a blacklisted class.
-   * - This is a security measure to prevent malicious scripts from accessing sensitive classes.
-   * - Remove the import statement to remove the error.
-   */
-  var SCRIPT_CLASS_MODULE_BLACKLISTED:String = 'script_class_module_blacklisted';
-
-  /**
-   * Your script file attempted to access a blacklisted field.
-   * - This is a security measure to prevent malicious scripts from accessing sensitive fields.
-   * - Remove the field access to remove the error.
-   */
-  var SCRIPT_CLASS_FIELD_BLACKLISTED:String = 'script_class_field_blacklisted';
-
-  /**
-   * You attempted to register a new enum with a name that is already in use.
-   * - Rename the enum to one that is unique and will not conflict with other enums.
-   * - If you need to clear all existing enum descriptors, call `Polymod.clearScripts()`.
-   */
-  var SCRIPT_ENUM_ALREADY_REGISTERED:String = 'script_enum_already_registered';
-
-  /**
-   * One or more scripts are about to be parsed.
-   * - This is an info message. You can log it or ignore it if you like.
-   */
-  var SCRIPT_PARSING:String = 'script_parsing';
-
-  /**
-   * One or more scripts have been successfully parsed.
-   * - This is an info message. You can log it or ignore it if you like.
-   */
-  var SCRIPT_PARSED:String = 'script_parsed';
-
-  /**
-   * A script file could not be parsed for some unknown reason.
-   * - Check the syntax of the script file is proper Haxe.
-   * - Read the error message for more information.
-   */
-  var SCRIPT_PARSE_ERROR:String = 'script_parse_error';
-
-  /**
-   * While running a script, an exception was thrown.
-   * - Read the error message for more information.
-   * - Scripted functions will have the local variable `script_error` assigned, allowing you to handle the error gracefully.
-   */
-  var SCRIPT_RUNTIME_EXCEPTION:String = 'script_runtime_exception';
-
-  /**
-   * An installed mod is looking for another mod with a specific version, but the mod is not of that version.
-   * - The mod may be a modpack that includes that mod, or it may be a mod that has the other mod as a dependency.
-   * - Inform your users to install the proper mod version.
-   */
-  var VERSION_CONFLICT_MOD:String = 'version_conflict_mod';
-
-  /**
-   * The mod has an API version that conflicts with the application's API version.
-   * - This means that the mod needs to be updated, checking for compatibility issues with any changes to API version.
-   * - If you're getting this error even for patch versions, be sure to tweak the `POLYMOD_API_VERSION_MATCH` config option.
-   */
-  var VERSION_CONFLICT_API:String = 'version_conflict_api';
-
-  /**
-   * One of the version strings you provided to Polymod.init is invalid.
-   * - Make sure you're using a valid Semantic Version string.
-   */
-  var PARAM_MOD_VERSION:String = 'param_mod_version';
-
-  /**
-   * Indicates what asset framework Polymod has automatically detected for use.
+   * Indicates what asset framework Polymod has been automatically or manually configured to use.
    * - This is an info message, and can either be logged or ignored.
    */
-  var FRAMEWORK_AUTODETECT:String = 'framework_autodetect';
+  public var FRAMEWORK_INIT:String = 'framework_init';
 
   /**
-   * Indicates what asset framework Polymod has been manually configured to use.
-   * - This is an info message, and can either be logged or ignored.
+   * You configured Polymod to use the `CUSTOM` asset framework, then didn't provide a custom backend to Polymod.
+   * - Ensure that `params.customBackend` provides a `Class<IBackend>`.
    */
-  var FRAMEWORK_INIT:String = 'framework_init';
+  public var BACKEND_CUSTOM_UNDEFINED:String = 'backend_custom_undefined';
 
   /**
-   * You configured Polymod to use the `CUSTOM` asset framework, then didn't provide a value for `params.customBackend`.
-   * - Define a class which extends IBackend, and provide it to Polymod.
+   * Polymod could not create the provided backend for the detected framework.
+   * - Read the error message for more information.
+   * - For the `CUSTOM` backend, ensure that `params.customBackend` provides a `Class<IBackend>` that can be properly instantiated.
    */
-  var UNDEFINED_CUSTOM_BACKEND:String = 'undefined_custom_backend';
+  public var BACKEND_INIT_FAILED:String = 'backend_init_failed';
 
   /**
-   * Polymod could not create an instance of the class you provided for `params.customBackend`.
-   * - Check that the class extends IBackend, and can be instantiated properly.
+   * Polymod has successfully registered a core asset path redirect.
+   * All standard assets will be loaded from the target directory instead of the original `assets` folder.
    */
-  var FAILED_CREATE_BACKEND:String = 'failed_create_backend';
+  public var ASSET_REDIRECT_DONE:String = 'asset_redirect_init_done';
 
   /**
-   * You attempted to use a functionality of Polymod that is not fully implemented, or not implemented for the current framework.
-   * - Report the issue here, and describe your setup and provide the error message:
-   *   https://github.com/larsiusprime/polymod/issues
+   * Polymod has failed to register a core asset path redirect.
+   * - Read the error message for more information.
    */
-  var FUNCTIONALITY_NOT_IMPLEMENTED:String = 'functionality_not_implemented';
+  public var ASSET_REDIRECT_MISSING_DIRECTORY:String = 'asset_redirect_missing_directory';
 
   /**
-   * You attempted to use a functionality of Polymod that has been deprecated and has/will be significantly reworked or altered.
-   * - New features and their associated documentation will be provided in future updates.
+   * Polymod has failed to register a core asset path redirect.
+   * - Read the error message for more information.
    */
-  var FUNCTIONALITY_DEPRECATED:String = 'functionality_deprecated';
+  public var ASSET_REDIRECT_FAILED:String = 'asset_redirect_failed';
 
   /**
-   * There was a warning or error attempting to perform a merge operation on a file.
-   * - Check the source and target files are correctly formatted and try again.
+   * Could not initialize the provided file system.
    */
-  var MERGE:String = 'merge_error';
+  public var FILESYSTEM_INIT_FAILED:String = 'filesystem_init_failed';
 
-  /**
-   * There was a warning or error attempting to perform an append operation on a file.
-   * - Check the source and target files are correctly formatted and try again.
-   */
-  var APPEND:String = 'append_error';
+  //
+  // Backend-Specific Errors: Lime
+  //
 
   /**
    * On the Lime and OpenFL platforms, if the base app defines multiple asset libraries,
    * each asset library must be assigned a path to allow mods to override their files.
    * - Provide a `frameworkParams.assetLibraryPaths` object to Polymod.init().
    */
-  var LIME_MISSING_ASSET_LIBRARY_INFO = 'lime_missing_asset_library_info';
+  public var BACKEND_LIME_MISSING_ASSET_LIBRARY_INFO = 'backend_lime_missing_asset_library_info';
 
   /**
    * On the Lime and OpenFL platforms, if the base app defines multiple asset libraries,
@@ -1445,5 +1407,145 @@ enum abstract PolymodErrorCode(String) from String to String
    * - All libraries must have a value under `frameworkParams.assetLibraryPaths`.
    * - Set the value to `./` to fetch assets from the root of the mod folder.
    */
-  var LIME_MISSING_ASSET_LIBRARY_REFERENCE = 'lime_missing_asset_library_reference';
+  public var BACKEND_LIME_MISSING_ASSET_LIBRARY_REFERENCE = 'backend_lime_missing_asset_library_reference';
+
+  //
+  // Asset Access Errors
+  //
+
+  /**
+   * Polymod tried to access a file from its filesystem, but that file could not be retrieved because it was missing.
+   * - Make sure the file exists before attempting to access it.
+   */
+  public var ASSET_MISSING_FILE:String = 'asset_missing_file';
+
+  /**
+   * Polymod tried to access a directory that was not found.
+   * - Make sure the directory exists before attempting to access it.
+   */
+  public var ASSET_MISSING_DIRECTORY:String = 'asset_missing_directory';
+
+  /**
+   * There was a warning or error attempting to perform a merge operation on a file.
+   * - Check the source and target files are correctly formatted and try again.
+   */
+  public var ASSET_MERGE_FAILED:String = 'asset_merge_failed';
+
+  /**
+   * There was a warning or error attempting to perform an append operation on a file.
+   * - Check the source and target files are correctly formatted and try again.
+   */
+  public var ASSET_APPEND_FAILED:String = 'asset_append_failed';
+
+  //
+  // Script Parsing Errors
+  //
+
+  /**
+   * One or more scripts are about to be parsed.
+   * - This is an info message. You can log it or ignore it if you like.
+   */
+  public var SCRIPT_PARSE_START:String = 'script_parse_start';
+
+  /**
+   * One or more scripts have been successfully parsed.
+   * - This is an info message. You can log it or ignore it if you like.
+   */
+  public var SCRIPT_PARSE_DONE:String = 'script_parse_done';
+
+  /**
+   * A script file could not be parsed for some unknown reason.
+   * - Check the syntax of the script file is proper Haxe code.
+   * - Read the error message for more information.
+   */
+  public var SCRIPT_PARSE_FAILED:String = 'script_parse_failed';
+
+  //
+  // Script Execution Errors
+  //
+
+  /**
+   * While running a script, an exception was thrown.
+   * - Read the error message for more information.
+   * - Annotated functions will have the local variable `script_error` assigned, allowing you to handle the error gracefully.
+   * - Scripted classes will purge the offending function, preventing the error from occuring again until the script is reloaded.
+   */
+  public var SCRIPT_RUNTIME_EXCEPTION:String = 'script_runtime_exception';
+
+  //
+  // Scripted Function Loading Errors
+  //
+
+  /**
+   * Polymod attempted to load a specific script file, but could not find it.
+   * - This happens when calling annotated functions in an `HScriptable` class when no script file exists.
+   * - Make sure the script file exists in the proper location in your assets folder.
+   * - Alternatively, you can expand your annotation to `@:hscript({optional: true})` to disable the error message,
+   *     if your function can resolve properly without an attached script.
+   */
+  public var SCRIPT_NOT_FOUND:String = 'script_not_found';
+
+  /**
+   * The scripted class does not import an `Assets` class to handle script loading.
+   * - When using `HScriptable` to invoke scripts with annotated functions, `Assets.getText` will be used to load the relevant script.
+   * - You will need to import `openfl.util.Assets` on the HScriptable class, even if you don't otherwise use it.
+   */
+  public var SCRIPT_NO_ASSET_HANDLER:String = 'script_no_asset_handler';
+
+  //
+  // Scripted Class Loading Errors
+  //
+
+  /**
+   * You attempted to instantiate a scripted class when no scripted classes were initialized.
+   * - Make sure that `useScriptedClasses` in your Polymod.init parameters is set to true.
+   */
+  public var SCRIPTED_CLASS_NOT_INITIALIZED:String = 'scripted_class_not_initialized';
+
+  /**
+   * You attempted to instantiate a scripted class that was not registered.
+   * - Make sure the script file containing your scripted class is in the assets folder.
+   * - Make sure that `useScriptedClasses` in your Polymod.init parameters is set to true.
+   * - If your scripted class extends another class, make sure that class exists as well.
+   */
+  public var SCRIPTED_CLASS_NOT_REGISTERED:String = 'scripted_class_not_registered';
+
+  /**
+   * You attempted to register a new scripted class or enum with a name that is already in use.
+   * - Rename the scripted class to one that is unique and will not conflict with other scripted classes.
+   * - You can also use a package name to avoid conflicts, although you may have to refer to the class by its full name to use it.
+   * - If you need to clear all existing class descriptors, call `Polymod.clearScripts()`.
+   */
+  public var SCRIPTED_CLASS_ALREADY_REGISTERED:String = 'scripted_class_already_registered';
+
+  /**
+   * Your script file attempted to import a class or module that was already imported.
+   * - This is a warning and can be ignored.
+   * - Remove the duplicate import statement to resolve the warning.
+   */
+  public var SCRIPTED_CLASS_REDUNDANT_IMPORT:String = 'scripted_class_redundant_import';
+
+  /**
+   * Your script file attempted to import a class or module that could not be resolved.
+   * - Check the syntax of the import statement, and check for any typos.
+   */
+  public var SCRIPTED_CLASS_UNRESOLVED_IMPORT:String = 'scripted_class_unresolved_import';
+
+  //
+  // Scripted Class Runtime Errors
+  //
+
+  /**
+   * Your script file attempted to import a class that was blacklisted with `Polymod.blacklistImport()`.
+   * - This is a security measure to prevent malicious scripts from accessing sensitive classes.
+   * - Remove the import statement to remove the error.
+   */
+  public var SCRIPTED_CLASS_BLACKLISTED_MODULE:String = 'scripted_class_blacklisted_module';
+
+  /**
+   * Your script file attempted to access a field that was blacklisted with `Polymod.blacklistStaticFields()` or `Polymod.blacklistInstanceFields()`
+   * - This is a security measure to prevent malicious scripts from accessing sensitive fields.
+   * - Remove the field access to remove the error.
+   */
+  public var SCRIPTED_CLASS_BLACKLISTED_FIELD:String = 'scripted_class_blacklisted_field';
 }

--- a/polymod/PolymodConfig.hx
+++ b/polymod/PolymodConfig.hx
@@ -85,7 +85,7 @@ class PolymodConfig
    * Set this option by setting the `POLYMOD_SCRIPT_CLASS_EXT` Haxe define at compile time,
    * or by setting this value in your code.
    *
-   * @default `.hclass`
+   * @default `.hxc`
    */
   public static var scriptClassExt(get, default):String;
 

--- a/polymod/backends/CastleBackend.hx
+++ b/polymod/backends/CastleBackend.hx
@@ -5,6 +5,6 @@ class CastleBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FUNCTIONALITY_NOT_IMPLEMENTED, 'CastleDB support in Polymod has not been implemented yet');
+    Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED, 'CastleDB support in Polymod has not been implemented yet', INIT);
   }
 }

--- a/polymod/backends/CeramicBackend.hx
+++ b/polymod/backends/CeramicBackend.hx
@@ -6,7 +6,7 @@ class CeramicBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FUNCTIONALITY_NOT_IMPLEMENTED, 'CeramicBackend requires the ceramic library, did you forget to install it?');
+    Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED, 'CeramicBackend requires the ceramic library, did you forget to install it?', INIT);
   }
 }
 #else
@@ -15,7 +15,7 @@ class CeramicBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FUNCTIONALITY_NOT_IMPLEMENTED, 'CeramicBackend support in Polymod has not been implemented yet');
+    Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED, 'CeramicBackend support in Polymod has not been implemented yet', INIT);
   }
 }
 #end

--- a/polymod/backends/FlixelBackend.hx
+++ b/polymod/backends/FlixelBackend.hx
@@ -15,7 +15,7 @@ class FlixelBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FAILED_CREATE_BACKEND, "FlixelBackend requires the flixel library, did you forget to install it?");
+    Polymod.error(BACKEND_INIT_FAILED, "FlixelBackend requires the flixel library, did you forget to install it?", INIT);
   }
 }
 #else
@@ -35,7 +35,7 @@ class FlixelBackend extends OpenFLBackend
    */
   public override function clearCache()
   {
-    Polymod.notice(FUNCTIONALITY_NOT_IMPLEMENTED,
+    Polymod.info(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED,
       "Watch out, the Flixel backend's clearCache function kinda sucks. " + "Ideally you should just disable Flixel's caching and manage everything yourself.");
     // To clarify, Flixel caches things in a way that is hard to clear automatically.
     // The FlxG.bitmap cache contains the following:

--- a/polymod/backends/HEAPSBackend.hx
+++ b/polymod/backends/HEAPSBackend.hx
@@ -28,7 +28,7 @@ class HEAPSBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FAILED_CREATE_BACKEND, "HEAPSBackend requires the heaps library, did you forget to install it?");
+    Polymod.error(BACKEND_INIT_FAILED, "HEAPSBackend requires the heaps library, did you forget to install it?");
   }
 }
 #else

--- a/polymod/backends/KhaBackend.hx
+++ b/polymod/backends/KhaBackend.hx
@@ -6,7 +6,7 @@ class KhaBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FUNCTIONALITY_NOT_IMPLEMENTED, 'KhaBackend requires the kha library, did you forget to install it?');
+    Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED, 'KhaBackend requires the kha library, did you forget to install it?', INIT);
   }
 }
 #else
@@ -15,7 +15,7 @@ class KhaBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FUNCTIONALITY_NOT_IMPLEMENTED, 'Kha support in Polymod has not been implemented yet');
+    Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED, 'Kha support in Polymod has not been implemented yet', INIT);
   }
 }
 #end

--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -40,12 +40,12 @@ class LimeBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FAILED_CREATE_BACKEND, "LimeBackend requires the lime library, did you forget to install it?");
+    Polymod.error(BACKEND_INIT_FAILED, "LimeBackend requires the lime library, did you forget to install it?", INIT);
   }
 
   public function preloadImagesToCache():Void
   {
-    Polymod.error(FAILED_CREATE_BACKEND, "LimeBackend requires the lime library, did you forget to install it?");
+    Polymod.error(BACKEND_INIT_FAILED, "LimeBackend requires the lime library, did you forget to install it?", INIT);
   }
 }
 #else
@@ -121,9 +121,9 @@ class LimeBackend implements IBackend
 
     if (hasMoreThanDefault && params.assetLibraryPaths == null)
     {
-      Polymod.error(PolymodErrorCode.LIME_MISSING_ASSET_LIBRARY_INFO,
+      Polymod.error(BACKEND_LIME_MISSING_ASSET_LIBRARY_INFO,
         "Your Lime/OpenFL configuration is using custom asset libraries, but you have not provided the frameworkParams.assetLibraryPaths parameter in Polymod.init() that tells Polymod which asset libraries to expect and what their mod sub-directory prefixes should be.",
-        PolymodErrorOrigin.INIT);
+        INIT);
       return false;
     }
 
@@ -135,10 +135,10 @@ class LimeBackend implements IBackend
       {
         if (!params.assetLibraryPaths.exists(key) && key != 'default')
         {
-          Polymod.error(PolymodErrorCode.LIME_MISSING_ASSET_LIBRARY_REFERENCE,
+          Polymod.error(BACKEND_LIME_MISSING_ASSET_LIBRARY_REFERENCE,
             "Your Lime/OpenFL configuration is using custom asset libraries, and you provided frameworkParams in Polymod.init(), but we couldn't find a match for this asset library: (" +
             key + ')',
-            PolymodErrorOrigin.INIT);
+            INIT);
           return false;
         }
         else

--- a/polymod/backends/NMEBackend.hx
+++ b/polymod/backends/NMEBackend.hx
@@ -24,7 +24,7 @@ class NMEBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FAILED_CREATE_BACKEND, "NMEBackend requires the nme library, did you forget to install it?");
+    Polymod.error(BACKEND_INIT_FAILED, "NMEBackend requires the nme library, did you forget to install it?", INIT);
   }
 }
 #else

--- a/polymod/backends/OpenFLBackend.hx
+++ b/polymod/backends/OpenFLBackend.hx
@@ -6,7 +6,7 @@ class OpenFLBackend extends StubBackend
   public function new()
   {
     super();
-    Polymod.error(FAILED_CREATE_BACKEND, "OpenFLBackend requires the openfl library, did you forget to install it?");
+    Polymod.error(BACKEND_INIT_FAILED, "OpenFLBackend requires the openfl library, did you forget to install it?", INIT);
   }
 }
 #else

--- a/polymod/backends/OpenFLWithNodeBackend.hx
+++ b/polymod/backends/OpenFLWithNodeBackend.hx
@@ -76,9 +76,9 @@ class OpenFLWithNodeBackend extends StubBackend
   {
     super();
     #if !openfl
-    Polymod.error(FAILED_CREATE_BACKEND, "OpenFLWithNodeBackend requires the openfl library, did you forget to install it?");
+    Polymod.error(BACKEND_INIT_FAILED, "OpenFLWithNodeBackend requires the openfl library, did you forget to install it?", INIT);
     #elseif !nodefs
-    Polymod.error(FAILED_CREATE_BACKEND, 'OpenFLWithNodeBackend requires the nodefs flag to be defined.');
+    Polymod.error(BACKEND_INIT_FAILED, 'OpenFLWithNodeBackend requires the nodefs flag to be defined.', INIT);
     #end
   }
 }

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -574,7 +574,7 @@ class PolymodAssetLibrary
 
   private function initMod(d:String):Void
   {
-    Polymod.notice(MOD_LOAD_PREPARE, 'Preparing to load mod $d');
+    Polymod.info(MOD_LOAD_START, 'Preparing to load mod $d');
     if (d == null) return;
 
     var all:Array<String> = null;
@@ -595,7 +595,7 @@ class PolymodAssetLibrary
       }
       catch (msg:Dynamic)
       {
-        Polymod.error(MOD_LOAD_FAILED, 'Failed to load mod $d : $msg');
+        Polymod.error(MOD_LOAD_FAILED, 'Failed to load mod $d : $msg', INIT);
         throw('ModAssetLibrary._initMod("$d") failed: $msg');
       }
     }
@@ -662,11 +662,11 @@ class PolymodAssetLibrary
       }
       #end
     }
-    Polymod.notice(MOD_LOAD_DONE, 'Done loading mod $d');
+    Polymod.info(MOD_LOAD_DONE, 'Done loading mod $d');
   }
 
   @:allow(polymod.backends.LimeCoreLibrary)
-  private function initRedirectPath(libraryId:String, redirectPath:String, pathPrefix:String = '')
+  private function initRedirectPath(libraryId:String, redirectPath:String, pathPrefix:String = ''):Void
   {
     if (!typeLibraries.exists(libraryId))
     {
@@ -687,13 +687,13 @@ class PolymodAssetLibrary
       }
       else
       {
-        Polymod.error(MOD_LOAD_FAILED, 'Failed to load core asset redirect $redirectPath : Directory does not exist!');
+        Polymod.error(ASSET_REDIRECT_MISSING_DIRECTORY, 'Failed to load core asset redirect $redirectPath : Directory does not exist!', INIT);
         throw('ModAssetLibrary.initRedirectPath("$redirectPath") failed: Directory does not exist!');
       }
     }
     catch (msg:Dynamic)
     {
-      Polymod.error(MOD_LOAD_FAILED, 'Failed to load core asset redirect $redirectPath : $msg');
+      Polymod.error(ASSET_REDIRECT_FAILED, 'Failed to load core asset redirect $redirectPath : $msg', INIT);
       throw('ModAssetLibrary.initRedirectPath("$redirectPath") failed: $msg');
     }
 
@@ -723,7 +723,7 @@ class PolymodAssetLibrary
       #end
     }
     var keyCount = typeLibraries.get(libraryId).length;
-    Polymod.notice(MOD_LOAD_DONE, 'Done loading core asset redirect $redirectPath ($keyCount keys)');
+    Polymod.info(ASSET_REDIRECT_DONE, 'Done loading core asset redirect $redirectPath ($keyCount keys)', INIT);
 
     _buildAllFilesCache();
   }

--- a/polymod/backends/PolymodAssets.hx
+++ b/polymod/backends/PolymodAssets.hx
@@ -79,11 +79,11 @@ class PolymodAssets
     if (framework == null)
     {
       framework = autoDetectFramework();
-      Polymod.notice(PolymodErrorCode.FRAMEWORK_AUTODETECT, 'Framework: Autodetect, going with $framework');
+      Polymod.info(FRAMEWORK_INIT, 'Framework: Autodetect, going with $framework');
     }
     else
     {
-      Polymod.notice(PolymodErrorCode.FRAMEWORK_INIT, 'Framework: User specified $framework');
+      Polymod.info(FRAMEWORK_INIT, 'Framework: User specified $framework');
     }
     var backend:IBackend = null;
     #if !macro
@@ -105,7 +105,7 @@ class PolymodAssets
         }
         else
         {
-          Polymod.error(PolymodErrorCode.UNDEFINED_CUSTOM_BACKEND, "params.customBackend was not defined!");
+          Polymod.error(BACKEND_CUSTOM_UNDEFINED, "customBackend was not defined!", INIT);
           null;
         }
       default: null;
@@ -113,7 +113,7 @@ class PolymodAssets
     #end
     if (backend == null)
     {
-      Polymod.error(PolymodErrorCode.FAILED_CREATE_BACKEND, 'Could not create a backend for framework: $framework');
+      Polymod.error(BACKEND_INIT_FAILED, 'Could not initialize backend for framework: $framework', INIT);
       return null;
     }
 
@@ -126,8 +126,8 @@ class PolymodAssets
         || framework == polymod.Framework.CERAMIC
         || framework == polymod.Framework.CASTLE)
       {
-        Polymod.error(PolymodErrorCode.FUNCTIONALITY_NOT_IMPLEMENTED,
-          'Polymod currently does not support FireTongue localization for ${framework}! Nag us on GitHub about it.');
+        Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED,
+          'Polymod currently does not support FireTongue localization for ${framework}! Nag us on GitHub about it.', INIT);
       }
     }
     #end

--- a/polymod/format/ParseRules.hx
+++ b/polymod/format/ParseRules.hx
@@ -120,7 +120,7 @@ class CSVParseFormat implements BaseParseFormat
       }
       catch (msg:Dynamic)
       {
-        Polymod.error(APPEND, 'CSV append error ($id): $msg');
+        Polymod.error(ASSET_MERGE_FAILED, 'CSV append error ($id): $msg');
         return baseText;
       }
 
@@ -148,7 +148,7 @@ class CSVParseFormat implements BaseParseFormat
       {
         if (compareFields < Std.int(baseCSV.fields.length / 2))
         {
-          Polymod.error(APPEND, 'Mod file ($id) is missing most or all of the expected header fields', INIT);
+          Polymod.error(ASSET_APPEND_FAILED, 'Mod file ($id) is missing most or all of the expected header fields');
         }
       }
 
@@ -192,7 +192,7 @@ class CSVParseFormat implements BaseParseFormat
 
       for (baseField in missingFields)
       {
-        Polymod.warning(PolymodErrorCode.APPEND, 'Mod file ($id) is missing expected field "$baseField", values will default to empty string.', INIT);
+        Polymod.warning(ASSET_APPEND_FAILED, 'Mod file ($id) is missing expected field "$baseField", values will default to empty string.');
       }
 
       return finalText;
@@ -211,7 +211,7 @@ class CSVParseFormat implements BaseParseFormat
     }
     catch (msg:Dynamic)
     {
-      Polymod.error(MERGE, 'CSV merge error ($id): $msg');
+      Polymod.error(ASSET_MERGE_FAILED, 'CSV merge error ($id): $msg');
       return baseText;
     }
 
@@ -597,8 +597,6 @@ class JSONParseFormat implements BaseParseFormat
 
     var patchData = convertJSONToPatches(appendJson);
 
-    // trace('Applying patches: ${patchData}');
-
     var finalJson = JSONPatch.applyPatches(baseJson, patchData);
 
     return print(finalJson);
@@ -626,8 +624,6 @@ class JSONParseFormat implements BaseParseFormat
   {
     var baseJson:JSONData = parse(baseText);
     var mergeJson:JSONData = parse(mergeText);
-
-    // trace('Applying patches: ${mergeJson}');
 
     var finalJson = JSONPatch.applyPatches(baseJson, mergeJson);
 
@@ -683,7 +679,7 @@ class PlainTextParseFormat implements BaseParseFormat // <String>
 
   public function merge(baseText:String, mergeText:String, id:String):String
   {
-    Polymod.warning(MERGE, '($id) Plain text files do not support merge functionality!');
+    Polymod.warning(ASSET_MERGE_FAILED, '($id) Plain text files do not support merge functionality!');
     return baseText;
   }
 

--- a/polymod/fs/MemoryFileSystem.hx
+++ b/polymod/fs/MemoryFileSystem.hx
@@ -188,7 +188,7 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
     return result;
   }
 
-  public function getMetadata(modId:String)
+  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     var modpath = Util.pathJoin(modRoot, modId);
     if (exists(modpath))
@@ -200,13 +200,13 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
 
       if (!exists(metaFile))
       {
-        Polymod.warning(MISSING_META, 'Could not find mod metadata file: $metaFile');
+        Polymod.warning(MOD_MISSING_METADATA, 'Could not find mod metadata file: $metaFile', origin);
         return null;
       }
       else
       {
         var metaText = getFileContent(metaFile);
-        meta = ModMetadata.fromJsonStr(metaText);
+        meta = ModMetadata.fromJsonStr(metaText, origin);
         if (meta == null) return null;
 
         meta.id = modId;
@@ -215,7 +215,7 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
 
       if (!exists(iconFile))
       {
-        Polymod.warning(MISSING_ICON, 'Could not find mod icon file: $iconFile');
+        Polymod.warning(MOD_MISSING_ICON, 'Could not find mod icon file: $iconFile', origin);
       }
       else
       {
@@ -227,7 +227,7 @@ class MemoryFileSystem implements PolymodFileSystem.IFileSystem
     }
     else
     {
-      Polymod.error(MISSING_MOD, 'Could not find mod directory: $modpath');
+      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $modpath', origin);
     }
     return null;
   }

--- a/polymod/fs/MemoryZipFileSystem.hx
+++ b/polymod/fs/MemoryZipFileSystem.hx
@@ -18,12 +18,12 @@ class MemoryZipFileSystem extends StubFileSystem
   public function new(params:ZipFileSystemParams)
   {
     super(params);
-    Polymod.warning(FUNCTIONALITY_NOT_IMPLEMENTED, "This file system not supported for this platform, and is only intended for use in html5");
+    Polymod.error(FUNCTIONALITY_NOT_IMPLEMENTED, "This file system not supported for this platform, and is only intended for use in html5");
   }
 
   public function addZipFile(zipName:String, zipBytes:Bytes)
   {
-    Polymod.warning(FUNCTIONALITY_NOT_IMPLEMENTED, "This file system not supported for this platform, and is only intended for use in html5");
+    Polymod.error(FUNCTIONALITY_NOT_IMPLEMENTED, "This file system not supported for this platform, and is only intended for use in html5");
   }
 }
 #else

--- a/polymod/fs/NodeFileSystem.hx
+++ b/polymod/fs/NodeFileSystem.hx
@@ -1,5 +1,6 @@
 package polymod.fs;
 
+import polymod.Polymod.PolymodErrorOrigin;
 import haxe.io.Bytes;
 import haxe.io.UInt8Array;
 import js.Browser;
@@ -167,7 +168,7 @@ class NodeFileSystem implements IFileSystem
   }
 
   // -----------------------------------------------------------------------------------------------
-  public function getMetadata(modId:String)
+  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Void
   {
     if (exists(modId))
     {
@@ -178,16 +179,16 @@ class NodeFileSystem implements IFileSystem
 
       if (!exists(metaFile))
       {
-        Polymod.warning(MISSING_META, 'Could not find mod metadata file: $metaFile');
+        Polymod.warning(MOD_MISSING_METADATA, 'Could not find mod metadata file: $metaFile', origin);
       }
       else
       {
         var metaText = getFileContent(metaFile);
-        meta = ModMetadata.fromJsonStr(metaText);
+        meta = ModMetadata.fromJsonStr(metaText, origin);
       }
       if (!exists(iconFile))
       {
-        Polymod.warning(MISSING_ICON, 'Could not find mod icon file: $iconFile');
+        Polymod.warning(MOD_MISSING_ICON, 'Could not find mod icon file: $iconFile', origin);
       }
       else
       {
@@ -199,7 +200,7 @@ class NodeFileSystem implements IFileSystem
     }
     else
     {
-      Polymod.error(MISSING_MOD, 'Could not find mod directory: "$modId"');
+      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: "$modId"', origin);
     }
     return null;
   }
@@ -219,7 +220,7 @@ class NodeFileSystem implements IFileSystem
 
       if (!isDirectory(testDir)) continue;
 
-      var meta:ModMetadata = this.getMetadata(dir);
+      var meta:ModMetadata = this.getMetadata(dir, PolymodErrorOrigin.SCAN);
 
       if (meta == null) continue;
 

--- a/polymod/fs/PolymodFileSystem.hx
+++ b/polymod/fs/PolymodFileSystem.hx
@@ -1,5 +1,6 @@
 package polymod.fs;
 
+import polymod.Polymod.PolymodErrorOrigin;
 import thx.semver.VersionRule;
 import haxe.io.Bytes;
 import polymod.Polymod.ModMetadata;
@@ -11,14 +12,16 @@ class PolymodFileSystem
 {
   /**
    * Constructs a new PolymodFileSystem.
-       * @param cls An input file system. Might be an IFileSystem or a Class<IFileSystem>.
+   * @param cls An input file system. Might be an IFileSystem or a Class<IFileSystem>.
+   * @param params A set of parameters for initializing the file system.
+   * @return The constructed file system.
    */
-  public static function makeFileSystem(cls:Dynamic = null, params:PolymodFileSystemParams):IFileSystem
+  public static function makeFileSystem(?cls:Dynamic, params:PolymodFileSystemParams):IFileSystem
   {
     if (cls == null)
     {
       // No IFileSystem provided, choose one to use as default.
-      return _detectFileSystem(params);
+      return detectFileSystem(params);
     }
     else if (Std.isOfType(cls, IFileSystem))
     {
@@ -32,15 +35,15 @@ class PolymodFileSystem
     }
     else
     {
-      Polymod.error(BAD_CUSTOM_FILESYSTEM, "Passed an unknown type for a custom filesystem. Reverting to default...");
+      Polymod.error(FILESYSTEM_INIT_FAILED, "Passed an unknown type for a custom filesystem. Reverting to default...", INIT);
       return makeFileSystem(null, params);
     }
   }
 
   /**
-   * Determine which PolymodFileSystem to create based on the current platform.
+   * Automatically determine the file system to use, based on the current platform, and instantiate it.
    */
-  static function _detectFileSystem(params:PolymodFileSystemParams)
+  static function detectFileSystem(params:PolymodFileSystemParams):IFileSystem
   {
     #if sys
     // Sys/native file system.
@@ -130,7 +133,9 @@ interface IFileSystem
   /**
    * Provides the metadata for a given mod. Returns null if the mod does not exist.
    * @param modId The ID of the mod.
+   * @param origin The context the error occurred in (while scanning for mods, while initializing mods, etc).
+   *   Used for error reporting.
    * @return The mod metadata.
    */
-  public function getMetadata(modId:String):Null<ModMetadata>;
+  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>;
 }

--- a/polymod/fs/StubFileSystem.hx
+++ b/polymod/fs/StubFileSystem.hx
@@ -1,8 +1,9 @@
 package polymod.fs;
 
+import polymod.Polymod.ModMetadata;
+import polymod.Polymod.PolymodErrorOrigin;
 import polymod.fs.PolymodFileSystem;
 import thx.semver.VersionRule;
-import polymod.Polymod.ModMetadata;
 
 /**
  * This stub file system returns false for all requests.
@@ -35,6 +36,6 @@ class StubFileSystem implements PolymodFileSystem.IFileSystem
   public inline function scanMods(?apiVersionRule:VersionRule):Array<ModMetadata>
     return [];
 
-  public inline function getMetadata(modId:String)
+  public inline function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
     return null;
 }

--- a/polymod/fs/SysFileSystem.hx
+++ b/polymod/fs/SysFileSystem.hx
@@ -1,6 +1,7 @@
 package polymod.fs;
 
 #if sys
+import polymod.Polymod.PolymodErrorOrigin;
 import polymod.Polymod.ModMetadata;
 import polymod.fs.PolymodFileSystem;
 import polymod.util.Util;
@@ -52,7 +53,7 @@ class SysFileSystem implements IFileSystem
     }
     catch (e)
     {
-      Polymod.warning(DIRECTORY_MISSING, 'Could not find directory "${path}"');
+      Polymod.warning(ASSET_MISSING_DIRECTORY, 'Could not find directory "${path}"');
       return [];
     }
   }
@@ -87,14 +88,15 @@ class SysFileSystem implements IFileSystem
       var fullDir = Util.pathJoin(modRoot, dir);
       if (!isDirectory(fullDir)) continue;
 
-      var meta:ModMetadata = this.getMetadata(dir);
+      var meta:ModMetadata = this.getMetadata(dir, PolymodErrorOrigin.SCAN);
 
       if (meta == null) continue;
 
       if (!VersionUtil.match(meta.apiVersion, apiVersionRule))
       {
         Polymod.warning(MOD_API_VERSION_MISMATCH,
-          'Mod "${dir}" is not compatible with API version "${apiVersionRule.toString()}", got "${meta.apiVersion.toString()}"');
+          'Mod "${dir}" is not compatible with API version "${apiVersionRule.toString()}", got "${meta.apiVersion.toString()}"',
+          SCAN);
         continue;
       }
 
@@ -104,7 +106,7 @@ class SysFileSystem implements IFileSystem
     return result;
   }
 
-  public function getMetadata(modId:String)
+  public function getMetadata(modId:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     var modPath = Util.pathJoin(modRoot, modId);
     if (exists(modPath))
@@ -116,13 +118,13 @@ class SysFileSystem implements IFileSystem
 
       if (!exists(metaFile))
       {
-        Polymod.warning(MISSING_META, 'Could not find mod metadata file: $metaFile');
+        Polymod.warning(MOD_MISSING_METADATA, 'Could not find mod metadata file: $metaFile', origin);
         return null;
       }
       else
       {
         var metaText = getFileContent(metaFile);
-        meta = ModMetadata.fromJsonStr(metaText);
+        meta = ModMetadata.fromJsonStr(metaText, origin);
       }
 
       if (meta == null) return null;
@@ -132,7 +134,7 @@ class SysFileSystem implements IFileSystem
 
       if (!exists(iconFile))
       {
-        Polymod.warning(MISSING_ICON, 'Could not find mod icon file: $iconFile');
+        Polymod.warning(MOD_MISSING_ICON, 'Could not find mod icon file: $iconFile', origin);
       }
       else
       {
@@ -144,7 +146,7 @@ class SysFileSystem implements IFileSystem
     }
     else
     {
-      Polymod.error(MISSING_MOD, 'Could not find mod directory: $modId');
+      Polymod.error(MOD_MISSING_DIRECTORY, 'Could not find mod directory: $modId', origin);
     }
     return null;
   }

--- a/polymod/fs/SysZipFileSystem.hx
+++ b/polymod/fs/SysZipFileSystem.hx
@@ -7,7 +7,7 @@ class SysZipFileSystem extends polymod.fs.StubFileSystem
   public function new(params:ZipFileSystemParams)
   {
     super(params);
-    Polymod.warning(FUNCTIONALITY_NOT_IMPLEMENTED, "This file system not supported for this platform, and is only intended for use on sys targets");
+    Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED, "This file system not supported for this platform, and is only intended for use on sys targets", INIT);
   }
 }
 #else
@@ -176,10 +176,10 @@ class SysZipFileSystem extends SysFileSystem
    */
   public function addAllZips():Void
   {
-    Polymod.notice(MOD_LOAD_PREPARE, 'Searching for ZIP files in ' + modRoot);
+    Polymod.debug('Searching for ZIP files in ' + modRoot);
     // Use SUPER because we don't want to add in files within the ZIPs.
     var modRootContents = super.readDirectory(modRoot);
-    Polymod.notice(MOD_LOAD_PREPARE, 'Found ${modRootContents.length} files in modRoot.');
+    Polymod.debug('Found ${modRootContents.length} files in modRoot.');
 
     for (modRootFile in modRootContents)
     {
@@ -191,7 +191,7 @@ class SysZipFileSystem extends SysFileSystem
       // Only process ZIP files.
       if (StringTools.endsWith(filePath, ".zip"))
       {
-        Polymod.notice(MOD_LOAD_PREPARE, '- Adding zip file: $filePath');
+        Polymod.debug('- Adding zip file: $filePath');
         addZipFile(filePath);
       }
     }

--- a/polymod/hscript/HScriptable.hx
+++ b/polymod/hscript/HScriptable.hx
@@ -203,7 +203,7 @@ class ScriptRunner
   {
     if (assetHandler == null)
     {
-      Polymod.error(PolymodErrorCode.SCRIPT_NO_ASSET_HANDLER, "Class does not import an Assets class for Polymod to fetch scripts with!");
+      Polymod.error(SCRIPT_NO_ASSET_HANDLER, "Class does not import an Assets class for Polymod to fetch scripts with!", SCRIPT_RUNTIME);
       return null;
     }
 
@@ -232,7 +232,7 @@ class ScriptRunner
     // If the script isn't loaded yet, do that now.
     if (!scripts.exists(name))
     {
-      Polymod.debug('Note: Late script load ($name). This is normal for dynamic pathNames.');
+      Polymod.debug('Scripted function loaded late (this is fine if the pathname is dynamic).');
       load(name, assetHandler);
     }
 
@@ -252,7 +252,7 @@ class ScriptRunner
     var script = get(name, assetHandler);
     if (script == null)
     {
-      Polymod.error(PolymodErrorCode.SCRIPT_NOT_FOUND, 'Could not load script $name for execution.');
+      Polymod.error(SCRIPT_NOT_FOUND, 'Could not load script $name for execution.', SCRIPT_RUNTIME);
     }
     return script.execute();
   }

--- a/polymod/hscript/_internal/HScriptableMacro.hx
+++ b/polymod/hscript/_internal/HScriptableMacro.hx
@@ -170,14 +170,14 @@ class HScriptableMacro
                     {
                       // We failed to find the script!
                       // But we only care about that if the script is not optional.
-                      polymod.Polymod.error(polymod.Polymod.PolymodErrorCode.SCRIPT_NOT_FOUND, 'The script ' + $v{pathName} + ' could not be found.');
+                      polymod.Polymod.error(SCRIPT_NOT_FOUND, 'The scripted function ' + $v{pathName} + ' could not be found.', SCRIPT_RUNTIME);
 
                       // Prevent the script and the function body from executing.
                       wasCancelled = true;
                     }
                     else
                     {
-                      polymod.Polymod.debug('The script ' + $v{pathName} + ' could not be found, but that is fine because it is optional.');
+                      polymod.Polymod.debug('The scripted function ' + $v{pathName} + ' could not be found, but that is fine because it is optional.', SCRIPT_RUNTIME);
 
                       // Prevent the script from running but do not prevent the function body from executing.
                       // wasCancelled = true;
@@ -194,7 +194,7 @@ class HScriptableMacro
                     if ($v{hscriptCancellable})
                     {
                       script.set('cancel', function() {
-                        polymod.Polymod.debug('Script called cancel()');
+                        polymod.Polymod.debug('Scripted function called cancel()');
                         wasCancelled = true;
                       });
                     }
@@ -206,7 +206,7 @@ class HScriptableMacro
                 }
                 catch (e:Dynamic)
                 {
-                  polymod.Polymod.error(polymod.Polymod.PolymodErrorCode.SCRIPT_RUNTIME_EXCEPTION, 'Error: script ' + $v{pathName} + ' threw:\n$e');
+                  polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Error: Scripted function ' + $v{pathName} + ' threw:\n$e', SCRIPT_RUNTIME);
                   script_error = e;
                 }
 

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -195,7 +195,7 @@ class HScriptedClassMacro
               if (clsRef == null)
               {
                 polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
-                  'Could not construct instance of scripted class (${clsName} extends ' + $v{clsTypeName} + ')\nUnknown error building class reference');
+                  'Could not construct instance of scripted class (${clsName} extends ' + $v{clsTypeName} + ')\nUnknown error building class reference', SCRIPT_RUNTIME);
                 return null;
               }
 
@@ -205,7 +205,7 @@ class HScriptedClassMacro
                 if (result == null)
                 {
                   polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
-                    'Could not construct instance of scripted class (${clsName} extends ' + $v{clsTypeName} + '):\nUnknown error instantiating class');
+                    'Could not construct instance of scripted class (${clsName} extends ' + $v{clsTypeName} + '):\nUnknown error instantiating class', SCRIPT_RUNTIME);
                   return null;
                 }
 
@@ -214,7 +214,7 @@ class HScriptedClassMacro
               catch (error)
               {
                 polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
-                  'Could not construct instance of scripted class (${clsName} extends ' + $v{clsTypeName} + '):\n${error}');
+                  'Could not construct instance of scripted class (${clsName} extends ' + $v{clsTypeName} + '):\n${error}', SCRIPT_RUNTIME);
                 return null;
               }
             },
@@ -989,7 +989,6 @@ class HScriptedClassMacro
                   {
                     if (_asc.hasScriptFunction($v{funcName}))
                     {
-                      // trace('ASC: Calling $fieldName() in macro-generated function...');
                       $
                       {
                         doesReturnVoid ? (macro
@@ -1012,7 +1011,6 @@ class HScriptedClassMacro
                     }
                   }
                   // Fallback, call the original function.
-                  // trace('ASC: Fallback to original ${fieldName}');
                   $
                   {
                     doesReturnVoid ? (macro super.$funcName($a{func_callArgs})) : (macro return super.$funcName($a{func_callArgs}))
@@ -1034,9 +1032,7 @@ class HScriptedClassMacro
                 ret: func_ret,
                 expr: macro
                 {
-                  // var fieldName:String = $v{funcName};
                   // Fallback, call the original function.
-                  // trace('ASC: Force call to super ${fieldName}');
                   $
                   {
                     doesReturnVoid ? (macro super.$funcName($a{func_callArgs})) : (macro return super.$funcName($a{func_callArgs}))

--- a/polymod/hscript/_internal/PolymodEnum.hx
+++ b/polymod/hscript/_internal/PolymodEnum.hx
@@ -22,7 +22,7 @@ class PolymodEnum
 
     if (field == null)
     {
-      Polymod.error(SCRIPT_PARSE_ERROR, '${e.name}.${value} does not exist.');
+      Polymod.error(SCRIPT_PARSE_FAILED, '${e.name}.${value} does not exist.', SCRIPT_RUNTIME);
       return;
     }
 
@@ -30,7 +30,7 @@ class PolymodEnum
 
     if (args.length != field.args.length)
     {
-      Polymod.error(SCRIPT_PARSE_ERROR, '${e.name}.${value} got the wrong number of arguments.');
+      Polymod.error(SCRIPT_PARSE_FAILED, '${e.name}.${value} got the wrong number of arguments.', SCRIPT_RUNTIME);
       return;
     }
 

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -231,8 +231,9 @@ class PolymodInterpEx extends Interp
 
     if (_scriptClassDescriptors.exists(name))
     {
-      Polymod.error(SCRIPT_CLASS_ALREADY_REGISTERED,
-        'Scripted class with fully qualified name "$name" has already been defined. Please change the class name or the package name to ensure uniqueness.');
+      Polymod.error(SCRIPTED_CLASS_ALREADY_REGISTERED,
+        'Scripted class with fully qualified name "$name" has already been defined. Please change the class name or the package name to ensure uniqueness.',
+        SCRIPT_RUNTIME);
       return;
     }
     else
@@ -292,13 +293,14 @@ class PolymodInterpEx extends Interp
 
     if (_scriptEnumDescriptors.exists(name))
     {
-      Polymod.error(SCRIPT_ENUM_ALREADY_REGISTERED,
-        'An enum with the fully qualified name "$name" has already been defined. Please change the enum name to ensure a unique name.');
+      Polymod.error(SCRIPTED_CLASS_ALREADY_REGISTERED,
+        'An enum with the fully qualified name "$name" has already been defined. Please change the enum name to ensure a unique name.',
+        SCRIPT_RUNTIME);
       return;
     }
     else
     {
-      Polymod.debug('Registering enum $name');
+      Polymod.debug('Registering scripted enum $name');
       _scriptEnumDescriptors.set(name, e);
     }
   }
@@ -394,7 +396,7 @@ class PolymodInterpEx extends Interp
           continue;
         }
 
-        Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not import ${imp.fullPath}. Check to ensure the module exists and is spelled correctly.', clsPath);
+        Polymod.error(SCRIPTED_CLASS_UNRESOLVED_IMPORT, 'Could not import ${imp.fullPath}. Check to ensure the module exists and is spelled correctly.', SCRIPT_RUNTIME);
       }
 
       // Check if the scripted classes extend the right type.
@@ -408,7 +410,7 @@ class PolymodInterpEx extends Interp
           case CTPath(path, params):
             if (params != null && params.length > 0)
             {
-              Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not extend ${superClassPath}, do not include type parameters in super class name.', clsPath);
+              Polymod.error(SCRIPTED_CLASS_UNRESOLVED_IMPORT, 'Could not extend ${superClassPath}, do not include type parameters in super class name.', SCRIPT_RUNTIME);
             }
 
           default:
@@ -416,7 +418,7 @@ class PolymodInterpEx extends Interp
         }
 
         // Default
-        Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not extend ${superClassPath}. Make sure the type to extend has been imported.', clsPath);
+        Polymod.error(SCRIPTED_CLASS_UNRESOLVED_IMPORT, 'Could not extend ${superClassPath}. Make sure the type to extend has been imported.', SCRIPT_RUNTIME);
       }
       else
       {
@@ -1464,7 +1466,7 @@ class PolymodInterpEx extends Interp
     // Check if the field is a blacklisted static field.
     if (PolymodScriptClass.blacklistedStaticFields.exists(o) && PolymodScriptClass.blacklistedStaticFields.get(o).contains(f))
     {
-      Polymod.error(SCRIPT_CLASS_FIELD_BLACKLISTED, 'Class field ${oCls}.${f} is blacklisted and cannot be used in scripts.');
+      Polymod.error(SCRIPTED_CLASS_BLACKLISTED_FIELD, 'Class field ${oCls}.${f} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
       return null;
     }
 
@@ -1473,7 +1475,7 @@ class PolymodInterpEx extends Interp
     {
       if (PolymodScriptClass.blacklistedInstanceFields.exists(oCls) && PolymodScriptClass.blacklistedInstanceFields.get(oCls).contains(f))
       {
-        Polymod.error(SCRIPT_CLASS_FIELD_BLACKLISTED, 'Class field ${oCls}.${f} is blacklisted and cannot be used in scripts.');
+        Polymod.error(SCRIPTED_CLASS_BLACKLISTED_FIELD, 'Class field ${oCls}.${f} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
         return null;
       }
     }
@@ -1791,7 +1793,7 @@ class PolymodInterpEx extends Interp
     }
     else
     {
-      Polymod.error(SCRIPT_CLASS_NOT_REGISTERED, 'Scripted class $clsName has not been defined.');
+      Polymod.error(SCRIPTED_CLASS_NOT_REGISTERED, 'Scripted class $clsName has not been defined.', SCRIPT_RUNTIME);
       return null;
     }
 
@@ -1841,7 +1843,7 @@ class PolymodInterpEx extends Interp
     {
       Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
         'Error while calling static function ${clsName}.${fnName}(): EInvalidAccess' + '\n' +
-        'Static function "${fnName}" does not exist! Define it or call the correct function.');
+        'Static function "${fnName}" does not exist! Define it or call the correct function.', SCRIPT_RUNTIME);
       return null;
     }
   }
@@ -1943,7 +1945,7 @@ class PolymodInterpEx extends Interp
     }
     else
     {
-      Polymod.error(SCRIPT_CLASS_NOT_REGISTERED, 'Scripted class $clsName has not been defined.');
+      Polymod.error(SCRIPTED_CLASS_NOT_REGISTERED, 'Scripted class $clsName has not been defined.', SCRIPT_RUNTIME);
       return false;
     }
 
@@ -2102,7 +2104,7 @@ class PolymodInterpEx extends Interp
     }
     else
     {
-      Polymod.error(SCRIPT_CLASS_NOT_REGISTERED, 'Scripted class $clsName has not been defined.');
+      Polymod.error(SCRIPTED_CLASS_NOT_REGISTERED, 'Scripted class $clsName has not been defined.', SCRIPT_RUNTIME);
       return null;
     }
   }
@@ -2148,11 +2150,11 @@ class PolymodInterpEx extends Interp
           {
             if (imports.get(clsName) == null)
             {
-              Polymod.error(SCRIPT_CLASS_MODULE_BLACKLISTED, 'Scripted class ${clsName} is blacklisted and cannot be used in scripts.', origin);
+              Polymod.error(SCRIPTED_CLASS_BLACKLISTED_MODULE, 'Scripted class ${clsName} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
             }
             else
             {
-              Polymod.warning(SCRIPT_CLASS_MODULE_ALREADY_IMPORTED, 'Scripted class ${clsName} has already been imported.', origin);
+              Polymod.warning(SCRIPTED_CLASS_REDUNDANT_IMPORT, 'Scripted class ${clsName} has already been imported.', SCRIPT_RUNTIME);
             }
             continue;
           }
@@ -2204,7 +2206,7 @@ class PolymodInterpEx extends Interp
                 continue;
               }
 
-              // Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not import class ${importedClass.fullPath}', origin);
+              // Polymod.error(SCRIPT_CLASS_MODULE_NOT_FOUND, 'Could not import class ${importedClass.fullPath}', SCRIPT_RUNTIME);
               // this could be a scripted class or enum that hasn't been registered yet
               importsToValidate.set(importedClass.name, importedClass);
               continue;
@@ -2234,11 +2236,11 @@ class PolymodInterpEx extends Interp
           {
             if (usings.get(clsName) == null)
             {
-              Polymod.error(SCRIPT_CLASS_MODULE_BLACKLISTED, 'Scripted class ${clsName} is blacklisted and cannot be used in scripts.', origin);
+              Polymod.error(SCRIPTED_CLASS_BLACKLISTED_MODULE, 'Scripted class ${clsName} is blacklisted and cannot be used in scripts.', SCRIPT_RUNTIME);
             }
             else
             {
-              Polymod.warning(SCRIPT_CLASS_MODULE_ALREADY_IMPORTED, 'Scripted class ${clsName} has already been used.', origin);
+              Polymod.warning(SCRIPTED_CLASS_REDUNDANT_IMPORT, 'Scripted class ${clsName} has already been used.', SCRIPT_RUNTIME);
             }
             continue;
           }
@@ -2284,8 +2286,6 @@ class PolymodInterpEx extends Interp
             registerImportForPackage(pkg, importedClass, true);
             continue;
           }
-
-          // Polymod.debug('Using class ${importedClass.name} from ${importedClass.fullPath}');
           usings.set(importedClass.name, importedClass);
         case DClass(c):
           if (isImportFile) continue;

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -154,7 +154,7 @@ class PolymodScriptClass
       var scriptBody = Polymod.assetLibrary.getText(path);
       if (scriptBody == null)
       {
-        Polymod.error(SCRIPT_PARSE_ERROR, 'Error while loading script "${path}", could not retrieve script contents!');
+        Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve script contents!', SCRIPT_RUNTIME);
         return;
       }
       try
@@ -171,13 +171,13 @@ class PolymodScriptClass
         #end
         {
           case EUnexpected(s):
-            Polymod.error(SCRIPT_PARSE_ERROR,
-              'Error while parsing function ${path}#${errLine}: EUnexpected' + '\n' + 'Unexpected token "${s}", is there invalid syntax on this line?');
+            Polymod.error(SCRIPT_PARSE_FAILED,
+              'Error while parsing function ${path}#${errLine}: EUnexpected' + '\n' + 'Unexpected token "${s}", is there invalid syntax on this line?', SCRIPT_RUNTIME);
           case EClassUnresolvedSuperclass(cls, reason):
-            Polymod.error(SCRIPT_PARSE_ERROR,
-              'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}');
+            Polymod.error(SCRIPT_PARSE_FAILED,
+              'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}', SCRIPT_RUNTIME);
           default:
-            Polymod.error(SCRIPT_PARSE_ERROR, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}');
+            Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
         }
       }
     }
@@ -189,14 +189,13 @@ class PolymodScriptClass
 
     if (!Polymod.assetLibrary.exists(path))
     {
-      Polymod.error(SCRIPT_PARSE_ERROR, 'Error while loading script "${path}", could not retrieve contents of non-existent script!');
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve contents of non-existent script!', SCRIPT_RUNTIME);
       return null;
     }
 
     Polymod.assetLibrary.loadText(path).onComplete((text) -> {
       try
       {
-        Polymod.debug('Fetched script class "$path", parsing...');
         registerScriptClassByString(text);
         promise.complete(true);
       }
@@ -210,22 +209,22 @@ class PolymodScriptClass
         #end
         {
           case EUnexpected(s):
-            Polymod.error(SCRIPT_PARSE_ERROR,
+            Polymod.error(SCRIPT_PARSE_FAILED,
               'Error while parsing script ${path}#${errLine}: EUnexpected' + '\n' +
-              'Unexpected error: Unexpected token "${s}", is there invalid syntax on this line?');
+              'Unexpected error: Unexpected token "${s}", is there invalid syntax on this line?', SCRIPT_RUNTIME);
           default:
-            Polymod.error(SCRIPT_PARSE_ERROR, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}');
+            Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
         }
         promise.error(err);
       }
     }).onError((err) -> {
       if (err == "404")
       {
-        Polymod.error(SCRIPT_PARSE_ERROR, 'Error while loading script "${path}", could not retrieve script contents (404 error)!');
+        Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve script contents (404 error)!', SCRIPT_RUNTIME);
       }
       else
       {
-        Polymod.error(SCRIPT_PARSE_ERROR, 'Error while parsing script ${path}: ' + '\n' + 'An unknown error occurred: ${err}');
+        Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
         promise.error(err);
       }
     });
@@ -332,8 +331,8 @@ class PolymodScriptClass
         {
           // importedClass was defined but `cls` was null. This class must have been blacklisted.
           var clsName = classDecl.pkg != null ? '${classDecl.pkg.join('.')}.${classDecl.name}' : classDecl.name;
-          Polymod.error(SCRIPT_PARSE_ERROR,
-            'Could not parse superclass "${classDecl.name}" of scripted class "${clsName}". The superclass may be blacklisted.');
+          Polymod.error(SCRIPT_PARSE_FAILED,
+            'Could not parse superclass "${classDecl.name}" of scripted class "${clsName}". The superclass may be blacklisted.', SCRIPT_RUNTIME);
           return [];
         }
         else if (importedClass != null)
@@ -365,7 +364,7 @@ class PolymodScriptClass
       {
         // The superclass is not a scripted class or native class. Probably doesn't exist, throw an error.
         var clsName = classDecl.pkg != null ? '${classDecl.pkg.join('.')}.${classDecl.name}' : classDecl.name;
-        Polymod.error(SCRIPT_PARSE_ERROR, 'Could not parse superclass "$fullSuperClsName" of scripted class "${clsName}". Did you forget to import it?');
+        Polymod.error(SCRIPT_PARSE_FAILED, 'Could not parse superclass "$fullSuperClsName" of scripted class "${clsName}". Did you forget to import it?', SCRIPT_RUNTIME);
         return [];
       }
     }
@@ -420,21 +419,21 @@ class PolymodScriptClass
           }
           else if (importedClass != null && importedClass.cls == null)
           {
-            Polymod.error(SCRIPT_PARSE_ERROR, 'Could not determine target class for "${pth.join('.')}" (blacklisted type?)');
+            Polymod.error(SCRIPT_PARSE_FAILED, 'Could not determine target class for "${pth.join('.')}" (blacklisted type?)', SCRIPT_RUNTIME);
           }
           else
           {
-            Polymod.error(SCRIPT_PARSE_ERROR, 'Could not determine target class for "${pth.join('.')}" (unregistered type?)');
+            Polymod.error(SCRIPT_PARSE_FAILED, 'Could not determine target class for "${pth.join('.')}" (unregistered type?)', SCRIPT_RUNTIME);
           }
         }
         else
         {
-          Polymod.error(SCRIPT_PARSE_ERROR, 'Could not determine target class for "${pth.join('.')}" (unregistered type?)');
+          Polymod.error(SCRIPT_PARSE_FAILED, 'Could not determine target class for "${pth.join('.')}" (unregistered type?)', SCRIPT_RUNTIME);
         }
       default:
         if (c.extend != null)
         {
-          Polymod.error(SCRIPT_PARSE_ERROR, 'Could not determine target class for "${c.extend}" (unknown type?)');
+          Polymod.error(SCRIPT_PARSE_FAILED, 'Could not determine target class for "${c.extend}" (unknown type?)', SCRIPT_RUNTIME);
         }
     }
     _interp = new PolymodInterpEx(targetClass, this);
@@ -576,7 +575,7 @@ class PolymodScriptClass
     className ??= '???';
     fnName ??= '(anonymous)';
 
-    Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Error while executing function ${className}.${fnName}()#${errLine}: ' + '\n' + message);
+    Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Error while executing function ${className}.${fnName}()#${errLine}: ' + '\n' + message, SCRIPT_RUNTIME);
   }
 
   public function callFunction(fnName:String, ?args:Array<Dynamic>):Dynamic
@@ -588,8 +587,6 @@ class PolymodScriptClass
     {
       // previousValues is used to restore variables after they are shadowed in the local scope.
       var previousValues:Map<String, Dynamic> = _interp.setFunctionValues(fn, args, fnName);
-
-      // Polymod.debug('Calling scripted class function "${fullyQualifiedName}.${fnName}(${args})"', null);
 
       // Copy the locals and store them for later.
       var localsCopy:Map<String, {r:Dynamic, ?isfinal:Null<Bool>}> = _interp.locals.copy();
@@ -650,7 +647,7 @@ class PolymodScriptClass
       {
         Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
           'Error while calling function ${fnName}(): EInvalidAccess' + '\n' +
-          'Script does not have function "${fnName}"! Define it or call the correct script function or superclass function.');
+          'Script does not have function "${fnName}"! Define it or call the correct script function or superclass function.', SCRIPT_RUNTIME);
         return null;
       }
 

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -469,8 +469,6 @@ class PolymodScriptClassMacro
 
     if (metaData.hscriptedClasses != null)
     {
-      // trace('Got hscriptedClasses: ' + metaData.hscriptedClasses);
-
       var result:Map<String, Class<Dynamic>> = [];
 
       // Each element is formatted as `[superClassPath, classPath]`.

--- a/polymod/hscript/_internal/PolymodStaticClassReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticClassReference.hx
@@ -49,7 +49,7 @@ class PolymodStaticClassReference
 
     if (asc == null)
     {
-      polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Could not construct instance of scripted class (${getFullyQualifiedName()})');
+      polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Could not construct instance of scripted class (${getFullyQualifiedName()})', SCRIPT_RUNTIME);
       return null;
     }
 

--- a/polymod/util/DependencyUtil.hx
+++ b/polymod/util/DependencyUtil.hx
@@ -83,7 +83,7 @@ class DependencyUtil
       // If the dependency is not found, throw a warning/error.
       if (depMod == null)
       {
-        Polymod.warning(DEPENDENCY_UNMET, 'Dependency "${dep}" not found.');
+        Polymod.warning(MOD_DEPENDENCY_UNMET, 'Required dependency "${dep}" not found.', INIT);
         continue;
       }
 
@@ -97,7 +97,7 @@ class DependencyUtil
       }
       else
       {
-        Polymod.warning(DEPENDENCY_VERSION_MISMATCH, 'Dependency "${dep}" has version "${depMod.modVersion}" but requires "${depRule}".');
+        Polymod.warning(MOD_DEPENDENCY_VERSION_MISMATCH, 'Dependency "${dep}" has version "${depMod.modVersion}" but requires "${depRule}".', INIT);
         continue;
       }
     }
@@ -142,7 +142,7 @@ class DependencyUtil
       // If the dependency is not found, throw a warning/error.
       if (depMod == null)
       {
-        Polymod.error(DEPENDENCY_UNMET, 'Dependency "${dep}" not found.');
+        Polymod.error(MOD_DEPENDENCY_UNMET, 'Dependency "${dep}" not found.', INIT);
         return false;
       }
 
@@ -154,7 +154,7 @@ class DependencyUtil
       }
       else
       {
-        Polymod.error(DEPENDENCY_VERSION_MISMATCH, 'Dependency "${dep}" has version "${depMod.modVersion}" but requires "${depRule}".');
+        Polymod.error(MOD_DEPENDENCY_VERSION_MISMATCH, 'Dependency "${dep}" has version "${depMod.modVersion}" but requires "${depRule}".', INIT);
         return false;
       }
     }
@@ -212,8 +212,7 @@ class DependencyUtil
           }
           else
           {
-            // trace('Skipping optional dependency ' + depKey + ' for mod ' + mod.id);
-            // dependencies.set(mod.id, [mod.id]);
+            Polymod.info(MOD_DEPENDENCY_UNMET, 'Optional dependency "${depKey}" for mod "${mod.id}" not found, skipping.', INIT);
           }
         }
       }
@@ -246,12 +245,12 @@ class DependencyUtil
       }).join(', ');
       if (skipErrors)
       {
-        Polymod.warning(DEPENDENCY_CYCLICAL, 'Circular dependency detected between mods: ${modList}');
+        Polymod.warning(MOD_DEPENDENCY_CYCLICAL, 'Circular dependency detected between mods: ${modList}', INIT);
         return [];
       }
       else
       {
-        Polymod.error(DEPENDENCY_CYCLICAL, 'Circular dependency detected between mods: ${modList}');
+        Polymod.error(MOD_DEPENDENCY_CYCLICAL, 'Circular dependency detected between mods: ${modList}', INIT);
         return null;
       }
     }

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -112,7 +112,7 @@ class Util
     }
     else
     {
-      Polymod.error(MERGE, "Could not merge file (" + id + "), no parse format was specified for extension (" + extension + ").");
+      Polymod.error(ASSET_MERGE_FAILED, "Could not merge file (" + id + "), no parse format was specified for extension (" + extension + ").");
       return baseText;
     }
     return baseText;

--- a/polymod/util/zip/ZipParser.hx
+++ b/polymod/util/zip/ZipParser.hx
@@ -92,7 +92,7 @@ class ZipParser
     var cdfh = centralDirectoryRecords.get(localFileName);
     if (cdfh == null)
     {
-      Polymod.warning(FILE_MISSING, 'The file $localFileName was not found in the zip: $fileName');
+      Polymod.warning(ASSET_MISSING_FILE, 'The file $localFileName was not found in the zip: $fileName');
       return null;
     }
     fileHandle.seek(cdfh.localFileHeaderOffset, SeekBegin);
@@ -294,7 +294,6 @@ class LocalFileHeader extends Header
 
     if (bytesRead < compressedSize)
     {
-      // trace('[WARNING] Bytes read was fewer than requested (Requested: $compressedSize, Read: $bytesRead)');
       bytesBuf.addBytes(bytesToReturn, 0, bytesRead);
       while (bytesRead < compressedSize)
       {


### PR DESCRIPTION
The PolymodErrorCode enum was super disorganized (there were two different error codes for trying to load a mod that's outdated for instance), so I refactored it and a bunch of the places in Polymod where it got used.

Part of a change to resolve FunkinCrew/Funkin#6992.