### PR TITLE
Display an error "when" extending non-scriptable class

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -415,7 +415,15 @@ class PolymodScriptClass
           var importedClass:ClassImport = c.imports.get(clsName);
           if (importedClass != null && importedClass.cls != null)
           {
-            targetClass = importedClass.cls;
+            if (untyped !importedClass.cls._isHScriptedClass)
+            {
+              Polymod.error(SCRIPT_PARSE_FAILED, 'Cannot extend non-scriptable class ("${Util.getFullClassName(c)}" tried extending "${pth.join('.')}").', SCRIPT_RUNTIME);
+              return;
+            }
+            else
+            {
+              targetClass = importedClass.cls;
+            }
           }
           else if (importedClass != null && importedClass.cls == null)
           {


### PR DESCRIPTION
#### Description
Shows an error message if you attempt to instantiate a class that extends a non-scriptable class (sorry the title is a bit clickbaity :trollface:)
<img width="678" height="225" alt="image" src="https://github.com/user-attachments/assets/ea88334d-1d35-4f07-870e-238a0e12c687" />
