### PR TITLE
[ENHANCEMENT] Fill the `preprocesorValues` map with defines

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -2387,10 +2387,36 @@ class Parser
         return !evalPreproCond(e);
       case EParent(e):
         return evalPreproCond(e);
-      case EBinop("&&", e1, e2):
-        return evalPreproCond(e1) && evalPreproCond(e2);
-      case EBinop("||", e1, e2):
-        return evalPreproCond(e1) || evalPreproCond(e2);
+      case EBinop(op, e1, e2):
+        inline function evalPreproValue(e:Expr)
+        {
+          return switch (expr(e))
+          {
+            case EIdent(id): id;
+            case EConst(CString(str, _)): str;
+            case EConst(CInt(num)): Std.string(num);
+            case EConst(CFloat(num)): Std.string(num);
+            default: null;
+          }
+        }
+
+        var value1 = evalPreproValue(e1);
+        var value2 = evalPreproValue(e2);
+
+        return switch (op)
+        {
+          case "&&": evalPreproCond(e1) && evalPreproCond(e2);
+          case "||": evalPreproCond(e1) || evalPreproCond(e2);
+          case ">=": (preprocValue(value1) ?? value1) >= (preprocValue(value2) ?? value2);
+          case ">": (preprocValue(value1) ?? value1) > (preprocValue(value2) ?? value2);
+          case "<=": (preprocValue(value1) ?? value1) <= (preprocValue(value2) ?? value2);
+          case "<": (preprocValue(value1) ?? value1) < (preprocValue(value2) ?? value2);
+          case "==": (preprocValue(value1) ?? value1) == (preprocValue(value2) ?? value2);
+          case "!=": (preprocValue(value1) ?? value1) != (preprocValue(value2) ?? value2);
+          default:
+            error(EInvalidPreprocessor("Invalid operator " + op), currentPos, currentPos);
+            return false;
+        }
       default:
         error(EInvalidPreprocessor("Can't eval " + expr(e).getName()), currentPos, currentPos);
         return false;

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -67,7 +67,7 @@ class Parser
   /**
     allows to check for #if / #else in code
   **/
-  public var preprocesorValues:Map<String, Dynamic> = new Map();
+  public static var preprocesorValues(get, default):Map<String, Dynamic>;
 
   /**
     activate JSON compatiblity
@@ -2539,4 +2539,22 @@ class Parser
       case TPrepro(id): "#" + id;
     }
   }
+
+  static function get_preprocesorValues()
+  {
+    if (preprocesorValues == null) preprocesorValues = getDefines();
+    return preprocesorValues;
+  }
+
+  macro static function getDefines():haxe.macro.Expr
+  {
+    return macro $v{getDefinesRaw()};
+  }
+
+  #if macro
+  static function getDefinesRaw()
+  {
+    return haxe.macro.Context.getDefines();
+  }
+  #end
 }


### PR DESCRIPTION
This PR just adds the values from `haxe.macro.Context.getDefines();`, as the logic was coded in beforehand

Tested with both
```haxe
#if desktop [...] #end
```
and
```haxe
#if (polymod >= "1.0.0") [...] #end
```
and they seem to work fine.