### PR TITLE
[BUGFIX] Fix the `#end` preprocessor at the end of the file throwing an error

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -2516,12 +2516,13 @@ class Parser
     while (true)
     {
       var tk = token();
-      if (tk == TEof) error(EInvalidPreprocessor("Unclosed"), pos, pos);
       if (preprocStack[spos] != obj)
       {
         push(tk);
         break;
       }
+
+      if (tk == TEof) error(EInvalidPreprocessor("Unclosed"), pos, pos);
     }
   }
 


### PR DESCRIPTION
This PR fixes the issue where doing something like this

<img width="601" height="338" alt="image" src="https://github.com/user-attachments/assets/608b3864-c712-4c3d-80df-4e186d03c931" />

would throw an error saying that the preprocessor is unclosed.