### PR TITLE
[PolymodScriptClassMacro] Remove `@:persistent` from generate callback

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -74,7 +74,6 @@ class PolymodScriptClassMacro
   }
 
   #if macro
-  @:persistent
   static var onGenerateCallbackRegistered:Bool = false;
   @:persistent
   static var onAfterTypingCallbackRegistered:Bool = false;


### PR DESCRIPTION
This just caused things to break if you compiled more than once with the compilation server enabled. Turns out only the one for `onAfterTyping` was needed to fix the issue in the other PR.