### PR TITLE
Implement `hscriptPos` to be fully built in

### DIFF
--- a/polymod/format/ScriptParseFormat.hx
+++ b/polymod/format/ScriptParseFormat.hx
@@ -51,7 +51,7 @@ class ScriptParseFormat implements BaseParseFormat
     }
     catch (e:Error)
     {
-      Polymod.error(ASSET_MERGE_FAILED, 'Script merge error: ${e#if hscriptPos .toString() #end}');
+      Polymod.error(ASSET_MERGE_FAILED, 'Script merge error: ${e.toString()}');
       return [];
     }
 
@@ -160,7 +160,7 @@ class ScriptParseFormat implements BaseParseFormat
                   continue;
                 }
 
-                var insertIndex:Int = switch (meta.params[0]#if hscriptPos .e #end)
+                var insertIndex:Int = switch (meta.params[0].e)
                 {
                   case EConst(c):
                     switch (c)
@@ -177,7 +177,7 @@ class ScriptParseFormat implements BaseParseFormat
                     switch (baseClass.fields[baseFieldIndex].kind)
                     {
                       case KFunction(f2):
-                        var funcExpr = #if hscriptPos f2.expr.e; #else f2.expr; #end
+                        var funcExpr = f2.expr.e;
 
                         // If the function isn't in a block, turn it into a block.
                         switch (funcExpr)

--- a/polymod/hscript/_internal/Async.hx
+++ b/polymod/hscript/_internal/Async.hx
@@ -42,37 +42,31 @@ class Async
   public var asyncIdents:Map<String, Bool>;
 
   static var nullExpr:Expr =
-    #if hscriptPos
-    {
-      e: null,
-      pmin: 0,
-      pmax: 0,
-      origin: "<null>",
-      line: 0
-    }
-    #else
-    null
-    #end;
+  {
+    e: null,
+    pmin: 0,
+    pmax: 0,
+    origin: "<null>",
+    line: 0
+  }
+
   static var nullId = mk(EIdent("null"), nullExpr);
 
   inline static function expr(e:Expr)
   {
-    return #if hscriptPos e.e #else e #end;
+    return e.e;
   }
 
   inline static function mk(e, inf:Expr):Expr
   {
-    return #if hscriptPos
-      {
-        e: e,
-        pmin: inf.pmin,
-        pmax: inf.pmax,
-        origin: inf.origin,
-        line: inf.line
-      }
-    #else
-      e
-    #end;
+    return
+    {
+      e: e,
+      pmin: inf.pmin,
+      pmax: inf.pmax,
+      origin: inf.origin,
+      line: inf.line
+    }
   }
 
   /**

--- a/polymod/hscript/_internal/Bytes.hx
+++ b/polymod/hscript/_internal/Bytes.hx
@@ -135,11 +135,9 @@ class Bytes
 
   function doEncode(e:Expr)
   {
-    #if hscriptPos
     doEncodeString(e.origin);
     doEncodeInt(e.line);
     var e = e.e;
-    #end
     bout.addByte(exprIndex(e));
     switch (e)
     {
@@ -296,24 +294,26 @@ class Bytes
 
   function doDecode():Expr
   {
-  #if hscriptPos
-  if (bin.get(pin) == 255)
-  {
-    pin++;
-    return null;
+    if (bin.get(pin) == 255)
+    {
+      pin++;
+      return null;
+    }
+
+    var origin = doDecodeString();
+    var line = doDecodeInt();
+
+    return {
+      e: _doDecode(),
+      pmin: 0,
+      pmax: 0,
+      origin: origin,
+      line: line
+    }
   }
-  var origin = doDecodeString();
-  var line = doDecodeInt();
-  return {
-    e: _doDecode(),
-    pmin: 0,
-    pmax: 0,
-    origin: origin,
-    line: line
-  };
-  } function _doDecode():ExprDef
+
+  function _doDecode():ExprDef
   {
-  #end
     return switch (bin.get(pin++))
     {
       case 0:

--- a/polymod/hscript/_internal/Checker.hx
+++ b/polymod/hscript/_internal/Checker.hx
@@ -509,17 +509,13 @@ class Checker
 
   inline function edef(e:Expr)
   {
-    #if hscriptPos
     return e.e;
-    #else
-    return e;
-    #end
   }
 
   inline function error(msg:String, curExpr:Expr)
   {
     var e = ECustom(msg);
-    #if hscriptPos var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line); #end
+    var e = new Error(e, curExpr.pmin, curExpr.pmax, curExpr.origin, curExpr.line);
     if (!isCompletion) throw e;
   }
 
@@ -1043,17 +1039,13 @@ class Checker
 
   function mk(e, p):Expr
   {
-    #if hscriptPos
     return {
       e: e,
       pmin: p.pmin,
       pmax: p.pmax,
       origin: p.origin,
       line: p.line
-    };
-    #else
-    return e;
-    #end
+    }
   }
 
   function isString(t:TType)

--- a/polymod/hscript/_internal/Expr.hx
+++ b/polymod/hscript/_internal/Expr.hx
@@ -29,7 +29,6 @@ enum Const
   CString(s:String, ?interpolated:Bool);
 }
 
-#if hscriptPos
 typedef Expr =
 {
   var e:ExprDef;
@@ -40,11 +39,6 @@ typedef Expr =
 }
 
 enum ExprDef
-#else
-typedef ExprDef = Expr;
-
-enum Expr
-#end
 {
   EConst(c:Const);
   EIdent(v:String);
@@ -99,7 +93,6 @@ enum CType
   CTExpr(e:Expr); // for type parameters only
 }
 
-#if hscriptPos
 /**
  * Stores information about an error.
  */
@@ -147,9 +140,6 @@ class Error
 }
 
 enum ErrorDef
-#else
-enum Error
-#end
 {
   EInvalidChar(c:Int);
   EUnexpected(s:String);

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -45,9 +45,7 @@ class Interp
   var declared:Array<{n:String, old:{r:Dynamic, ?isfinal:Bool}}>;
   var returnValue:Dynamic;
 
-  #if hscriptPos
   var curExpr:Expr;
-  #end
 
   public function new()
   {
@@ -75,9 +73,7 @@ class Interp
 
   public function posInfos():PosInfos
   {
-    #if hscriptPos
     if (curExpr != null) return cast {fileName: curExpr.origin, lineNumber: curExpr.line};
-    #end
     return cast {fileName: "hscript", lineNumber: 0};
   }
 
@@ -209,10 +205,8 @@ class Interp
 
   function increment(e:Expr, prefix:Bool, delta:Int):Dynamic
   {
-    #if hscriptPos
     curExpr = e;
     var e = e.e;
-    #end
     switch (e)
     {
       case EIdent(id):
@@ -323,9 +317,9 @@ class Interp
     }
   }
 
-  inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Dynamic
+  inline function error(e:ErrorDef, rethrow = false):Dynamic
   {
-    #if hscriptPos var e = new Error(e, curExpr?.pmin ?? 0, curExpr?.pmax ?? 0, curExpr?.origin ?? 'unknown', curExpr?.line ?? 0); #end
+    var e = new Error(e, curExpr?.pmin ?? 0, curExpr?.pmax ?? 0, curExpr?.origin ?? 'unknown', curExpr?.line ?? 0);
     if (rethrow) this.rethrow(e)
     else
       throw e;
@@ -350,10 +344,8 @@ class Interp
 
   public function expr(e:Expr):Dynamic
   {
-    #if hscriptPos
     curExpr = e;
     var e = e.e;
-    #end
     switch (e)
     {
       case EConst(c):
@@ -435,9 +427,7 @@ class Interp
         Tools.getKeyIterator(it, function(vk, vv, it) {
           if (vk == null)
           {
-            #if hscriptPos
             curExpr = it;
-            #end
             error(ECustom("Invalid for expression"));
             return;
           }
@@ -549,9 +539,7 @@ class Interp
                 keys.push(expr(eKey));
                 values.push(expr(eValue));
               default:
-                #if hscriptPos
                 curExpr = e;
-                #end
                 error(ECustom("Invalid map key=>value expression"));
             }
           }

--- a/polymod/hscript/_internal/JsInterp.hx
+++ b/polymod/hscript/_internal/JsInterp.hx
@@ -92,13 +92,9 @@ class JsInterp extends Interp
 
   function addPos(estr:String)
   {
-    #if hscriptPos
     var expr = curExpr;
     var p = '{pmin:,pmax:,origin:"",line:}';
     return '($$i._p(${expr.pmin},${expr.pmax},"${expr.origin}",${expr.line}),$estr)';
-    #else
-    return estr;
-    #end
   }
 
   function isContext(v:String)
@@ -145,10 +141,8 @@ class JsInterp extends Interp
 
   function exprJS(expr:Expr):String
   {
-    #if hscriptPos
     curExpr = expr;
     var expr = expr.e;
-    #end
     switch (expr)
     {
       case EConst(c):
@@ -346,9 +340,7 @@ class JsInterp extends Interp
                 keys.push(exprValue(eKey));
                 values.push(exprValue(eValue));
               default:
-                #if hscriptPos
                 curExpr = e;
-                #end
                 error(ECustom("Invalid map key=>value expression"));
             }
           }
@@ -427,7 +419,6 @@ class JsInterp extends Interp
     return Std.isOfType(v1, v2);
   }
 
-  #if hscriptPos
   function _p(pmin, pmax, origin, line)
   {
     curExpr =
@@ -439,5 +430,4 @@ class JsInterp extends Interp
         line: line
       };
   }
-  #end
 }

--- a/polymod/hscript/_internal/Macro.hx
+++ b/polymod/hscript/_internal/Macro.hx
@@ -23,9 +23,7 @@
 package polymod.hscript._internal;
 
 import polymod.hscript._internal.Expr.Error;
-#if hscriptPos
 import polymod.hscript._internal.Expr.ErrorDef;
-#end
 import haxe.macro.Expr;
 
 class Macro
@@ -185,7 +183,7 @@ class Macro
   public function convert(e:hscript.Expr):Expr
   {
     return {
-      expr: switch (#if hscriptPos e.e #else e #end)
+      expr: switch (e.e)
       {
         case EConst(c):
           EConst( switch (c)
@@ -223,7 +221,7 @@ class Macro
         case EDoWhile(c, e):
           EWhile(convert(c), convert(e), false);
         case EFor(v, it, efor):
-          var p = #if (!macro && hscriptPos)
+          var p = #if !macro
             {file: p.file, min: e.pmin, max: e.pmax} #else p #end;
           EFor({expr: EBinop(OpIn, {expr: EConst(CIdent(v)), pos: p}, convert(it)), pos: p}, convert(efor));
         case EForGen(it, efor):
@@ -282,13 +280,13 @@ class Macro
               {values: [for (v in c.values) convert(v)], expr: convert(c.expr)}
           ], edef == null ? null : convert(edef));
         case EMeta(m, params, esub):
-          var mpos = #if (!macro && hscriptPos)
+          var mpos = #if !macro
             {file: p.file, min: e.pmin, max: e.pmax} #else p #end;
           EMeta({name: m, params: params == null ? [] : [for (p in params) convert(p)], pos: mpos}, convert(esub));
         case ECheckType(e, t):
           ECheckType(convert(e), convertType(t));
       },
-      pos: #if (!macro && hscriptPos)
+      pos: #if !macro
       {file: p.file, min: e.pmin, max: e.pmax} #else p #end
     }
   }

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -104,20 +104,12 @@ class Parser
   var idents:Array<Bool>;
   var uid:Int = 0;
 
-  #if hscriptPos
   var origin:String;
   var tokenMin:Int;
   var tokenMax:Int;
   var oldTokenMin:Int;
   var oldTokenMax:Int;
   var tokens:List<{min:Int, max:Int, t:Token}>;
-  #else
-  static inline var p1 = 0;
-  static inline var tokenMin = 0;
-  static inline var tokenMax = 0;
-
-  var tokens:haxe.ds.GenericStack<Token>;
-  #end
 
   public function new()
   {
@@ -172,11 +164,8 @@ class Parser
 
   public inline function error(err, pmin, pmax)
   {
-    if (!resumeErrors) #if hscriptPos
+    if (!resumeErrors)
       throw new Error(err, pmin, pmax, origin, line);
-    #else
-      throw err;
-    #end
   }
 
   public function invalidChar(c)
@@ -189,15 +178,11 @@ class Parser
     // line=1 - don't reset line : it might be set manualy
     preprocStack = [];
     preprocessing = false;
-    #if hscriptPos
     this.origin = origin;
     readPos = 0;
     tokenMin = oldTokenMin = pos;
     tokenMax = oldTokenMax = pos;
     tokens = new List();
-    #else
-    tokens = new haxe.ds.GenericStack<Token>();
-    #end
     offset = pos;
     char = -1;
     ops = new Array();
@@ -233,13 +218,9 @@ class Parser
 
   inline function push(tk)
   {
-    #if hscriptPos
     tokens.push({t: tk, min: tokenMin, max: tokenMax});
     tokenMin = oldTokenMin;
     tokenMax = oldTokenMax;
-    #else
-    tokens.add(tk);
-    #end
   }
 
   inline function ensure(tk)
@@ -277,34 +258,21 @@ class Parser
 
   inline function expr(e:Expr)
   {
-    #if hscriptPos
     return e.e;
-    #else
-    return e;
-    #end
   }
 
   inline function pmin(e:Expr)
   {
-    #if hscriptPos
     return e == null ? 0 : e.pmin;
-    #else
-    return 0;
-    #end
   }
 
   inline function pmax(e:Expr)
   {
-    #if hscriptPos
     return e == null ? 0 : e.pmax;
-    #else
-    return 0;
-    #end
   }
 
   inline function mk(e, ?pmin, ?pmax):Expr
   {
-    #if hscriptPos
     if (e == null) return null;
     if (pmin == null) pmin = tokenMin;
     if (pmax == null) pmax = tokenMax;
@@ -314,10 +282,7 @@ class Parser
       pmax: pmax,
       origin: origin,
       line: line
-    };
-    #else
-    return e;
-    #end
+    }
   }
 
   function isBlock(e)
@@ -427,9 +392,7 @@ class Parser
   function parseExpr()
   {
     var tk = token();
-    #if hscriptPos
     var p1 = tokenMin;
-    #end
     switch (tk)
     {
       case TId(id):
@@ -736,9 +699,7 @@ class Parser
   var inSwitchCase:Bool = false;
   function parseStructure(id)
   {
-    #if hscriptPos
     var p1 = tokenMin;
-    #end
     return switch (id)
     {
       case "if":
@@ -1208,11 +1169,7 @@ class Parser
                     if (op == ">") break;
                     if (op.charCodeAt(0) == ">".code)
                     {
-                      #if hscriptPos
                       tokens.add({t: TOp(op.substr(1)), min: tokenMax - op.length - 1, max: tokenMax});
-                      #else
-                      tokens.add(TOp(op.substr(1)));
-                      #end
                       break;
                     }
                   default:
@@ -1255,7 +1212,7 @@ class Parser
                 {
                   case null:
                   case v:
-                    error(ECustom('Default values not allowed in function types'), #if hscriptPos v.pmin, v.pmax #else 0, 0 #end);
+                    error(ECustom('Default values not allowed in function types'), v.pmin, v.pmax);
                 }
 
                 CTNamed(arg.name, if (arg.opt) CTOpt(arg.t) else arg.t);
@@ -1874,9 +1831,7 @@ class Parser
     var qt = [false];
     var old = line;
     var s = input;
-    #if hscriptPos
     var p1 = currentPos - 1;
-    #end
     while (true)
     {
       var c = readChar();
@@ -1966,9 +1921,7 @@ class Parser
     var b:StringBuf = new StringBuf();
     var parts:Array<Expr> = [];
     var state:InterpState = Literal;
-    #if hscriptPos
     var p1:Int = tokenMin;
-    #end
 
     inline function pushBuf(i:Int)
     {
@@ -2055,15 +2008,13 @@ class Parser
               var oldTokenMin:Int = tokenMin;
               var oldTokenMax:Int = tokenMax;
 
-              parts.push(parseString('(${b.toString()})' #if hscriptPos, origin, p1 + i - b.length #end));
+              parts.push(parseString('(${b.toString()})', origin, p1 + i - b.length));
 
               input = oldInput;
               readPos = oldPos;
               offset = oldOffset;
-              #if hscriptPos
               tokenMin = oldTokenMin;
               tokenMax = oldTokenMax;
-              #end
               char = -1;
 
               b = new StringBuf();
@@ -2131,26 +2082,28 @@ class Parser
 
   function token()
   {
-  #if hscriptPos
-  var t = tokens.pop();
-  if (t != null)
-  {
-    tokenMin = t.min;
-    tokenMax = t.max;
-    return t.t;
-  }
-  oldTokenMin = tokenMin;
-  oldTokenMax = tokenMax;
-  tokenMin = (this.char < 0) ? currentPos : currentPos - 1;
-  var t = _token();
-  tokenMax = (this.char < 0) ? currentPos - 1 : currentPos - 2;
-  return t;
-  } function _token()
+    var t = tokens.pop();
 
+    if (t != null)
+    {
+      tokenMin = t.min;
+      tokenMax = t.max;
+      return t.t;
+    }
+
+    oldTokenMin = tokenMin;
+    oldTokenMax = tokenMax;
+
+    tokenMin = (this.char < 0) ? currentPos : currentPos - 1;
+
+    var t = _token();
+    tokenMax = (this.char < 0) ? currentPos - 1 : currentPos - 2;
+
+    return t;
+  }
+
+  function _token()
   {
-  #else
-  if (!tokens.isEmpty()) return tokens.pop();
-  #end
     var char;
     if (this.char < 0) char = readChar();
     else
@@ -2170,14 +2123,10 @@ class Parser
         case 0:
           return TEof;
         case 32, 9, 13: // space, tab, CR
-          #if hscriptPos
           tokenMin++;
-          #end
         case 10:
           line++; // LF
-          #if hscriptPos
           tokenMin++;
-          #end
         case 48, 49, 50, 51, 52, 53, 54, 55, 56, 57: // 0...9
           var n = (char - 48) * 1.0;
           var exp = 0.;

--- a/polymod/hscript/_internal/PolymodInterpEx.hx
+++ b/polymod/hscript/_internal/PolymodInterpEx.hx
@@ -647,12 +647,8 @@ class PolymodInterpEx extends Interp
   public override function expr(e:Expr):Dynamic
   {
     // Override to provide some fixes, falling back to super.expr() when not needed.
-    #if hscriptPos
     curExpr = e;
     switch (e.e)
-    #else
-    switch (e)
-    #end
     {
       // These overrides are used to handle specific cases where problems occur.
       case EVar(name, type, expression):
@@ -885,11 +881,7 @@ class PolymodInterpEx extends Interp
         }
         catch (error:Error)
         {
-          #if hscriptPos
           var err = error.e;
-          #else
-          var err = error;
-          #end
           // restore vars
           restore(old);
           inTry = oldTry;
@@ -1051,12 +1043,9 @@ class PolymodInterpEx extends Interp
       return this.expr(e);
     }
 
-    #if hscriptPos
     curExpr = e;
+
     switch (e.e)
-    #else
-    switch (e)
-    #end
     {
       case EArrayDecl(arr):
         // Initialize an array (or map) from a declaration.
@@ -1084,9 +1073,7 @@ class PolymodInterpEx extends Interp
                 }
                 else
                 {
-                  #if hscriptPos
                   curExpr = e;
-                  #end
                   var err = 'Invalid expression in map initialization (expected key=>value, got ${Printer.toString(e)})';
                   error(ECustom(err));
                 }
@@ -1105,9 +1092,7 @@ class PolymodInterpEx extends Interp
                 }
                 else
                 {
-                  #if hscriptPos
                   curExpr = e;
-                  #end
                   var err = 'Invalid expression in array initialization (expected no key=>value pairs, got ${Printer.toString(e)})';
                   error(ECustom(err));
                 }
@@ -1146,9 +1131,8 @@ class PolymodInterpEx extends Interp
         default:
           // Complain about anything else.
           // This error message has been modified to provide more information.
-          #if hscriptPos
           curExpr = e;
-          #end
+
           var err = 'Invalid expression in map initialization (expected key=>value, got ${Printer.toString(e)})';
           error(ECustom(err));
       }
@@ -1194,7 +1178,7 @@ class PolymodInterpEx extends Interp
 
   function getIdent(e:Expr):Null<String>
   {
-    switch (#if hscriptPos e.e #else e #end)
+    switch (e.e)
     {
       case EIdent(v):
         return v;

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -163,12 +163,8 @@ class PolymodScriptClass
       }
       catch (err:Expr.Error)
       {
-        var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
-        #if hscriptPos
+        var errLine:String = '${err.line}';
         switch (err.e)
-        #else
-        switch (err)
-        #end
         {
           case EUnexpected(s):
             Polymod.error(SCRIPT_PARSE_FAILED,
@@ -201,12 +197,8 @@ class PolymodScriptClass
       }
       catch (err:Expr.Error)
       {
-        var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
-        #if hscriptPos
+        var errLine:String = '${err.line}';
         switch (err.e)
-        #else
-        switch (err)
-        #end
         {
           case EUnexpected(s):
             Polymod.error(SCRIPT_PARSE_FAILED,
@@ -571,8 +563,8 @@ class PolymodScriptClass
 
   public static function reportError(err:Expr.Error, ?className:String, ?fnName:String):Void
   {
-    var errLine:String = #if hscriptPos '${err.line}' #else "???" #end;
-    var message:String = switch (#if hscriptPos err.e #else err #end)
+    var errLine:String = '${err.line}';
+    var message:String = switch (err.e)
     {
       case ECustom(msg):
         'An unknown error occurred: $msg';

--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -175,7 +175,7 @@ class Printer
       add("??NULL??");
       return;
     }
-    switch (#if hscriptPos e.e #else e #end)
+    switch (e.e)
     {
       case EConst(c):
         addConst(c);
@@ -211,15 +211,15 @@ class Printer
           // account for null coalescing
           if (el.length == 2)
           {
-            switch (#if hscriptPos el[0].e #else el[0] #end)
+            switch (el[0].e)
             {
               case EVar(n, _, e):
                 if (n.indexOf("__a_") == 0)
                 {
-                  switch (#if hscriptPos el[1].e #else el[1] #end)
+                  switch (el[1].e)
                   {
                     case ETernary(c, e11, e12):
-                      switch (#if hscriptPos c.e #else c #end)
+                      switch (c.e)
                       {
                         case EBinop(op, _, _):
                           if (op == "==")
@@ -282,7 +282,7 @@ class Printer
       case ECall(e, args):
         if (e == null) expr(e);
         else
-          switch (#if hscriptPos e.e #else e #end)
+          switch (e.e)
           {
             case EField(_), EIdent(_), EConst(_):
               expr(e);
@@ -730,12 +730,12 @@ class Printer
   /**
    * Converts an `Error` object into a human-readable `String` representation.
    * @param e The error to convert.
-   * @param includePosInfo Prepends the origin and line position number, only works if `hscriptPos` is defined.
+   * @param includePosInfo Prepends the origin and line position number.
    * @return String
    */
   public static function errorToString(e:Expr.Error, includePosInfo:Bool = true):String
   {
-    var message = switch (#if hscriptPos e.e #else e #end)
+    var message = switch (e.e)
     {
       case EInvalidChar(c): "Invalid character: '" + (StringTools.isEof(c) ? "EOF" : String.fromCharCode(c)) + "' (" + c + ")";
       case EUnexpected(s): "Unexpected token: \"" + s + "\"";
@@ -769,9 +769,9 @@ class Printer
       case EScriptThrow(v): "User script threw an exception: " + v;
       case ECustom(msg): msg;
     };
-    #if hscriptPos
+
     if (includePosInfo) message = e.origin + ":" + e.line + ": " + message;
-    #end
+
     return message;
   }
 }

--- a/polymod/hscript/_internal/Tools.hx
+++ b/polymod/hscript/_internal/Tools.hx
@@ -148,26 +148,18 @@ class Tools
 
   public static inline function expr(e:Expr):ExprDef
   {
-    #if hscriptPos
     return e.e;
-    #else
-    return e;
-    #end
   }
 
   public static inline function mk(e:ExprDef, p:Expr)
   {
-    #if hscriptPos
     return {
       e: e,
       pmin: p.pmin,
       pmax: p.pmax,
       origin: p.origin,
       line: p.line
-    };
-    #else
-    return e;
-    #end
+    }
   }
 
   public static inline function getKeyIterator<T>(e:Expr, callb:String->String->Expr->T)

--- a/samples/flixel/Project.xml
+++ b/samples/flixel/Project.xml
@@ -14,7 +14,6 @@
 	<haxelib name="flixel-ui" />
 	<haxelib name="flixel-addons" />
 	<haxelib name="polymod" />
-	<haxedef name="hscriptPos" />
 	<haxedef name="HXCPP_CHECK_POINTER" />
 	<haxedef name="HXCPP_STACK_LINE" />
 	<haxedef name="FLX_NO_DEBUG" unless="debug" />

--- a/samples/flixel_zip/Project.xml
+++ b/samples/flixel_zip/Project.xml
@@ -14,7 +14,6 @@
 	<haxelib name="flixel-ui" />
 	<haxelib name="flixel-addons" />
 	<haxelib name="polymod" />
-	<haxedef name="hscriptPos" />
 	<haxedef name="HXCPP_CHECK_POINTER" />
 	<haxedef name="HXCPP_STACK_LINE" />
 	<haxedef name="FLX_NO_DEBUG" unless="debug" />

--- a/samples/openfl_hscript_class/project.xml
+++ b/samples/openfl_hscript_class/project.xml
@@ -20,5 +20,4 @@
 	<haxedef name="POLYMOD_DEBUG" value="true" />
 	<haxedef name="POLYMOD_SCRIPT_EXT" value=".hxs" />
 	<haxedef name="POLYMOD_SCRIPT_CLASS_EXT" value=".hxc" />
-	<haxedef name="hscriptPos" />
 </project>


### PR DESCRIPTION
This PR removes the need for `hscriptPos` in order for line numbers to be used in script errors. `hscriptPos` doesn't need to be something you have to manually enable. In fact, you probably never want it disabled, because why wouldn't you want line numbers??

This should also put an end to PRs having to be made due to any compiling problems that occur because of `hscriptPos` being disabled.