### PR TITLE
[FIX] Apply expression typing for class fields

### DIFF
--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -66,7 +66,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
           {
             if (v.expr != null)
             {
-              varValue = this._interp.expr(v.expr);
+              varValue = this._interp.exprWithType(v.expr, v.type);
               this._interp.variables.set(name, varValue);
             }
           }

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -880,7 +880,7 @@ class PolymodScriptClass
           _cachedVarDecls.set(f.name, v);
           if (v.expr != null)
           {
-            var varValue = this._interp.expr(v.expr);
+            var varValue = this._interp.exprWithType(v.expr, v.type);
             this._interp.variables.set(f.name, varValue);
           }
         default:


### PR DESCRIPTION
Allows Map class fields to properly initialize as maps when using an empty array declaration (e.g `public var map:Map<... , ...> = [];`) . Previously this only happened with local variables.

This happened to break a mod's script, but it was due to user error since it was initializing an `Array<String>` with a Map body.