### PR TITLE
[FEATURE] Add `cast`

### DIFF
--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -61,6 +61,7 @@ enum Expr
   EFor(v:String, it:Expr, e:Expr);
   EBreak;
   EContinue;
+  ECast(e:Expr, ?t:CType);
   EFunction(args:Array<Argument>, e:Expr, ?name:String, ?ret:CType);
   EReturn(?e:Expr);
   EArray(e:Expr, index:Expr);

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -448,6 +448,8 @@ class Interp
         throw SBreak;
       case EContinue:
         throw SContinue;
+      case ECast(e, t):
+        return expr(e);
       case EReturn(e):
         returnValue = e == null ? null : expr(e);
         throw SReturn;

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -964,6 +964,20 @@ class Parser
           }
         }
         mk(ESwitch(e, cases, def), p1, tokenMax);
+      case "cast":
+        if (maybe(TPOpen))
+        {
+          var e = parseExpr();
+          var t = null;
+          if (allowTypes && maybe(TComma)) t = parseType();
+          ensure(TPClose);
+          return mk(ECast(e, t), p1, tokenMax);
+        }
+        else
+        {
+          var e = parseExpr();
+          return mk(ECast(e, null), p1, pmax(e));
+        }
       default:
         null;
     }

--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -336,6 +336,15 @@ class Printer
         add("break");
       case EContinue:
         add("continue");
+      case ECast(e, t):
+        add("cast(");
+        expr(e);
+        if (t != null)
+        {
+          add(", ");
+          type(t);
+        }
+        add(")");
       case EFunction(params, e, name, ret):
         add("function");
         if (name != null) add(" " + name);

--- a/polymod/hscript/_internal/Tools.hx
+++ b/polymod/hscript/_internal/Tools.hx
@@ -66,6 +66,8 @@ class Tools
         f(it);
         f(e);
       case EBreak, EContinue:
+      case ECast(e, _):
+        f(e);
       case EFunction(_, e, _, _):
         f(e);
       case EReturn(e):
@@ -114,6 +116,7 @@ class Tools
     var edef = switch (expr(e))
     {
       case EConst(_), EIdent(_), EBreak, EContinue: expr(e);
+      case ECast(e, t): ECast(f(e), t);
       case EVar(n, t, e): EVar(n, t, if (e != null) f(e) else null);
       case EFinal(n, t, e): EFinal(n, t, if (e != null) f(e) else null);
       case EParent(e): EParent(f(e));


### PR DESCRIPTION
I've been doing some trickery to have autocompleting on code for scripts and needed to cast stuff so no errors happen.

They don't really have a functionality, just parses them and interpret the expression cus hscript doesn't have types

Supports `cast object`, `cast(object)` and `cast(object, CoolClass)`

I'm not sure about what I did in Printer.hx and Tools.hx so
any suggestions are welcome!! :  )