### PR TITLE
Fix string interpolation interfering with preprocessor checks

### DIFF
--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -2053,6 +2053,7 @@ class Parser
               }
 
               var oldInput:String = input;
+              var oldPreprocStack:Array<{r:Bool}> = preprocStack.copy();
               var oldPos:Int = readPos;
               var oldOffset:Int = offset;
               var oldTokenMin:Int = tokenMin;
@@ -2068,6 +2069,7 @@ class Parser
               parts.push(e);
 
               input = oldInput;
+              preprocStack = oldPreprocStack;
               readPos = oldPos;
               offset = oldOffset;
               #if hscriptPos


### PR DESCRIPTION
Fixes a case where simply having an interpolated string with `${}` like below would screw up preprocessor checks
<img width="238" height="60" alt="image" src="https://github.com/user-attachments/assets/9dbe14dd-a48c-4cc2-8004-ced611eb2bf3" />
