### PR TITLE
[ENHANCEMENT] Better function argument validation.

### DIFF
--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -164,6 +164,7 @@ enum Error
   EBlacklistedField(f:String);
   EPurgedFunction(f:String); // Function can't be called because it previously threw an uncaught exception
   EInvalidArgCount(f:String, expected:Int, given:Int); // Given arguments count don't match the minimum required parameters
+  EExceedArgsCount(f:String, allowed:Int, passed:Int); // Provided arguments exceed the maximum allowed parameter count
   ENullObjectReference(f:String); // Accessing a field of "null"
   EInvalidScriptedFnAccess(f:String);
   EInvalidScriptedVarGet(v:String);

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1941,15 +1941,24 @@ class PolymodInterpEx extends Interp
     if (args == null) return;
 
     var minParams = 0;
+    var maxAllowed = params.length;
+
     for (i in 0...params.length)
     {
       var p = params[i];
       if (!p.opt && p.value == null) minParams = i + 1;
     }
 
+    final funcName:String = (name != null) ? " for function '" + name + "'" : "";
     if (args.length < minParams)
     {
-      error(EInvalidArgCount((name != null) ? " for function '" + name + "'" : "", minParams, args.length));
+      error(EInvalidArgCount(funcName, minParams, args.length));
+    }
+    else if (args.length > maxAllowed)
+    {
+      // Manual return for `new` as parameter count shouldn't matter here
+      if (name == "new") return;
+      error(EExceedArgsCount(funcName, maxAllowed, args.length));
     }
   }
 

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -586,7 +586,7 @@ class PolymodScriptClass
     if (fn != null)
     {
       // previousValues is used to restore variables after they are shadowed in the local scope.
-      var previousValues:Map<String, Dynamic> = _interp.setFunctionValues(fn, args, fnName);
+      var previousValues:Map<String, Dynamic> = [];
 
       // Copy the locals and store them for later.
       var localsCopy:Map<String, {r:Dynamic, ?isfinal:Null<Bool>}> = _interp.locals.copy();
@@ -594,6 +594,7 @@ class PolymodScriptClass
       var r:Dynamic = null;
       try
       {
+        previousValues = _interp.setFunctionValues(fn, args, fnName);
         r = _interp.executeEx(fn.expr);
       }
       catch (err:Expr.Error)

--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -696,7 +696,8 @@ class Printer
       case EInvalidModule(m): "Invalid module: " + m;
       case EBlacklistedModule(m): "Blacklisted module: " + m;
       case EBlacklistedField(m): "Blacklisted field: " + m;
-      case EInvalidArgCount(f, expected, given): 'Invalid number of given arguments. Got $given, required $expected' + f;
+      case EInvalidArgCount(f, expected, given): 'Provided arguments are fewer than the required function parameters. Got $given, required $expected' + f;
+      case EExceedArgsCount(f, allowed, passed): 'Provided arguments exceeds the allowed function parameter count. Passed $passed, allowed $allowed' + f;
       case EPurgedFunction(f): "Invalid access to purged function (did it throw an uncaught exception earlier?): " + f;
       case ENullObjectReference(f): "Invalid reference to field of a null object: " + f;
       case EInvalidInStaticContext(v): "Invalid field access from static context: " + v;


### PR DESCRIPTION
## Linked Issues
- Closes #352

## Description
This PR fixes the argument validation crashing when native functions call scripts with less arguments than function parameters.
Also add a new error `EExceedArgsCount` that is thrown when passing more arguments than the function parameters have.
And finally changed the `EInvalidArgCount` error message from:

`Invalid number of given arguments. Got x, required y for function` 
to
`Provided arguments are fewer than the required function parameters. Got x, required y for function`