### PR TITLE
[BUGFIX] Fix crash when loading mods without `dirs` param set

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -246,7 +246,10 @@ class Polymod
         modRoot = './mods';
       }
     }
-    var dirs = params.dirs == null ? [] : params.dirs;
+
+    params.dirs ??= [];
+
+    var dirs = params.dirs;
 
     if (params.fileSystemParams == null) params.fileSystemParams = {modRoot: modRoot};
     if (params.fileSystemParams.modRoot == null) params.fileSystemParams.modRoot = modRoot;


### PR DESCRIPTION
This PR fixes a crash that occurs when loading mods without specifying the `dirs` parameter for `Polymod.init()`. Although this is an extremely easy thing to avoid, this crash can cause confusion for people trying to use Polymod for themselves, not realizing that `dirs` is a parameter that needs to be set (it's an optional parameter). Also I'd been confused by this crash myself and it took me quite a while to discover it was because of this.