### PR TITLE
Rename `staticScriptHas` to `scriptStaticHas`

### DIFF
--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -429,9 +429,9 @@ class HScriptedClassMacro
           })
       };
 
-    var function_staticScriptHas:Field =
+    var function_scriptStaticHas:Field =
       {
-        name: 'staticScriptHas',
+        name: 'scriptStaticHas',
         doc: 'Determines if a static field of a scripted class exists or not.',
         access: [APublic],
         meta: null,
@@ -461,7 +461,7 @@ class HScriptedClassMacro
       function_scriptStaticCall,
       function_scriptStaticGet,
       function_scriptStaticSet,
-      function_staticScriptHas
+      function_scriptStaticHas
     ];
   }
 


### PR DESCRIPTION
This is a breaking change, but it makes the field name more consistent with the get, set, and call functions.