### PR TITLE
Re-enable checks for final access.

### DIFF
--- a/checkstyle.json
+++ b/checkstyle.json
@@ -172,7 +172,9 @@
         "ignoreOverride": true,
         "tokens": ["ABSTRACT_DEF", "CLASS_DEF", "ENUM_DEF", "INTERFACE_DEF"],
         "modifier": "PUBLIC",
-        "excludeNames": ["new", "toString"]
+        "excludeNames": ["new", "toString"],
+
+        "severity": "IGNORE"
       },
       "type": "FieldDocComment"
     },
@@ -494,7 +496,9 @@
       "props": {
         "enforceReturnTypeForAnonymous": false,
         "allowEmptyReturn": true,
-        "enforceReturnType": true
+        "enforceReturnType": true,
+
+        "severity": "IGNORE"
       },
       "type": "Return"
     },

--- a/include.xml
+++ b/include.xml
@@ -4,7 +4,5 @@
   <haxelib name="thx.semver" />
 
   <haxeflag name="--macro" value="polymod.hscript._internal.HScriptRedirectDefines.run()" if="POLYMOD_REDIRECT_HSCRIPT" />
-  <!--
-    <haxeflag name="- -macro" value="polymod.hscript._internal.PolymodFinalMacro.locateAllFinals()" />
-  -->
+  <haxeflag name="--macro" value="polymod.hscript._internal.PolymodFinalMacro.locateAllFinals()" />
 </project>

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -185,8 +185,11 @@ class HScriptedClassMacro
               }
               catch (error)
               {
+                var callStack:String = polymod.util.Util.fetchCallStack();
+
                 polymod.Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
-                  'Could not construct instance of scripted class (${clsName} extends ' + $v{clsTypeName} + '):\n${error}', SCRIPT_RUNTIME);
+                  'An uncaught exception was thrown while constructing an instance of scripted class (${clsName} extends ' + $v{clsTypeName} + '):\n$error\n$callStack',
+                  SCRIPT_RUNTIME);
                 return null;
               }
             },
@@ -524,7 +527,7 @@ class HScriptedClassMacro
           {
             if (_asc == null)
             {
-              return $v{'PolymodScriptedClass<${cls.name} extends ${cls.superClass.t.get().name}>(NO ASC)'};
+              return $v{'PolymodScriptClass<${cls.name} extends ${cls.superClass.t.get().name}>(NO ASC)'};
             }
             else
             {

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -145,6 +145,8 @@ class HScriptedClassMacro
   {
     // Context.info('  Building scripted class init() function', Context.currentPos());
     var clsTypeName:String = cls.pack.join('.') != '' ? '${cls.pack.join('.')}.${cls.name}' : cls.name;
+    // scriptInit returns null if the script throws an error while initializing.
+    var clsType:ComplexType = Context.toComplexType(Context.getType(clsTypeName));
     var function_init:Field =
       {
         name: 'scriptInit',
@@ -157,7 +159,7 @@ class HScriptedClassMacro
             args: [
               {name: 'clsName', type: macro :String}, {name: 'args', type: macro :...Dynamic}],
             params: null,
-            ret: Context.toComplexType(Context.getType(clsTypeName)),
+            ret: polymod.util.MacroUtil.nullable(clsType),
             expr: macro
             {
               var clsRef = polymod.hscript._internal.PolymodStaticClassReference.tryBuild(clsName);

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -745,10 +745,12 @@ class Interp
           {
             var superClass:PolymodAbstractScriptClass = cast(_proxy.superClass, PolymodScriptClass);
             return superClass.fieldWrite(id, v);
-          } else {
-            set(_proxy.superClass, id, v);
-            return v;
           }
+
+          // Directly assign the value.
+          // This is needed because `assignValue` may sometimes be called from the constructor.
+          PolymodAbstractScriptClass.setClassObjectField(_proxy.superClass, id, v);
+          return v;
         }
 
         @:privateAccess

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -759,6 +759,7 @@ class Interp
             switch (decl?.set)
             {
               case "set":
+                // Allow assigning to "null" only for local fields.
                 final setName = 'set_$id';
                 if (!_propTrack.exists(setName))
                 {
@@ -771,6 +772,11 @@ class Interp
               case "never":
                 error(EInvalidPropSet(id));
                 return null;
+
+              case "null":
+                // If the property setter is "null", it can only be assigned on local fields.
+                // Thankfully, this is a local field!
+                // So we can just fallthrough to the default case.
             }
 
             if ((decl?.isfinal ?? false) && decl?.expr != null)
@@ -2386,14 +2392,21 @@ class Interp
       }
       catch (e:Dynamic)
       {
-        error(EInvalidFinalSet(f));
+        error(EInvalidAccess(f));
       }
     }
     else if (Std.isOfType(o, PolymodStaticClassReference))
     {
       var ref:PolymodStaticClassReference = cast(o, PolymodStaticClassReference);
 
-      return ref.setField(f, v);
+      try
+      {
+        return ref.setField(f, v);
+      }
+      catch (e:Dynamic)
+      {
+        error(EInvalidAccess(f));
+      }
     }
     else if (Std.isOfType(o, PolymodScriptClass))
     {
@@ -2891,45 +2904,44 @@ class Interp
     var fieldDecl = getScriptClassStaticFieldDecl(clsName, fieldName);
     if (fieldDecl != null)
     {
-      if (!this.variables.exists(prefixedName))
+      switch (fieldDecl.kind)
       {
-        switch (fieldDecl.kind)
-        {
-          case KFunction(_fn):
-            throw 'Cannot override function ${prefixedName}';
-          case KVar(v):
-            if (v.set != null)
+        case KFunction(_fn):
+          throw 'Cannot override function ${prefixedName}';
+        case KVar(v):
+          if (v.set != null)
+          {
+            switch (v.set)
             {
-              switch (v.set)
-              {
-                case 'set':
-                  var setterFunc = 'set_${fieldName}';
-                  if (hasScriptClassStaticFunction(clsName, setterFunc))
-                  {
-                    return callScriptClassStaticFunction(clsName, setterFunc, [value]);
-                  }
-                  else
-                  {
-                    throw 'Could not resolve setter for property ${prefixedName}';
-                  }
-                case 'default':
-                  this.variables.set(prefixedName, value);
-                  return value;
-                default:
+              case 'set':
+                var setterFunc = 'set_${fieldName}';
+                if (hasScriptClassStaticFunction(clsName, setterFunc))
+                {
+                  return callScriptClassStaticFunction(clsName, setterFunc, [value]);
+                }
+                else
+                {
                   throw 'Could not resolve setter for property ${prefixedName}';
-              }
+                }
+
+              case 'never':
+                throw 'Cannot assign to property ${prefixedName}';
+
+              case 'null':
+                throw 'Cannot assign to property ${prefixedName}';
+
+              case 'default':
+                this.variables.set(prefixedName, value);
+                return value;
+              default:
+                throw 'Could not resolve setter for property ${prefixedName}';
             }
-            else
-            {
-              this.variables.set(prefixedName, value);
-              return value;
-            }
-        }
-      }
-      else
-      {
-        this.variables.set(prefixedName, value);
-        return value;
+          }
+          else
+          {
+            this.variables.set(prefixedName, value);
+            return value;
+          }
       }
     }
     else

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -674,10 +674,10 @@ class Interp
       {
         var superClass:PolymodAbstractScriptClass = cast(_proxy.superClass, PolymodScriptClass);
         return superClass.fieldWrite(id, v);
+      } else {
+        set(_proxy.superClass, id, v);
+        return v;
       }
-
-      Reflect.setProperty(_proxy.superClass, id, v);
-      return v;
     }
 
     // Fallback to setting in local scope.
@@ -745,10 +745,10 @@ class Interp
           {
             var superClass:PolymodAbstractScriptClass = cast(_proxy.superClass, PolymodScriptClass);
             return superClass.fieldWrite(id, v);
+          } else {
+            set(_proxy.superClass, id, v);
+            return v;
           }
-
-          Reflect.setProperty(_proxy.superClass, id, v);
-          return v;
         }
 
         @:privateAccess
@@ -808,7 +808,7 @@ class Interp
                   return superClass.fieldWrite(id, v);
                 }
 
-                Reflect.setProperty(_proxy.superClass, id, v);
+                set(_proxy.superClass, id, v);
                 return v;
               }
             }
@@ -822,11 +822,19 @@ class Interp
                   for (imp in _proxy._c.imports)
                   {
                     if (imp.name != id0) continue;
-                    var finals = PolymodFinalMacro.getAllFinals().get(imp.fullPath) ?? [];
+                    var finals = PolymodFinalMacro.getFinals(imp.fullPath);
 
                     if (finals.contains(id))
                     {
                       error(EInvalidFinalSet(id));
+                      return null;
+                    }
+
+                    var privates = PolymodFinalMacro.getPrivateProperties(imp.fullPath);
+
+                    if (privates.contains(id))
+                    {
+                      error(EInvalidPropSet(id));
                       return null;
                     }
                   }
@@ -1118,7 +1126,7 @@ class Interp
     }
   }
 
-  inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Dynamic
+  public inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Dynamic
   {
     #if hscriptPos var e = new Error(e, curExpr?.pmin ?? 0, curExpr?.pmax ?? 0, curExpr?.origin ?? 'unknown', curExpr?.line ?? 0); #end
     if (rethrow) this.rethrow(e)
@@ -2423,7 +2431,7 @@ class Interp
           return superClass.fieldWrite(f, v);
         }
 
-        Reflect.setProperty(proxy.superClass, f, v);
+        set(proxy.superClass, f, v);
       }
       else
       {
@@ -2439,6 +2447,20 @@ class Interp
       }
 
       error(EInvalidScriptedVarSet(f));
+    }
+
+    // Prevent setting final variables, or properties with (never) accessors
+    var finals = PolymodFinalMacro.getFinalsOf(o);
+    if (finals.contains(f))
+    {
+      error(EInvalidFinalSet(f));
+    }
+
+    // Prevent setting properties with (null) accessors
+    var privates = PolymodFinalMacro.getPrivatePropertiesOf(o);
+    if (privates.contains(f))
+    {
+      error(EInvalidPropSet(f));
     }
 
     try
@@ -2909,6 +2931,9 @@ class Interp
         case KFunction(_fn):
           throw 'Cannot override function ${prefixedName}';
         case KVar(v):
+          if (v.isfinal) {
+            throw 'Cannot override final static field ${prefixedName}';
+          }
           if (v.set != null)
           {
             switch (v.set)

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -808,7 +808,9 @@ class Interp
                   return superClass.fieldWrite(id, v);
                 }
 
-                set(_proxy.superClass, id, v);
+                // Directly assign the value.
+                // This is needed because `assignValue` may sometimes be called from the constructor.
+                PolymodAbstractScriptClass.setClassObjectField(_proxy.superClass, id, v);
                 return v;
               }
             }
@@ -2346,23 +2348,6 @@ class Interp
       }
     }
     #end
-    // if (o == null) error(EInvalidAccess(f));
-    // return
-    // {
-    //   #if php
-    //   // https://github.com/HaxeFoundation/haxe/issues/4915
-    //   try
-    //   {
-    //     Reflect.getProperty(o, f);
-    //   }
-    //   catch (e:Dynamic)
-    //   {
-    //     Reflect.field(o, f);
-    //   }
-    //   #else
-    //   Reflect.getProperty(o, f);
-    //   #end
-    // }
   }
 
   function set(o:Dynamic, f:String, v:Dynamic):Dynamic
@@ -2449,23 +2434,9 @@ class Interp
       error(EInvalidScriptedVarSet(f));
     }
 
-    // Prevent setting final variables, or properties with (never) accessors
-    var finals = PolymodFinalMacro.getFinalsOf(o);
-    if (finals.contains(f))
-    {
-      error(EInvalidFinalSet(f));
-    }
-
-    // Prevent setting properties with (null) accessors
-    var privates = PolymodFinalMacro.getPrivatePropertiesOf(o);
-    if (privates.contains(f))
-    {
-      error(EInvalidPropSet(f));
-    }
-
     try
     {
-      Reflect.setProperty(o, f, v);
+      PolymodAbstractScriptClass.setClassObjectField(o, f, v);
     }
     catch (e)
     {

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -424,7 +424,11 @@ class Interp
       }
       catch (error)
       {
-        Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Could not construct instance of scripted class ($clsToInit extends ' + clsName + '):\n${error}');
+        var callStack:String = polymod.util.Util.fetchCallStack();
+
+        Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
+          'An uncaught exception was thrown while constructing an instance of scripted class ($clsToInit extends ' + clsName + '):\n$error\n$callStack',
+          SCRIPT_RUNTIME);
         return null;
       }
     }

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -508,7 +508,7 @@ class Interp
     }
   }
 
-  private static function registerScriptClass(c:ClassDecl)
+  static function registerScriptClass(c:ClassDecl)
   {
     var name = Util.getFullClassName(c);
 
@@ -775,7 +775,7 @@ class Interp
 
             if ((decl?.isfinal ?? false) && decl?.expr != null)
             {
-              error(EInvalidAccess(id));
+              error(EInvalidFinalSet(id));
               return null;
             }
           }
@@ -976,7 +976,7 @@ class Interp
 
         var l = locals.get(id);
         var v:Dynamic = (l == null) ? resolve(id) : l.r;
-        if (l != null && l.isfinal && l.r != null) return error(EInvalidAccess(id));
+        if (l != null && l.isfinal && l.r != null) return error(EInvalidFinalSet(id));
         if (prefix)
         {
           v += delta;
@@ -1480,7 +1480,7 @@ class Interp
         {
           case EField(e, f):
             var obj = expr(e);
-            if (obj == null) error(EInvalidAccess(f));
+            if (obj == null) error(ENullObjectReference(f));
             return fcall(obj, f, args);
           default:
             return call(null, expr(e), args);
@@ -2294,22 +2294,6 @@ class Interp
       }
 
       error(EInvalidScriptedVarGet(f));
-
-      // var result = Reflect.getProperty(o, f);
-      // To save a bit of performance, we only query for the existence of the property
-      // if the value is reported as null, AND only in debug builds.
-
-      // #if debug
-      // if (!Reflect.hasField(o, f))
-      // {
-      // 	  var propertyList = Type.getInstanceFields(Type.getClass(o));
-      // 	  if (propertyList.indexOf(f) == -1)
-      // 	  {
-      // 	  	error(EInvalidScriptedVarGet(f));
-      // 	  }
-      // }
-      // #end
-      // return result;
     }
     #if (hl && haxe4)
     else if (Std.isOfType(o, Enum))
@@ -2442,9 +2426,6 @@ class Interp
       }
 
       error(EInvalidScriptedVarSet(f));
-
-      // Reflect.setProperty(o, f, v);
-      // return v;
     }
 
     try

--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -251,6 +251,8 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
 
   static function retrieveClassObjectFields(o:Dynamic):Array<String>
   {
+    if (Util.getTypeNameOf(o) == "Object") return [];
+
     final superClassCls = Type.getClass(o);
     if (superClassCls == null) throw "Provided object isn't a class";
 
@@ -266,14 +268,30 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
 
   static function getClassObjectField(o:Dynamic, field:String):Null<Dynamic>
   {
+    if (Util.getTypeNameOf(o) == "Object") return Reflect.getProperty(o, field);
+
     var fields = retrieveClassObjectFields(o);
     if (fields.contains(field) || fields.contains('get_$field')) return Reflect.getProperty(o, field);
 
     throw 'No such field $field';
   }
 
-  static function setClassObjectField(o:Dynamic, field:String, value:Dynamic):Bool
+  /**
+   * Assign a field of a class object.
+   * Checks for `final` and `private` variables and fails to assign to immutable fields.
+   *
+   * @param o The object to modify.
+   * @param field The name of the field to modify.
+   * @param value The value to assign to the field.
+   * @return `true` for success.
+   */
+  public static function setClassObjectField(o:Dynamic, field:String, value:Dynamic):Bool
   {
+    if (Util.getTypeNameOf(o) == "Object") {
+      Reflect.setProperty(o, field, value);
+      return true;
+    }
+
     var finals = PolymodFinalMacro.getFinalsOf(o);
     if (finals.contains(field))
     {
@@ -289,7 +307,6 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
     var fields = retrieveClassObjectFields(o);
     if (fields.contains(field) || fields.contains('set_$field'))
     {
-      trace('Setting ${Util.getTypeNameOf(o)}.${field} = ${value}');
       Reflect.setProperty(o, field, value);
       return true;
     }
@@ -299,6 +316,8 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
 
   static function hasClassObjectField(o:Dynamic, field:String):Bool
   {
+    if (Util.getTypeNameOf(o) == "Object") return Reflect.hasField(o, field);
+
     var fields = retrieveClassObjectFields(o);
     if (fields.contains(field) || fields.contains('get_$field') || fields.contains('set_$field')) return true;
 

--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -1,6 +1,9 @@
 package polymod.hscript._internal;
 
 import haxe.ds.ObjectMap;
+import polymod.util.Util;
+
+using StringTools;
 
 @:forward
 @:access(polymod.hscript._internal.PolymodScriptClass)
@@ -78,7 +81,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
         }
         else if (this.superClass == null)
         {
-          @:privateAccess this._interp.error(EInvalidAccess(name));
+          return this._interp.error(EInvalidAccess(name));
         }
         else if (Type.getClass(this.superClass) == null)
         {
@@ -89,7 +92,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
           }
           else
           {
-            @:privateAccess this._interp.error(EInvalidAccess(name));
+            return this._interp.error(EInvalidAccess(name));
           }
         }
         else if (Std.isOfType(this.superClass, PolymodScriptClass))
@@ -111,7 +114,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
           }
           catch (e:String)
           {
-            @:privateAccess this._interp.error(EInvalidAccess(name));
+            return this._interp.error(EInvalidAccess(name));
           }
         }
     }
@@ -173,7 +176,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
       var decl = this.findVar(name, true);
       if (decl.isfinal && decl.expr != null) // The variable already exists and has a set value.
       {
-        @:privateAccess this._interp.error(EInvalidFinalSet(name));
+        return this._interp.error(EInvalidFinalSet(name));
       }
 
       @:privateAccess
@@ -217,22 +220,32 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
     else
     {
       // Class object
-      if (setClassObjectField(this.superClass, name, value))
-      {
-        return value;
+      try {
+        if (setClassObjectField(this.superClass, name, value))
+        {
+          return value;
+        }
+      } catch (e:String) {
+        if (e.contains('final')) {
+          return this._interp.error(EInvalidFinalSet(name));
+        } else if (e.contains('private')) {
+          return this._interp.error(EInvalidPropSet(name));
+        } else {
+          return this._interp.error(EInvalidAccess(name));
+        }
       }
-
-      @:privateAccess this._interp.error(EInvalidAccess(name));
     }
 
     if (this.superClass == null)
     {
-      @:privateAccess this._interp.error(EInvalidAccess(name));
+      return this._interp.error(EInvalidAccess(name));
     }
     else
     {
-      @:privateAccess this._interp.error(EInvalidAccess(name));
+      return this._interp.error(EInvalidAccess(name));
     }
+
+    trace('fieldWrite() fallthrough???');
     return null;
   }
 
@@ -251,7 +264,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
     return fields;
   }
 
-  private static function getClassObjectField(o:Dynamic, field:String):Null<Dynamic>
+  static function getClassObjectField(o:Dynamic, field:String):Null<Dynamic>
   {
     var fields = retrieveClassObjectFields(o);
     if (fields.contains(field) || fields.contains('get_$field')) return Reflect.getProperty(o, field);
@@ -259,18 +272,32 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
     throw 'No such field $field';
   }
 
-  private static function setClassObjectField(o:Dynamic, field:String, value:Dynamic):Bool
+  static function setClassObjectField(o:Dynamic, field:String, value:Dynamic):Bool
   {
+    var finals = PolymodFinalMacro.getFinalsOf(o);
+    if (finals.contains(field))
+    {
+      throw 'Cannot set final field $field';
+    }
+
+    var privates = PolymodFinalMacro.getPrivatePropertiesOf(o);
+    if (privates.contains(field))
+    {
+      throw 'Cannot set private field $field';
+    }
+
     var fields = retrieveClassObjectFields(o);
     if (fields.contains(field) || fields.contains('set_$field'))
     {
+      trace('Setting ${Util.getTypeNameOf(o)}.${field} = ${value}');
       Reflect.setProperty(o, field, value);
       return true;
     }
-    return false;
+
+    throw 'No such field $field';
   }
 
-  private static function hasClassObjectField(o:Dynamic, field:String):Bool
+  static function hasClassObjectField(o:Dynamic, field:String):Bool
   {
     var fields = retrieveClassObjectFields(o);
     if (fields.contains(field) || fields.contains('get_$field') || fields.contains('set_$field')) return true;

--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -78,8 +78,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
         }
         else if (this.superClass == null)
         {
-          // @:privateAccess this._interp.error(EInvalidAccess(name));
-          throw 'field "$name" does not exist in script class ${this.fullyQualifiedName}"';
+          @:privateAccess this._interp.error(EInvalidAccess(name));
         }
         else if (Type.getClass(this.superClass) == null)
         {
@@ -90,8 +89,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
           }
           else
           {
-            // @:privateAccess this._interp.error(EInvalidAccess(name));
-            throw 'field "$name" does not exist in script class ${this.fullyQualifiedName}" or super class "${Type.getClassName(Type.getClass(this.superClass))}"';
+            @:privateAccess this._interp.error(EInvalidAccess(name));
           }
         }
         else if (Std.isOfType(this.superClass, PolymodScriptClass))
@@ -114,7 +112,6 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
           catch (e:String)
           {
             @:privateAccess this._interp.error(EInvalidAccess(name));
-            // throw "field '" + name + "' does not exist in script class '" + this.fullyQualifiedName + "' or super class '" + Type.getClassName(Type.getClass(this.superClass)) + "'";
           }
         }
     }
@@ -171,83 +168,75 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
 
   @:op(a.b) public function fieldWrite(name:String, value:Dynamic):Dynamic
   {
-    switch (name)
+    if (this.findVar(name) != null)
     {
-      case _:
-        if (this.findVar(name) != null)
-        {
-          var decl = this.findVar(name, true);
-          if (decl.isfinal && decl.expr != null) // The variable already exists and has a set value.
+      var decl = this.findVar(name, true);
+      if (decl.isfinal && decl.expr != null) // The variable already exists and has a set value.
+      {
+        @:privateAccess this._interp.error(EInvalidFinalSet(name));
+      }
+
+      @:privateAccess
+      switch (decl.set)
+      {
+        case "set":
+          final setName = 'set_$name';
+          if (!this._interp._propTrack.exists(setName))
           {
-            throw "Invalid access to field " + name;
-            return null;
+            this._interp._propTrack.set(setName, true);
+            var r:Dynamic = null;
+            // Children may override it
+            if (this.topASC != null && this.topASC.findFunction(setName) != null)
+            {
+              r = this.topASC.callFunction(setName, [value]);
+            }
+            else
+            {
+              r = this.callFunction(setName, [value]);
+            }
+            this._interp._propTrack.remove(setName);
+            return r;
           }
 
-          @:privateAccess
-          switch (decl.set)
-          {
-            case "set":
-              final setName = 'set_$name';
-              if (!this._interp._propTrack.exists(setName))
-              {
-                this._interp._propTrack.set(setName, true);
-                var r:Dynamic = null;
-                // Children may override it
-                if (this.topASC != null && this.topASC.findFunction(setName) != null)
-                {
-                  r = this.topASC.callFunction(setName, [value]);
-                }
-                else
-                {
-                  r = this.callFunction(setName, [value]);
-                }
-                this._interp._propTrack.remove(setName);
-                return r;
-              }
+        case "never" | "null":
+          return this._interp.error(EInvalidPropSet(name));
+      }
 
-            case "never" | "null":
-              return this._interp.error(EInvalidPropSet(name));
-          }
+      this._interp.variables.set(name, value);
+      return value;
+    }
+    else if (this.superClass != null && Std.isOfType(this.superClass, PolymodScriptClass))
+    {
+      var superScriptClass:PolymodAbstractScriptClass = cast(this.superClass, PolymodScriptClass);
+      try
+      {
+        return superScriptClass.fieldWrite(name, value);
+      }
+      catch (e:Dynamic) {}
+    }
+    else
+    {
+      // Class object
+      if (setClassObjectField(this.superClass, name, value))
+      {
+        return value;
+      }
 
-          this._interp.variables.set(name, value);
-          return value;
-        }
-        else if (this.superClass != null && Std.isOfType(this.superClass, PolymodScriptClass))
-        {
-          var superScriptClass:PolymodAbstractScriptClass = cast(this.superClass, PolymodScriptClass);
-          try
-          {
-            return superScriptClass.fieldWrite(name, value);
-          }
-          catch (e:Dynamic) {}
-        }
-        else
-        {
-          // Class object
-          if (setClassObjectField(this.superClass, name, value))
-          {
-            return value;
-          }
-
-          @:privateAccess this._interp.error(EInvalidAccess(name));
-          // throw "field '" + name + "' does not exist in script class '" + this.fullyQualifiedName + "' or super class '" + Type.getClassName(Type.getClass(this.superClass)) + "'";
-        }
+      @:privateAccess this._interp.error(EInvalidAccess(name));
     }
 
     if (this.superClass == null)
     {
       @:privateAccess this._interp.error(EInvalidAccess(name));
-      // throw "field '" + name + "' does not exist in script class '" + this.fullyQualifiedName + "'";
     }
     else
     {
       @:privateAccess this._interp.error(EInvalidAccess(name));
-      // throw "field '" + name + "' does not exist in script class '" + this.fullyQualifiedName + "' or super class '" + Type.getClassName(Type.getClass(this.superClass)) + "'";
     }
     return null;
   }
 
-  private static function retrieveClassObjectFields(o:Dynamic):Array<String>
+  static function retrieveClassObjectFields(o:Dynamic):Array<String>
   {
     final superClassCls = Type.getClass(o);
     if (superClassCls == null) throw "Provided object isn't a class";

--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -253,14 +253,31 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
   {
     if (Util.getTypeNameOf(o) == "Object") return [];
 
-    final superClassCls = Type.getClass(o);
-    if (superClassCls == null) throw "Provided object isn't a class";
+    if (Std.isOfType(o, Class)) return [];
 
-    var fields = fieldsCache.get(superClassCls);
+    final objectCls = Type.getClass(o);
+    if (objectCls == null) throw "Provided object isn't a class";
+
+    var fields = fieldsCache.get(objectCls);
     if (fields == null)
     {
-      fields = Type.getInstanceFields(superClassCls);
-      fieldsCache.set(superClassCls, fields);
+      fields = Type.getInstanceFields(objectCls);
+      fieldsCache.set(objectCls, fields);
+    }
+
+    return fields;
+  }
+
+  static function retrieveClassFields(o:Class<Dynamic>):Array<String>
+  {
+    final className = Type.getClassName(o);
+    if (className == null) throw "Provided object isn't a class";
+
+    var fields = fieldsCache.get('Class<$className>');
+    if (fields == null)
+    {
+      fields = Type.getClassFields(o);
+      fieldsCache.set(className, fields);
     }
 
     return fields;
@@ -304,11 +321,22 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
       throw 'Cannot set private field $field';
     }
 
-    var fields = retrieveClassObjectFields(o);
-    if (fields.contains(field) || fields.contains('set_$field'))
-    {
-      Reflect.setProperty(o, field, value);
-      return true;
+    if (Std.isOfType(o, Class)) {
+      // Set class fields.
+      var fields = retrieveClassFields(o);
+      if (fields.contains(field) || fields.contains('set_$field'))
+      {
+        Reflect.setProperty(o, field, value);
+        return true;
+      }
+    } else {
+      // Set instance fields.
+      var fields = retrieveClassObjectFields(o);
+      if (fields.contains(field) || fields.contains('set_$field'))
+      {
+        Reflect.setProperty(o, field, value);
+        return true;
+      }
     }
 
     throw 'No such field $field';

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -1,20 +1,44 @@
 package polymod.hscript._internal;
 
+import polymod.util.Util;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
 import haxe.rtti.Meta;
 
+@:nullSafety
 class PolymodFinalMacro
 {
-  private static var _allFinals:Map<String, Array<String>> = null;
+  public static inline function getFinals(fullPath:String):Array<String> {
+    return getAllFinals().get(fullPath) ?? [];
+  }
+
+  public static inline function getFinalsOf(obj:Dynamic):Array<String> {
+    return getFinals(Util.getTypeNameOf(obj));
+  }
+
+  public static inline function getPrivateProperties(fullPath:String):Array<String> {
+    return getAllPrivateProperties().get(fullPath) ?? [];
+  }
+
+  public static inline function getPrivatePropertiesOf(obj:Dynamic):Array<String> {
+    return getFinals(Util.getTypeNameOf(obj));
+  }
+
+  private static var _allFinals:Null<Map<String, Array<String>>> = null;
 
   public static function getAllFinals():Map<String, Array<String>>
   {
-    if (_allFinals == null)
-      _allFinals = PolymodFinalMacro.fetchAllFinals();
+    if (_allFinals == null) _allFinals = PolymodFinalMacro.fetchAllFinals();
     return _allFinals;
-    return [];
+  }
+
+  private static var _allPrivates:Null<Map<String, Array<String>>> = null;
+
+  public static function getAllPrivateProperties():Map<String, Array<String>>
+  {
+    if (_allPrivates == null) _allPrivates = PolymodFinalMacro.fetchAllPrivateProperties();
+    return _allPrivates;
   }
 
   public static macro function locateAllFinals():Void
@@ -23,6 +47,7 @@ class PolymodFinalMacro
       if (calledBefore) return;
 
       var allFinals:Array<Expr> = [];
+      var allPrivates:Array<Expr> = [];
 
       for (type in types)
       {
@@ -34,17 +59,36 @@ class PolymodFinalMacro
             if (classType.isInterface) continue;
 
             var finals:Array<String> = [];
+            var privates:Array<String> = [];
             for (field in classType.statics.get())
             {
-              if (!field.isFinal) continue;
-              finals.push(field.name);
+              // Add final variables.
+              if (field.isFinal) finals.push(field.name);
+
+              // Add properties with `never`/`null` accessors.
+              switch (field.kind) {
+                case FVar(read, write):
+                  switch (write) {
+                    case AccNever:
+                      finals.push(field.name);
+                    case AccNo:
+                      privates.push(field.name);
+                    default: // Do nothing
+                  }
+                default: // Do nothing
+              }
             }
 
-            if (finals.length == 0) continue;
+            if (finals.length > 0) {
+              var entryData = [macro $v{classPath}, macro $v{finals}];
+              allFinals.push(macro $a{entryData});
+            }
 
-            var entryData = [macro $v{classPath}, macro $v{finals}];
+            if (privates.length > 0) {
+              var entryData = [macro $v{classPath}, macro $v{privates}];
+              allPrivates.push(macro $a{entryData});
+            }
 
-            allFinals.push(macro $a{entryData});
           default:
             continue;
         }
@@ -57,7 +101,9 @@ class PolymodFinalMacro
         case TInst(t, _):
           var finalMacroClassType:ClassType = t.get();
           finalMacroClassType.meta.remove('finals');
+          finalMacroClassType.meta.remove('privates');
           finalMacroClassType.meta.add('finals', allFinals, Context.currentPos());
+          finalMacroClassType.meta.add('privates', allPrivates, Context.currentPos());
         default:
           throw 'Could not find PolymodFinalMacro type';
       }
@@ -93,6 +139,32 @@ class PolymodFinalMacro
     else
     {
       throw 'No finals found in PolymodFinalMacro';
+    }
+  }
+
+  public static function fetchAllPrivateProperties():Map<String, Array<String>>
+  {
+    var metaData = Meta.getType(PolymodFinalMacro);
+
+    if (metaData.privates != null)
+    {
+      var result:Map<String, Array<String>> = [];
+
+      for (element in metaData.privates)
+      {
+        if (element.length != 2) throw 'Malformed element in privates: ' + element;
+
+        var classPath:String = element[0];
+        var privates:Array<String> = element[1];
+
+        result.set(classPath, privates);
+      }
+
+      return result;
+    }
+    else
+    {
+      throw 'No private properties found in PolymodFinalMacro';
     }
   }
 }

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -1,14 +1,18 @@
 package polymod.hscript._internal;
 
-import polymod.util.Util;
+#if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
+#else
+import polymod.util.Util;
+#end
 import haxe.rtti.Meta;
 
 @:nullSafety
 class PolymodFinalMacro
 {
+  #if !macro
   public static inline function getFinals(fullPath:String):Array<String> {
     return getAllFinals().get(fullPath) ?? [];
   }
@@ -40,6 +44,7 @@ class PolymodFinalMacro
     if (_allPrivates == null) _allPrivates = PolymodFinalMacro.fetchAllPrivateProperties();
     return _allPrivates;
   }
+  #end
 
   public static macro function locateAllFinals():Void
   {

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -11,9 +11,9 @@ class PolymodFinalMacro
 
   public static function getAllFinals():Map<String, Array<String>>
   {
-    // if (_allFinals == null)
-    //   _allFinals = PolymodFinalMacro.fetchAllFinals();
-    // return _allFinals;
+    if (_allFinals == null)
+      _allFinals = PolymodFinalMacro.fetchAllFinals();
+    return _allFinals;
     return [];
   }
 

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -5,20 +5,28 @@ import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
 #else
-import polymod.util.Util;
 #end
+import polymod.util.Util;
 import haxe.rtti.Meta;
 
 @:nullSafety
 class PolymodFinalMacro
 {
-  #if !macro
+  /**
+   * The name for the Haxe resource that stores Generation Metadata.
+   */
+  static inline final METADATA_RESOURCE_NAME:String = 'PolymodFinalMacro_METADATA';
+
   public static inline function getFinals(fullPath:String):Array<String> {
     return getAllFinals().get(fullPath) ?? [];
   }
 
   public static inline function getFinalsOf(obj:Dynamic):Array<String> {
-    return getFinals(Util.getTypeNameOf(obj));
+    while (Std.isOfType(obj, PolymodScriptClass)) obj = obj.superClass;
+
+    var typeName:String = Util.getTypeNameOf(obj);
+    var result = getFinals(typeName);
+    return result;
   }
 
   public static inline function getPrivateProperties(fullPath:String):Array<String> {
@@ -26,7 +34,11 @@ class PolymodFinalMacro
   }
 
   public static inline function getPrivatePropertiesOf(obj:Dynamic):Array<String> {
-    return getFinals(Util.getTypeNameOf(obj));
+    while (Std.isOfType(obj, PolymodScriptClass)) obj = obj.superClass;
+
+    var typeName:String = Util.getTypeNameOf(obj);
+    var result = getPrivateProperties(typeName);
+    return result;
   }
 
   private static var _allFinals:Null<Map<String, Array<String>>> = null;
@@ -44,15 +56,16 @@ class PolymodFinalMacro
     if (_allPrivates == null) _allPrivates = PolymodFinalMacro.fetchAllPrivateProperties();
     return _allPrivates;
   }
-  #end
 
   public static macro function locateAllFinals():Void
   {
     Context.onAfterTyping((types) -> {
       if (calledBefore) return;
 
-      var allFinals:Array<Expr> = [];
-      var allPrivates:Array<Expr> = [];
+      var startTime:Float = Sys.time();
+
+      var allFinals:Array<Dynamic> = [];
+      var allPrivates:Array<Dynamic> = [];
 
       for (type in types)
       {
@@ -63,35 +76,16 @@ class PolymodFinalMacro
             var classPath:String = t.toString();
             if (classType.isInterface) continue;
 
-            var finals:Array<String> = [];
-            var privates:Array<String> = [];
-            for (field in classType.statics.get())
-            {
-              // Add final variables.
-              if (field.isFinal) finals.push(field.name);
-
-              // Add properties with `never`/`null` accessors.
-              switch (field.kind) {
-                case FVar(read, write):
-                  switch (write) {
-                    case AccNever:
-                      finals.push(field.name);
-                    case AccNo:
-                      privates.push(field.name);
-                    default: // Do nothing
-                  }
-                default: // Do nothing
-              }
-            }
-
+            var finals:Array<String> = listFinalsOfClassType(classType);
             if (finals.length > 0) {
-              var entryData = [macro $v{classPath}, macro $v{finals}];
-              allFinals.push(macro $a{entryData});
+              var entryData:Array<Dynamic> = [classPath, finals];
+              allFinals.push(entryData);
             }
 
+            var privates:Array<String> = listPrivatesOfClassType(classType);
             if (privates.length > 0) {
-              var entryData = [macro $v{classPath}, macro $v{privates}];
-              allPrivates.push(macro $a{entryData});
+              var entryData:Array<Dynamic> = [classPath, privates];
+              allPrivates.push(entryData);
             }
 
           default:
@@ -99,37 +93,117 @@ class PolymodFinalMacro
         }
       }
 
-      var finalMacroType:Type = Context.getType('polymod.hscript._internal.PolymodFinalMacro');
+      var metadataHXSF = haxe.Serializer.run({
+        finals: allFinals,
+        privates: allPrivates
+      });
+      Context.addResource(METADATA_RESOURCE_NAME, haxe.io.Bytes.ofString(metadataHXSF));
 
-      switch (finalMacroType)
-      {
-        case TInst(t, _):
-          var finalMacroClassType:ClassType = t.get();
-          finalMacroClassType.meta.remove('finals');
-          finalMacroClassType.meta.remove('privates');
-          finalMacroClassType.meta.add('finals', allFinals, Context.currentPos());
-          finalMacroClassType.meta.add('privates', allPrivates, Context.currentPos());
-        default:
-          throw 'Could not find PolymodFinalMacro type';
-      }
+      var endTime:Float = Sys.time();
+
+      var duration:Float = endTime - startTime;
+
+      Context.info('PolymodFinalMacro: '
+        + 'Detected ${allFinals.length} classes with final variables, '
+        + '${allPrivates.length} classes with (default,null) properties '
+        + 'in ${duration} sec.',
+        Context.currentPos());
 
       calledBefore = true;
     });
   }
 
   #if macro
+  static function listFinalsOfClassType(classType:Null<ClassType>):Array<String> {
+    if (classType == null) return [];
+
+    var result:Array<String> = [];
+
+    for (field in classType.fields.get())
+    {
+      // Add final variables.
+      if (field.isFinal) result.push(field.name);
+
+      // Add properties with `never` accessors.
+      switch (field.kind) {
+        case FVar(read, write):
+          switch (write) {
+            case AccNever:
+              result.push(field.name);
+            default: // Do nothing
+          }
+        default: // Do nothing
+      }
+    }
+
+    for (field in classType.statics.get())
+    {
+      // Add final variables.
+      if (field.isFinal) result.push(field.name);
+
+      // Add properties with `never` accessors.
+      switch (field.kind) {
+        case FVar(read, write):
+          switch (write) {
+            case AccNever:
+              result.push(field.name);
+            default: // Do nothing
+          }
+        default: // Do nothing
+      }
+    }
+
+    return result.concat(listFinalsOfClassType(classType?.superClass?.t?.get()));
+  }
+
+  static function listPrivatesOfClassType(classType:Null<ClassType>):Array<String> {
+    if (classType == null) return [];
+
+    var result:Array<String> = [];
+
+    for (field in classType.fields.get()) {
+      // Add properties with `null` accessors.
+      switch (field.kind) {
+        case FVar(read, write):
+          switch (write) {
+            case AccNo:
+              result.push(field.name);
+            default: // Do nothing
+          }
+        default: // Do nothing
+      }
+    }
+
+    for (field in classType.statics.get())
+    {
+      // Add properties with `null` accessors.
+      switch (field.kind) {
+        case FVar(read, write):
+          switch (write) {
+            case AccNo:
+              result.push(field.name);
+            default: // Do nothing
+          }
+        default: // Do nothing
+      }
+    }
+
+    return result.concat(listPrivatesOfClassType(classType?.superClass?.t?.get()));
+  }
+
   static var calledBefore:Bool = false;
   #end
 
   public static function fetchAllFinals():Map<String, Array<String>>
   {
-    var metaData = Meta.getType(PolymodFinalMacro);
+    var metaData = fetchMetadata();
+    var finals:Array<Dynamic> = cast metaData.finals;
 
-    if (metaData.finals != null)
+    if (finals != null)
     {
       var result:Map<String, Array<String>> = [];
 
-      for (element in metaData.finals)
+      for (element in finals)
       {
         if (element.length != 2) throw 'Malformed element in finals: ' + element;
 
@@ -149,13 +223,14 @@ class PolymodFinalMacro
 
   public static function fetchAllPrivateProperties():Map<String, Array<String>>
   {
-    var metaData = Meta.getType(PolymodFinalMacro);
+    var metaData = fetchMetadata();
+    var privates:Array<Dynamic> = cast metaData.privates;
 
-    if (metaData.privates != null)
+    if (privates != null)
     {
       var result:Map<String, Array<String>> = [];
 
-      for (element in metaData.privates)
+      for (element in privates)
       {
         if (element.length != 2) throw 'Malformed element in privates: ' + element;
 
@@ -171,5 +246,15 @@ class PolymodFinalMacro
     {
       throw 'No private properties found in PolymodFinalMacro';
     }
+  }
+
+  static var _metadata:Dynamic = null;
+  static function fetchMetadata():Dynamic
+  {
+    if (_metadata != null) return _metadata;
+
+    var metaDataHXSF:String = haxe.Resource.getString(METADATA_RESOURCE_NAME);
+    _metadata = haxe.Unserializer.run(metaDataHXSF);
+    return _metadata;
   }
 }

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -150,35 +150,33 @@ class PolymodScriptClass
    */
   static function registerScriptClassByPath(path:String):Void
   {
-    @:privateAccess {
-      var scriptBody = Polymod.assetLibrary.getText(path);
-      if (scriptBody == null)
+    var scriptBody = Polymod.assetLibrary.getText(path);
+    if (scriptBody == null)
+    {
+      Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve script contents!', SCRIPT_RUNTIME);
+      return;
+    }
+    try
+    {
+      registerScriptClassByString(scriptBody, path);
+    }
+    catch (err:Expr.Error)
+    {
+      var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
+      #if hscriptPos
+      switch (err.e)
+      #else
+      switch (err)
+      #end
       {
-        Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve script contents!', SCRIPT_RUNTIME);
-        return;
-      }
-      try
-      {
-        registerScriptClassByString(scriptBody, path);
-      }
-      catch (err:Expr.Error)
-      {
-        var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
-        #if hscriptPos
-        switch (err.e)
-        #else
-        switch (err)
-        #end
-        {
-          case EUnexpected(s):
-            Polymod.error(SCRIPT_PARSE_FAILED,
-              'Error while parsing function ${path}#${errLine}: EUnexpected' + '\n' + 'Unexpected token "${s}", is there invalid syntax on this line?', SCRIPT_RUNTIME);
-          case EClassUnresolvedSuperclass(cls, reason):
-            Polymod.error(SCRIPT_PARSE_FAILED,
-              'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}', SCRIPT_RUNTIME);
-          default:
-            Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
-        }
+        case EUnexpected(s):
+          Polymod.error(SCRIPT_PARSE_FAILED,
+            'Error while parsing function ${path}#${errLine}: EUnexpected' + '\n' + 'Unexpected token "${s}", is there invalid syntax on this line?', SCRIPT_RUNTIME);
+        case EClassUnresolvedSuperclass(cls, reason):
+          Polymod.error(SCRIPT_PARSE_FAILED,
+            'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}', SCRIPT_RUNTIME);
+        default:
+          Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
       }
     }
   }
@@ -454,7 +452,7 @@ class PolymodScriptClass
       callFunction("new", args);
       if (superClass == null && _c.extend != null)
       {
-        @:privateAccess _interp.error(EClassSuperNotCalled);
+        _interp.error(EClassSuperNotCalled);
       }
     }
     else if (_c.extend != null)
@@ -533,7 +531,7 @@ class PolymodScriptClass
 
         if (clsToCreate == null)
         {
-          @:privateAccess _interp.error(EClassUnresolvedSuperclass(fullExtendString, 'WHY?'));
+          _interp.error(EClassUnresolvedSuperclass(fullExtendString, 'WHY?'));
         }
       }
       else if (_c.imports.exists(extendString))
@@ -542,12 +540,12 @@ class PolymodScriptClass
 
         if (clsToCreate == null)
         {
-          @:privateAccess _interp.error(EClassUnresolvedSuperclass(extendString, 'target class blacklisted'));
+          _interp.error(EClassUnresolvedSuperclass(extendString, 'target class blacklisted'));
         }
       }
       else
       {
-        @:privateAccess _interp.error(EClassUnresolvedSuperclass(extendString, 'missing import'));
+        _interp.error(EClassUnresolvedSuperclass(extendString, 'missing import'));
       }
 
       superClass = Type.createInstance(clsToCreate, args);

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -114,7 +114,6 @@ class PolymodScriptClassMacro
           }
 
         case TType(t, _params):
-          var typedefType:DefType = t.get();
           var typedefPath:String = t.toString();
           var typedefTarget:Type = Context.followWithAbstracts(type);
 
@@ -240,7 +239,6 @@ class PolymodScriptClassMacro
           }
           else
           {
-            var abstractImplPath = abstractType.impl.toString();
             var abstractImplType = abstractType.impl.get();
             var abstractImplStatics:Array<ClassField> = abstractImplType.statics.get();
 

--- a/polymod/hscript/_internal/PolymodStaticAbstractReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticAbstractReference.hx
@@ -105,6 +105,16 @@ class PolymodStaticAbstractReference
   {
     if (this.absImpl != null)
     {
+      var finals = PolymodFinalMacro.getFinalsOf(this.absImpl);
+      if (finals.contains(fieldName)) {
+        throw 'Could not assign abstract static final field ${fieldName}';
+      }
+
+      var privates = PolymodFinalMacro.getPrivatePropertiesOf(this.absImpl);
+      if (privates.contains(fieldName)) {
+        throw 'Could not assign abstract static property ${fieldName}';
+      }
+
       if (Reflect.hasField(this.absImpl, fieldName))
       {
         Reflect.setProperty(this.absImpl, fieldName, fieldValue);

--- a/polymod/hscript/_internal/PolymodStaticAbstractReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticAbstractReference.hx
@@ -105,19 +105,9 @@ class PolymodStaticAbstractReference
   {
     if (this.absImpl != null)
     {
-      var finals = PolymodFinalMacro.getFinalsOf(this.absImpl);
-      if (finals.contains(fieldName)) {
-        throw 'Could not assign abstract static final field ${fieldName}';
-      }
-
-      var privates = PolymodFinalMacro.getPrivatePropertiesOf(this.absImpl);
-      if (privates.contains(fieldName)) {
-        throw 'Could not assign abstract static property ${fieldName}';
-      }
-
       if (Reflect.hasField(this.absImpl, fieldName))
       {
-        Reflect.setProperty(this.absImpl, fieldName, fieldValue);
+        PolymodAbstractScriptClass.setClassObjectField(this.absImpl, fieldName, fieldValue);
         return fieldValue;
       }
       var setterName:String = 'set_$fieldName';

--- a/polymod/util/MacroUtil.hx
+++ b/polymod/util/MacroUtil.hx
@@ -39,6 +39,10 @@ class MacroUtil
     }
   }
 
+	public static function nullable(complexType : ComplexType):ComplexType {
+    return macro: Null<$complexType>;
+  }
+
   public static function areClassesEqual(class1:ClassType, class2:ClassType):Bool
   {
     return class1.pack.join('.') == class2.pack.join('.') && class1.name == class2.name;

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -694,6 +694,32 @@ class Util
     return indexOfInsens(arr, x, ignoreConfig) != -1;
   }
 
+  public static function fetchCallStack(exception:Bool = true):String {
+    var errorMessage:String = "";
+    var callStack:Array<haxe.CallStack.StackItem> = haxe.CallStack.exceptionStack(true);
+
+    for (stackItem in callStack)
+    {
+      switch (stackItem)
+      {
+        case FilePos(innerStackItem, file, line, column):
+          errorMessage += ' in ${file}#${line}';
+          if (column != null) errorMessage += ':${column}';
+        case CFunction:
+          errorMessage += '[Function] ';
+        case Module(m):
+          errorMessage += '[Module(${m})] ';
+        case Method(classname, method):
+          errorMessage += '[Function(${classname}.${method})] ';
+        case LocalFunction(v):
+          errorMessage += '[LocalFunction(${v})] ';
+      }
+      errorMessage += '\n';
+    }
+
+    return errorMessage;
+  }
+
   public static function getTypeNameOf(obj:Dynamic):String
   {
     var type = Type.typeof(obj);


### PR DESCRIPTION
- Improve error messages for invalid access to `final` variables in scripts.
- Improve handling of properties with `null` or `never` setters (Haxe never allows assignment to `never`, and only allows local assignment to `null`).
- Re-enable the code to prevent assignment to `final` constants from Haxe code. This prevents issues like being able to re-assign values despite them being defined as immutable constants.