### PR TITLE
Fix HashLink crash

### DIFF
--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -884,7 +884,7 @@ class HScriptedClassMacro
                     else
                     {
                       // If another scripted class is being extended, call if the function exists there
-                      var _super = _asc.superClass;
+                      var _super:Dynamic = _asc.superClass;
                       while (_super is polymod.hscript._internal.PolymodScriptClass)
                       {
                         var _scriptSuper = (_super : polymod.hscript._internal.PolymodScriptClass);


### PR DESCRIPTION
Fixes a crash about an invalid cast on HashLink.

The compiler guesses the type of `_super` as of `PolymodScriptClass`, but it can be of the instance of a `HScriptedClass` extending scriptable class. We force it to type as `Dynamic` instead.