### PR TITLE
Fix incorrect use of expression reification

### DIFF
--- a/polymod/hscript/_internal/HScriptableMacro.hx
+++ b/polymod/hscript/_internal/HScriptableMacro.hx
@@ -118,7 +118,7 @@ class HScriptableMacro
             {
               var module:String = Context.getLocalModule();
               module = StringTools.replace(module, '.', '/');
-              pathName = $v{'$module/$pathName'};
+              pathName = '$module/$pathName';
             }
 
             // If pathName is a string, set it.


### PR DESCRIPTION
Fixes #225 

This PR fixes an improper use of expression reification in a macro, we only use these after a `macro` keyword AND if we're trying to get an Expr, but we all it wants is to format a string so it's not actually needed.