### PR TITLE
[BUGFIX] Fix Scripted Class Extending not working with multiple scripted layers

### DIFF
--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -995,18 +995,26 @@ class HScriptedClassMacro
                           {_asc.callFunction($v{funcName}, [$a{func_callArgs}]); return;}) : (macro return _asc.callFunction($v{funcName}, [$a{func_callArgs}]))
                       }
                     }
-                    // If another scripted class is being extended, call if the function exists there
-                    else if ((_asc.superClass is polymod.hscript._internal.PolymodScriptClass)
-                      && _asc.superClass.hasScriptFunction($v{funcName}))
+                    else
                     {
-                      var _super = (_asc.superClass : polymod.hscript._internal.PolymodScriptClass);
-                      $
+                      // If another scripted class is being extended, call if the function exists there
+                      var _super = _asc.superClass;
+                      while (_super is polymod.hscript._internal.PolymodScriptClass)
                       {
-                        doesReturnVoid ? (macro
+                        var _scriptSuper = (_super : polymod.hscript._internal.PolymodScriptClass);
+                        if (_scriptSuper.hasScriptFunction($v{funcName}))
+                        {
+                          $
                           {
-                            _super.callFunction($v{funcName}, [$a{func_callArgs}]);
-                            return;
-                          }) : (macro return _super.callFunction($v{funcName}, [$a{func_callArgs}]))
+                            doesReturnVoid ? (macro
+                              {
+                                _scriptSuper.callFunction($v{funcName}, [$a{func_callArgs}]);
+                                return;
+                              }) : (macro return _scriptSuper.callFunction($v{funcName}, [$a{func_callArgs}]))
+                          }
+                        }
+
+                        _super = _scriptSuper.superClass;
                       }
                     }
                   }


### PR DESCRIPTION
## What does this PR do?
There is currently a bug with `HScriptedClassMacro` where after multiple layers of scripted class extending, it would not detect any layers except the first two. This PR fixes that by making the super lookup recursive.

## More Info about the Bug
By applying [this patch](https://github.com/user-attachments/files/27283626/scripted-class-layer-bug.patch), the `openfl_hscript_class` example will include two new stages in `mod8`. "Even Less Basic Stage" should not work unless this PR is the base. This is due to it extending "Less Basic Stage", which extends "Basic Stage".