### PR TITLE
[FIX] Prevent null access on certain errors

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -325,7 +325,7 @@ class Interp
 
   inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Dynamic
   {
-    #if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
+    #if hscriptPos var e = new Error(e, curExpr?.pmin ?? 0, curExpr?.pmax ?? 0, curExpr?.origin ?? 'unknown', curExpr?.line ?? 0); #end
     if (rethrow) this.rethrow(e)
     else
       throw e;


### PR DESCRIPTION
## Description

Sometimes, `error` can be called before `curExpr` is able to be set, which causes a null access. This PR allows the error to be shown, however it will have no valid position or origin. Ideally we should make a fix to ensure the error will always have proper context but this will suffice for the time being.