### PR TITLE
[FIX] Move preprocessor defines in DefineUtil to fix compiler errors.

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -23,6 +23,7 @@
 package polymod.hscript._internal;
 
 import polymod.hscript._internal.Expr;
+import polymod.util.DefineUtil;
 
 enum Token
 {
@@ -2568,19 +2569,7 @@ class Parser
 
   static function get_preprocesorValues()
   {
-    if (preprocesorValues == null) preprocesorValues = getDefines();
+    if (preprocesorValues == null) preprocesorValues = DefineUtil.getDefines();
     return preprocesorValues;
   }
-
-  macro static function getDefines():haxe.macro.Expr
-  {
-    return macro $v{getDefinesRaw()};
-  }
-
-  #if macro
-  static function getDefinesRaw()
-  {
-    return haxe.macro.Context.getDefines();
-  }
-  #end
 }

--- a/polymod/util/DefineUtil.hx
+++ b/polymod/util/DefineUtil.hx
@@ -8,6 +8,11 @@ class DefineUtil
 {
   // Only macros should be able to use these.
   #if macro
+  public static function getDefinesRaw()
+  {
+    return Context.getDefines();
+  }
+
   public static function getDefineStringArrayRaw(key:String, ?defaultValue:Array<String>):Array<String>
   {
     if (defaultValue == null) defaultValue = new Array<String>();
@@ -41,5 +46,10 @@ class DefineUtil
   public static macro function getDefineBool(key:String, defaultValue:Bool = false):haxe.macro.Expr
   {
     return macro $v{getDefineBoolRaw(key, defaultValue)};
+  }
+
+  public static macro function getDefines():haxe.macro.Expr
+  {
+    return macro $v{getDefinesRaw()};
   }
 }


### PR DESCRIPTION
This PR moves the Define map getter for preprocessors in `DefineUtil` since compilers might error because of it.

Like here:

<img width="958" height="110" alt="image" src="https://github.com/user-attachments/assets/e169e745-64da-4901-9c2c-880f10a4b5f2" />
