### PR TITLE
[REMOVAL] Remove `EExceedArgsCount` implementation for now, since it crashes the application.

### DIFF
--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -1941,7 +1941,7 @@ class PolymodInterpEx extends Interp
     if (args == null) return;
 
     var minParams = 0;
-    var maxAllowed = params.length;
+    //var maxAllowed = params.length;
 
     for (i in 0...params.length)
     {
@@ -1954,12 +1954,12 @@ class PolymodInterpEx extends Interp
     {
       error(EInvalidArgCount(funcName, minParams, args.length));
     }
-    else if (args.length > maxAllowed)
-    {
-      // Manual return for `new` as parameter count shouldn't matter here
-      if (name == "new") return;
-      error(EExceedArgsCount(funcName, maxAllowed, args.length));
-    }
+//    else if (args.length > maxAllowed)
+//    {
+//      // Manual return for `new` as parameter count shouldn't matter here
+//      if (name == "new") return;
+//      error(EExceedArgsCount(funcName, maxAllowed, args.length));
+//    }
   }
 
   public function hasScriptClassStaticFunction(clsName:String, fnName:String):Bool


### PR DESCRIPTION
My PR that added a38409aa7a06db3c342dd98fa8dd31adba7f791c brought a issue where the application crashes if the error is thrown.

Maybe in the future this will be added back but for now just comment out the implementation..