### PR TITLE
[FIX] Enable case-insensitive lookup for ZIP override as well

### DIFF
--- a/polymod/fs/SysZipFileSystem.hx
+++ b/polymod/fs/SysZipFileSystem.hx
@@ -60,7 +60,7 @@ class SysZipFileSystem extends SysFileSystem
     if (params.autoScan) addAllZips();
   }
 
-  #if linux
+  #if (!windows)
   public override function getPathLike(path:String):Null<String>
   {
     var filePath = filesLocations.get(path);


### PR DESCRIPTION
The previous PR that enabled case insensitive lookup for other non-Windows filesystems forgot to account for the override in `SysZipFileSystem`, which probably broke ZIP mods on these platforms ("probably" because I have no way to test iOS or macOS, but I had to fix the same issue on Linux once)