### PR TITLE
[PolymodScriptClassMacro] Make callback registered flags persist across compilations

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -74,7 +74,9 @@ class PolymodScriptClassMacro
   }
 
   #if macro
+  @:persistent
   static var onGenerateCallbackRegistered:Bool = false;
+  @:persistent
   static var onAfterTypingCallbackRegistered:Bool = false;
 
   static function onGenerate(allTypes:Array<haxe.macro.Type>)


### PR DESCRIPTION
This seems to not only improve the time Haxe language server spends on "parsing classpaths", going from over a minute to only around 20 seconds, but also shows a ~42% decrease in memory usage after it's done:
<img width="625" height="30" alt="haxe-before" src="https://github.com/user-attachments/assets/5ac838d9-fc8a-4bd2-b7a8-dde5ff669eb1" /> <img width="625" height="30" alt="haxe-after" src="https://github.com/user-attachments/assets/6e59c5e8-25c4-4efa-b15d-7024f50a439f" />
