### PR TITLE
[COMPAT] Add back `getMetadata` as deprecated for backwards compatibility.

### DIFF
--- a/polymod/fs/MemoryFileSystem.hx
+++ b/polymod/fs/MemoryFileSystem.hx
@@ -188,6 +188,12 @@ class MemoryFileSystem implements IFileSystem
     return result;
   }
 
+  @:deprecated("getMetadata is deprecated, use getMetadataByDir")
+  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
+    return getMetadataByDir(dirName, origin);
+  }
+
   public function getMetadataByDir(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     var modpath = Util.pathJoin(modRoot, dirName);

--- a/polymod/fs/MemoryZipFileSystem.hx
+++ b/polymod/fs/MemoryZipFileSystem.hx
@@ -99,6 +99,12 @@ class MemoryZipFileSystem extends MemoryFileSystem
     return compressedBytes; // if it wasn't actually compressed
   }
 
+  @:deprecated("getMetadata is deprecated, use getMetadataByDir")
+  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
+    return getMetadataByDir(dirName, origin);
+  }
+
   public override function getMetadataByDir(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     return super.getMetadataByDir(dirName, origin);

--- a/polymod/fs/NodeFileSystem.hx
+++ b/polymod/fs/NodeFileSystem.hx
@@ -195,6 +195,12 @@ class NodeFileSystem implements IFileSystem
     return result;
   }
 
+  @:deprecated("getMetadata is deprecated, use getMetadataByDir")
+  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
+    return getMetadataByDir(dirName, origin);
+  }
+
   public function getMetadataByDir(dir:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     if (exists(dir))

--- a/polymod/fs/SysFileSystem.hx
+++ b/polymod/fs/SysFileSystem.hx
@@ -106,6 +106,12 @@ class SysFileSystem implements IFileSystem
     return result;
   }
 
+  @:deprecated("getMetadata is deprecated, use getMetadataByDir")
+  public function getMetadata(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
+  {
+    return getMetadataByDir(dirName, origin);
+  }
+
   public function getMetadataByDir(dirName:String, ?origin:PolymodErrorOrigin):Null<ModMetadata>
   {
     var modPath = Util.pathJoin(modRoot, dirName);


### PR DESCRIPTION
This PR adds back the `getMetadata` function back as deprecated for backwards compatibility because some mods might use it. With this they can smoothly transition to the newer functions without their mods breaking.
> [!IMPORTANT]
> This should be removed in later versions.