### PR TITLE
[ENHANCEMENT] Add separate error code for optional dependencies.

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -1289,6 +1289,14 @@ enum abstract PolymodErrorCode(String) from String to String
    * Polymod attempted to load a mod, but one or more of its dependencies were missing.
    * - This is a warning if `skipDependencyErrors` is true, the problematic mod will be skipped.
    * - This is an error if `skipDependencyErrors` is false, no mods will be loaded.
+   * - Make sure to inform the user that the optional mods are missing.
+   */
+  public var MOD_OPTIONAL_DEPENDENCY_UNMET:String = 'mod_optional_dependency_unmet';
+
+  /**
+   * Polymod attempted to load a mod, but one or more of its dependencies were missing.
+   * - This is a warning if `skipDependencyErrors` is true, the problematic mod will be skipped.
+   * - This is an error if `skipDependencyErrors` is false, no mods will be loaded.
    * - Make sure to inform the user that the required mods are missing.
    */
   public var MOD_DEPENDENCY_UNMET:String = 'mod_dependency_unmet';

--- a/polymod/util/DependencyUtil.hx
+++ b/polymod/util/DependencyUtil.hx
@@ -212,7 +212,7 @@ class DependencyUtil
           }
           else
           {
-            Polymod.info(MOD_DEPENDENCY_UNMET, 'Optional dependency "${depKey}" for mod "${mod.id}" not found, skipping.', INIT);
+            Polymod.info(MOD_OPTIONAL_DEPENDENCY_UNMET, 'Optional dependency "${depKey}" for mod "${mod.id}" not found, skipping.', INIT);
           }
         }
       }


### PR DESCRIPTION
## Description

This PR adds a new `PolymodErrorCode` for optional dependencies `MOD_OPTIONAL_DEPENDENCY_UNMET`, because optional dependencies should be separated, since games might throw window errors for optional dependencies when they should be treated as optional.