### PR TITLE
[ENHANCEMENT] Allow single-expression (braceless) functions to be parsed.

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -1657,6 +1657,7 @@ class Parser
         case "function":
           var name = getIdent();
           var inf = parseFunctionDecl();
+          maybe(TSemicolon);
           return {
             name: name,
             meta: meta,


### PR DESCRIPTION
## Linked Issues
- Closes #319

## Description

This PR allows single-expression (braceless) functions to be parsed and not throw errors.
All with a one-liner.

## Screenshot

<img width="554" height="412" alt="image" src="https://github.com/user-attachments/assets/a416f1e8-dfdc-4dc4-8f8a-38170243b441" />

*Note: Local functions such as `lambda()` in this case, worked before this change, module scoped functions didn't*