### PR TITLE
[FEATURE] `hscript` to Polymod import redirection

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -2,7 +2,8 @@
 <project>
   <!-- These values are added to the project XML when you include this library. -->
   <haxelib name="thx.semver" />
-  <!-- <haxelib name="hscript" /> This library is now OPTIONAL. -->
+
+  <haxeflag name="--macro" value="polymod.hscript._internal.HScriptRedirectDefines.run()" if="POLYMOD_REDIRECT_HSCRIPT" />
   <!--
     <haxeflag name="- -macro" value="polymod.hscript._internal.PolymodFinalMacro.locateAllFinals()" />
   -->

--- a/polymod/hscript/_internal/HScriptRedirectDefines.hx
+++ b/polymod/hscript/_internal/HScriptRedirectDefines.hx
@@ -1,0 +1,59 @@
+package polymod.hscript._internal;
+
+#if macro
+import haxe.macro.Context;
+import haxe.macro.Compiler;
+import haxe.macro.Expr.TypeDefinition;
+
+using StringTools;
+
+/**
+ * The macro for the `POLYMOD_REDIRECT_HSCRIPT` define functionality.
+ */
+class HScriptRedirectDefines
+{
+  static inline final DEFINE:String = 'POLYMOD_REDIRECT_HSCRIPT';
+
+  /**
+   * The entry point for the macro.
+   * Performs the preparations for the function that actually redirects the types.
+   */
+  public static function run():Void
+  {
+    if (Context.defined('hscript') && Context.defined(DEFINE))
+    {
+      Context.warning('"$DEFINE" present but hscript is installed. Not doing anything.', Context.currentPos());
+      return;
+    }
+
+    Compiler.define('hscript');
+    Context.onTypeNotFound(generateHScriptRedirect);
+  }
+
+  /**
+   * Returns a typedef where a referenced hscript type could not be found which redirects to a Polymod HScript class.
+   * @param typeName
+   * @return TypeDefinition
+   */
+  static function generateHScriptRedirect(typeName:String):TypeDefinition
+  {
+    if (!typeName.startsWith('hscript')) return null;
+
+    final POLY_PACK:Array<String> = ['polymod', 'hscript', '_internal'];
+    var typePack:Array<String> = typeName.split('.');
+    var name:String = typePack.pop();
+
+    return {
+      pack: typePack,
+      name: name,
+      pos: Context.currentPos(),
+      kind: TDAlias(TPath(
+        {
+          pack: POLY_PACK,
+          name: name,
+        })),
+      fields: []
+    };
+  }
+}
+#end


### PR DESCRIPTION
## Wat dis do?

Adds a define, `POLYMOD_REDIRECT_HSCRIPT` that when enabled will redirect imports to `hscript` to the internal implementation of Polymod. This can be useful, for instance, to allow the HaxeFlixel Debugger console to work without the need of having hscript installed.

> [!NOTE]
> Building may break in the future the more the classes are merged together. 