### PR TITLE
[FIX] Fix parsing of `|` as alternative to `,` in switch cases.

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -730,6 +730,7 @@ class Parser
     }
   }
 
+  var inSwitchCase:Bool = false;
   function parseStructure(id)
   {
     #if hscriptPos
@@ -898,6 +899,7 @@ class Parser
           switch (tk)
           {
             case TId("case"):
+              inSwitchCase = true;
               var c = {values: [], expr: null};
               cases.push(c);
               while (true)
@@ -910,6 +912,7 @@ class Parser
                   case TComma:
                     // next expr
                   case TDoubleDot:
+                    inSwitchCase = false;
                     break;
                   default:
                     unexpected(tk);
@@ -2326,6 +2329,7 @@ class Parser
               if (!ops[char])
               {
                 this.char = char;
+                if (inSwitchCase && op == '|') return TComma; // In switch case handle | as a ,
                 return TOp(op);
               }
               var pop = op;


### PR DESCRIPTION

This PR fixes the parsing of `|` in switch cases to actually be an alternative to `,` instead of an `EOp('|')`.
In haxe `|` is used as separator and not an operator in cases.

## Example Screenshot

<img width="495" height="195" alt="image" src="https://github.com/user-attachments/assets/dd74bdb1-74ab-4bac-ac3b-b5bddedb977c" />
