### PR TITLE
chore: optimize imports, remove unused fields and correct the function return types

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -258,8 +258,6 @@ class Polymod
     params.modIds ??= [];
     params.dirs ??= [];
 
-    var shouldLoadMods:Bool = params.modIds.length == 0 && params.dirs.length == 0;
-
     if (params.fileSystemParams == null) params.fileSystemParams = {modRoot: modRoot};
     if (params.fileSystemParams.modRoot == null) params.fileSystemParams.modRoot = modRoot;
     if (params.apiVersionRule == null) params.apiVersionRule = VersionUtil.DEFAULT_VERSION_RULE;
@@ -402,7 +400,7 @@ class Polymod
    * Retrieve the IFileSystem instance currently in use by Polymod.
    * This may be useful if you're using a MemoryFileSystem or a custom file system that you want to call functions on.
    */
-  public static function getFileSystem():IFileSystem
+  public static function getFileSystem():Null<IFileSystem>
   {
     if (assetLibrary == null)
     {

--- a/polymod/backends/FlixelBackend.hx
+++ b/polymod/backends/FlixelBackend.hx
@@ -1,6 +1,5 @@
 package polymod.backends;
 
-import polymod.backends.PolymodAssets.PolymodAssetType;
 #if flixel
 #if !macro
 import lime.utils.Assets as LimeAssets;

--- a/polymod/backends/HEAPSBackend.hx
+++ b/polymod/backends/HEAPSBackend.hx
@@ -1,10 +1,7 @@
 package polymod.backends;
 
 import haxe.io.Bytes;
-import haxe.xml.Fast;
-import haxe.xml.Printer;
 import polymod.Polymod;
-import polymod.Polymod.PolymodError;
 import polymod.util.Util;
 import polymod.backends.PolymodAssetLibrary;
 import polymod.backends.PolymodAssets.PolymodAssetType;

--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -4,9 +4,7 @@ import lime.system.ThreadPool;
 import polymod.backends.PolymodAssetLibrary;
 import polymod.backends.PolymodAssets.PolymodAssetType;
 import polymod.fs.PolymodFileSystem;
-import polymod.fs.PolymodFileSystem.IFileSystem;
 import polymod.Polymod;
-import polymod.Polymod.FrameworkParams;
 import polymod.util.Util;
 
 using StringTools;

--- a/polymod/backends/OpenFLWithNodeBackend.hx
+++ b/polymod/backends/OpenFLWithNodeBackend.hx
@@ -15,7 +15,7 @@ import polymod.backends.LimeBackend.LimeModLibrary;
 import openfl.events.Event;
 import openfl.events.EventDispatcher;
 #end
-import polymod.Polymod.FrameworkParams;
+import polymod.Polymod;
 
 /**
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -229,7 +229,7 @@ class PolymodAssetLibrary
    * @param	theDir
    * @return
    */
-  public function getTextDirectly(id:String, directory:String = ''):String
+  public function getTextDirectly(id:String, directory:String = ''):Null<String>
   {
     var bytes = null;
     if (checkDirectly(id, directory))
@@ -370,7 +370,7 @@ class PolymodAssetLibrary
     return exists;
   }
 
-  public function getType(id:String):PolymodAssetType
+  public function getType(id:String):Null<PolymodAssetType>
   {
     var exists = _checkExists(id);
     if (exists)
@@ -444,7 +444,7 @@ class PolymodAssetLibrary
    * with the given locale prefix prepended.
    * (will ignore all installed mods)
    */
-  public function fileLocale(id:String):String
+  public function fileLocale(id:String):Null<String>
   {
     #if firetongue
     if (localeAssetPrefix != null)

--- a/polymod/backends/PolymodAssets.hx
+++ b/polymod/backends/PolymodAssets.hx
@@ -1,15 +1,11 @@
 package polymod.backends;
 
 import haxe.io.Bytes;
-import polymod.Polymod.Framework;
-import polymod.Polymod.FrameworkParams;
-import polymod.Polymod.PolymodErrorCode;
+import polymod.Polymod;
 import polymod.backends.IBackend;
 import polymod.backends.PolymodAssetLibrary;
 import polymod.format.ParseRules;
-import polymod.fs.PolymodFileSystem.IFileSystem;
-import polymod.fs.StubFileSystem;
-import polymod.fs.SysFileSystem;
+import polymod.fs.PolymodFileSystem;
 #if firetongue
 import firetongue.FireTongue;
 #end
@@ -19,7 +15,7 @@ typedef PolymodAssetsParams =
   /**
    * the Haxe framework you're using (OpenFL, HEAPS, Kha, NME, etc..)
    */
-  framework:polymod.Framework,
+  ?framework:Framework,
 
   /**
    * the file system to use to access mods.
@@ -79,9 +75,9 @@ typedef PolymodAssetsParams =
 
 class PolymodAssets
 {
-  public static function init(params:PolymodAssetsParams):PolymodAssetLibrary
+  public static function init(params:PolymodAssetsParams):Null<PolymodAssetLibrary>
   {
-    var framework:polymod.Framework = params.framework;
+    var framework:Framework = params.framework;
     if (framework == null)
     {
       framework = autoDetectFramework();
@@ -202,7 +198,7 @@ class PolymodAssets
    * Powered by compile-time macros.
    * @return polymod.Framework
    */
-  private static function autoDetectFramework():polymod.Framework
+  private static function autoDetectFramework():Framework
   {
     #if castle
     return CASTLE;

--- a/polymod/backends/StubBackend.hx
+++ b/polymod/backends/StubBackend.hx
@@ -25,12 +25,12 @@ class StubBackend implements IBackend
     return false;
   }
 
-  public function getBytes(id:String):Bytes
+  public function getBytes(id:String):Null<Bytes>
   {
     return null;
   }
 
-  public function getText(id:String):String
+  public function getText(id:String):Null<String>
   {
     return null;
   }
@@ -47,7 +47,7 @@ class StubBackend implements IBackend
   }
   #end
 
-  public function getPath(id:String):String
+  public function getPath(id:String):Null<String>
   {
     return null;
   }

--- a/polymod/format/BaseParseFormat.hx
+++ b/polymod/format/BaseParseFormat.hx
@@ -1,6 +1,6 @@
 package polymod.format;
 
-import polymod.format.ParseRules.TextFileFormat;
+import polymod.format.ParseRules;
 
 interface BaseParseFormat
 {

--- a/polymod/format/CSV.hx
+++ b/polymod/format/CSV.hx
@@ -159,8 +159,6 @@ class CSV
 
   private function processCells(cells:Array<String>, row:Int = 0):Void
   {
-    var col:Int = 0;
-    var newline:Bool = false;
     var row_array:Array<String> = null;
 
     if (grid == null)

--- a/polymod/format/ParseRules.hx
+++ b/polymod/format/ParseRules.hx
@@ -1,16 +1,9 @@
 package polymod.format;
 
-import haxe.Json;
 import json.JSONData;
 import json.patch.JSONPatch;
 import polymod.Polymod;
-import polymod.Polymod.PolymodError;
-import polymod.Polymod.PolymodErrorType;
 import polymod.util.Util;
-#if unifill
-import unifill.Unifill;
-#end
-import UnicodeString;
 
 class ParseRules
 {
@@ -253,7 +246,6 @@ class CSVParseFormat implements BaseParseFormat
   {
     var buf = new StringBuf();
 
-    var lf = 0x0A;
     var dq = 0x22;
 
     for (i in 0...csv.fields.length)
@@ -358,7 +350,6 @@ class TSVParseFormat implements BaseParseFormat
     var buf = new StringBuf();
 
     var tab = 0x09;
-    var lf = 0x0A;
 
     for (i in 0...tsv.fields.length)
     {
@@ -661,7 +652,6 @@ class PlainTextParseFormat implements BaseParseFormat // <String>
   public function append(baseText:String, appendText:String, id:String):String
   {
     var lastChar = Util.uCharAt(baseText, Util.uLength(baseText) - 1);
-    var lastLastChar = Util.uCharAt(baseText, Util.uLength(baseText) - 1);
     var joiner = '';
 
     var endLine = '\n';

--- a/polymod/format/XMLMerge.hx
+++ b/polymod/format/XMLMerge.hx
@@ -112,7 +112,6 @@ class XMLMerge
               var aValue = a.get(key);
               if (aValue == value)
               {
-                var bValue = b.get(key);
                 mergeXMLWork(a, b);
               }
             }

--- a/polymod/fs/MemoryFileSystem.hx
+++ b/polymod/fs/MemoryFileSystem.hx
@@ -119,7 +119,7 @@ class MemoryFileSystem implements IFileSystem
    * @param path The path name of the file to read.
    * @return The text contents of the file.
    */
-  public function getFileContent(path:String):String
+  public function getFileContent(path:String):Null<String>
   {
     var fileBytes = getFileBytes(path);
     if (fileBytes == null) return null;

--- a/polymod/fs/MemoryZipFileSystem.hx
+++ b/polymod/fs/MemoryZipFileSystem.hx
@@ -8,7 +8,6 @@ import haxe.io.Bytes;
 import haxe.io.BytesInput;
 import haxe.io.Path;
 import haxe.zip.Entry;
-import haxe.zip.InflateImpl;
 
 #if !html5
 class MemoryZipFileSystem extends StubFileSystem

--- a/polymod/fs/NodeFileSystem.hx
+++ b/polymod/fs/NodeFileSystem.hx
@@ -1,12 +1,11 @@
 package polymod.fs;
 
-import polymod.Polymod.PolymodErrorOrigin;
 import haxe.io.Bytes;
 import haxe.io.UInt8Array;
 import js.Browser;
 import js.html.ScriptElement;
 import js.Lib;
-import polymod.Polymod.ModMetadata;
+import polymod.Polymod;
 import polymod.PolymodConfig;
 import polymod.fs.PolymodFileSystem.IFileSystem;
 import polymod.util.Util;

--- a/polymod/fs/PolymodFileSystem.hx
+++ b/polymod/fs/PolymodFileSystem.hx
@@ -1,9 +1,8 @@
 package polymod.fs;
 
-import polymod.Polymod.PolymodErrorOrigin;
+import polymod.Polymod;
 import thx.semver.VersionRule;
 import haxe.io.Bytes;
-import polymod.Polymod.ModMetadata;
 
 /**
  * Provides factory and utility functions for instantiating an IFileSystem.

--- a/polymod/fs/StubFileSystem.hx
+++ b/polymod/fs/StubFileSystem.hx
@@ -1,7 +1,6 @@
 package polymod.fs;
 
-import polymod.Polymod.ModMetadata;
-import polymod.Polymod.PolymodErrorOrigin;
+import polymod.Polymod;
 import polymod.fs.PolymodFileSystem;
 import thx.semver.VersionRule;
 

--- a/polymod/fs/SysFileSystem.hx
+++ b/polymod/fs/SysFileSystem.hx
@@ -1,8 +1,7 @@
 package polymod.fs;
 
 #if sys
-import polymod.Polymod.PolymodErrorOrigin;
-import polymod.Polymod.ModMetadata;
+import polymod.Polymod;
 import polymod.fs.PolymodFileSystem;
 import polymod.util.Util;
 import polymod.util.VersionUtil;

--- a/polymod/fs/SysZipFileSystem.hx
+++ b/polymod/fs/SysZipFileSystem.hx
@@ -1,8 +1,7 @@
 package polymod.fs;
 
-import polymod.Polymod.PolymodErrorOrigin;
 import polymod.util.VersionUtil;
-import polymod.Polymod.ModMetadata;
+import polymod.Polymod;
 import polymod.fs.ZipFileSystem.ZipFileSystemParams;
 #if !sys
 class SysZipFileSystem extends polymod.fs.StubFileSystem
@@ -21,7 +20,6 @@ import haxe.io.Path;
 import polymod.util.Util;
 import polymod.util.InsensitiveMap;
 import polymod.util.zip.ZipParser;
-import sys.io.File;
 import thx.semver.VersionRule;
 
 using StringTools;

--- a/polymod/hscript/HScriptable.hx
+++ b/polymod/hscript/HScriptable.hx
@@ -65,7 +65,7 @@ class HScriptParams
    */
   public var pathName(default, set):String = null;
 
-  function set_pathName(newValue:String):String
+  function set_pathName(newValue:String):Null<String>
   {
     if (pathNameDynId != null) return null;
 
@@ -199,7 +199,7 @@ class ScriptRunner
     scripts.clear();
   }
 
-  public function load(name:String, assetHandler:Dynamic):Script
+  public function load(name:String, assetHandler:Dynamic):Null<Script>
   {
     if (assetHandler == null)
     {
@@ -227,7 +227,7 @@ class ScriptRunner
     return Util.pathJoin('${PolymodConfig.scriptLibrary}:${PolymodConfig.rootPath}', '$pathName${PolymodConfig.scriptExt}');
   }
 
-  public function get(name:String, ?assetHandler:Dynamic = null):Script
+  public function get(name:String, ?assetHandler:Dynamic = null):Null<Script>
   {
     // If the script isn't loaded yet, do that now.
     if (!scripts.exists(name))

--- a/polymod/hscript/_internal/Checker.hx
+++ b/polymod/hscript/_internal/Checker.hx
@@ -108,7 +108,7 @@ class Completion
   }
 }
 
-@:allow(hscript.Checker)
+@:allow(polymod.hscript._internal.Checker)
 class CheckerTypes
 {
   var types:Map<String, CTypedecl> = new Map();
@@ -356,7 +356,7 @@ class CheckerTypes
     return t;
   }
 
-  public function resolve(name:String, ?args:Array<TType>):TType
+  public function resolve(name:String, ?args:Array<TType>):Null<TType>
   {
     if (name == "Null")
     {
@@ -528,7 +528,7 @@ class Checker
     return [for (k in locals.keys()) k => locals.get(k)];
   }
 
-  function makeType(t:CType, e:Expr):TType
+  function makeType(t:CType, e:Expr):Null<TType>
   {
     return switch (t)
     {
@@ -1005,7 +1005,7 @@ class Checker
     }
   }
 
-  public function unasync(t:TType):TType
+  public function unasync(t:TType):Null<TType>
   {
     switch (follow(t))
     {
@@ -1483,7 +1483,6 @@ class Checker
           default:
             if (op.charCodeAt(op.length - 1) == "=".code)
             {
-              var t = typeExpr(mk(EBinop(op.substr(0, op.length - 1), e1, e2), expr), withType);
               return typeExpr(mk(EBinop("=", e1, e2), expr), withType);
             }
             error("Unsupported operation " + op, expr);

--- a/polymod/hscript/_internal/HLWrapperMacro.hx
+++ b/polymod/hscript/_internal/HLWrapperMacro.hx
@@ -33,8 +33,6 @@ class HLStd extends Std
   }
 }
 #else
-import haxe.macro.MacroStringTools;
-import haxe.macro.TypedExprTools;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;

--- a/polymod/hscript/_internal/HScriptRedirectDefines.hx
+++ b/polymod/hscript/_internal/HScriptRedirectDefines.hx
@@ -35,7 +35,7 @@ class HScriptRedirectDefines
    * @param typeName
    * @return TypeDefinition
    */
-  static function generateHScriptRedirect(typeName:String):TypeDefinition
+  static function generateHScriptRedirect(typeName:String):Null<TypeDefinition>
   {
     if (!typeName.startsWith('hscript')) return null;
 

--- a/polymod/hscript/_internal/HScriptableMacro.hx
+++ b/polymod/hscript/_internal/HScriptableMacro.hx
@@ -11,7 +11,7 @@ using haxe.macro.TypeTools;
 
 class HScriptableMacro
 {
-  public static macro function build():Array<Field>
+  public static macro function build():Null<Array<Field>>
   {
     var cls:haxe.macro.Type.ClassType = Context.getLocalClass().get();
     var fields:Array<Field> = Context.getBuildFields();

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -19,7 +19,7 @@ class HScriptedClassMacro
    * The second build step (called in an onAfterTyping callback) creates the rest of the functions,
    *   which require initial typing to be completed before they can be created.
    */
-  public static macro function build():Array<Field>
+  public static macro function build():Null<Array<Field>>
   {
     var cls:ClassType = Context.getLocalClass().get();
 
@@ -48,39 +48,6 @@ class HScriptedClassMacro
 
     // Returning null is equal to "don't do anything".
     return null;
-  }
-
-  /**
-   * Parse `@:hscriptClass`.
-   */
-  static function parseHScriptClassParams(metaEntry:MetadataEntry):HScriptClassParams
-  {
-    var result:HScriptClassParams = {};
-
-    switch (metaEntry.params[0].expr)
-    {
-      case EObjectDecl(paramFields):
-        // paramFields
-        for (paramField in paramFields)
-        {
-          switch (paramField.field)
-          {
-            case 'baseClass':
-              switch (paramField.expr.expr)
-              {
-                case EConst(CIdent(baseClassName)):
-                  result.baseClass = baseClassName;
-                default:
-                  Context.error("Error: @:hscriptClass baseClass must be a string", Context.currentPos());
-              }
-              break;
-          }
-        }
-      default:
-        Context.error("Error: @:hscriptClass({}) must contain an object", Context.currentPos());
-    }
-
-    return result;
   }
 
   /**
@@ -141,7 +108,7 @@ class HScriptedClassMacro
     return fields;
   }
 
-  static function buildScriptedClassInit(cls:ClassType, superCls:ClassType):Field
+  static function buildScriptedClassInit(cls:ClassType, superCls:ClassType):Null<Field>
   {
     // Context.info('  Building scripted class init() function', Context.currentPos());
     var clsTypeName:String = cls.pack.join('.') != '' ? '${cls.pack.join('.')}.${cls.name}' : cls.name;
@@ -996,33 +963,6 @@ class HScriptedClassMacro
           },
         }),
     };
-  }
-
-  /**
-   * Create the type corresponding to an array of the given type.
-   * For example, toComplexTypeArray(String) will return Array<String>.
-   */
-  static function toComplexTypeArray(inputType:ComplexType):ComplexType
-  {
-    var typeParams = (inputType != null) ? [TPType(inputType)] : [
-      TPType(TPath(
-        {
-          pack: [],
-          name: 'Dynamic',
-          sub: null,
-          params: []
-        }))
-    ];
-
-    var result:ComplexType = TPath(
-      {
-        pack: [],
-        name: 'Array',
-        sub: null,
-        params: typeParams,
-      });
-
-    return result;
   }
 
   static function buildEmptyScriptedClassConstructor():Field

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -71,7 +71,7 @@ class Interp
   var curExpr:Expr;
   #end
 
-  function getClassDecl():ClassDecl
+  function getClassDecl():Null<ClassDecl>
   {
     if (_classDeclOverride != null)
     {
@@ -194,7 +194,7 @@ class Interp
    * @param args The arguments to apply to that function.
    * @return The result of the function call.
    */
-  function call(target:Dynamic, fun:Dynamic, args:Array<Dynamic>):Dynamic
+  function call(target:Dynamic, fun:Dynamic, args:Array<Dynamic>):Null<Dynamic>
   {
     // Calling fn() in hscript won't resolve an object first. Thus, we need to change it to use this.fn() instead.
     if (target == null && _nextCallObject != null)
@@ -383,7 +383,7 @@ class Interp
    * @param args The arguments to pass to the function.
    * @return The return value of the function.
    */
-  public function callScriptClassStaticFunction(clsName:String, fnName:String, args:Array<Dynamic> = null):Dynamic
+  public function callScriptClassStaticFunction(clsName:String, fnName:String, args:Array<Dynamic> = null):Null<Dynamic>
   {
     // For functions listScriptClasses and scriptInit, we want to return the needed values without much checking.
     if (fnName == "listScriptClasses")
@@ -736,7 +736,7 @@ class Interp
     return assignValue(e1, expr(e2));
   }
 
-  function assignValue(e1:Expr, v:Dynamic, _abstractInlineAssign:Bool = false):Dynamic
+  function assignValue(e1:Expr, v:Dynamic, _abstractInlineAssign:Bool = false):Null<Dynamic>
   {
     switch (Tools.expr(e1))
     {
@@ -1055,7 +1055,7 @@ class Interp
     }
   }
 
-  public function execute(expr:Expr):Dynamic
+  public function execute(expr:Expr):Null<Dynamic>
   {
     // If this function is being called (and not executeEx),
     // PolymodScriptClass is not being used to call the expression.
@@ -1086,7 +1086,7 @@ class Interp
     return exprReturn(expr);
   }
 
-  function exprReturn(e):Dynamic
+  function exprReturn(e):Null<Dynamic>
   {
     try
     {
@@ -1134,7 +1134,7 @@ class Interp
     }
   }
 
-  public inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Dynamic
+  public inline function error(e:#if hscriptPos ErrorDef #else Error #end, rethrow = false):Null<Dynamic>
   {
     #if hscriptPos var e = new Error(e, curExpr?.pmin ?? 0, curExpr?.pmax ?? 0, curExpr?.origin ?? 'unknown', curExpr?.line ?? 0); #end
     if (rethrow) this.rethrow(e)
@@ -1152,7 +1152,7 @@ class Interp
     #end
   }
 
-  function resolve(id:String):Dynamic
+  function resolve(id:String):Null<Dynamic>
   {
     _nextCallObject = null;
     if (id == "super")
@@ -1352,7 +1352,7 @@ class Interp
     return true;
   }
 
-  public function expr(e:Expr):Dynamic
+  public function expr(e:Expr):Null<Dynamic>
   {
     #if hscriptPos
     curExpr = e;
@@ -2189,7 +2189,7 @@ class Interp
     cast(map, haxe.Constraints.IMap<Dynamic, Dynamic>).set(key, value);
   }
 
-  function makeMap(keys:Array<Dynamic>, values:Array<Dynamic>):Dynamic
+  function makeMap(keys:Array<Dynamic>, values:Array<Dynamic>):Null<Dynamic>
   {
     var isAllString:Bool = true;
     var isAllInt:Bool = true;
@@ -2234,7 +2234,7 @@ class Interp
     return null;
   }
 
-  function get(o:Dynamic, f:String):Dynamic
+  function get(o:Dynamic, f:String):Null<Dynamic>
   {
     if (o == null) error(ENullObjectReference(f));
 
@@ -2356,7 +2356,7 @@ class Interp
     #end
   }
 
-  function set(o:Dynamic, f:String, v:Dynamic):Dynamic
+  function set(o:Dynamic, f:String, v:Dynamic):Null<Dynamic>
   {
     if (o == null) error(ENullObjectReference(f));
 
@@ -2833,7 +2833,7 @@ class Interp
     return false;
   }
 
-  public function getScriptClassStaticField(clsName:String, fieldName:String):Dynamic
+  public function getScriptClassStaticField(clsName:String, fieldName:String):Null<Dynamic>
   {
     var prefixedName = clsName + '#' + fieldName;
     var fieldDecl = getScriptClassStaticFieldDecl(clsName, fieldName);
@@ -2897,7 +2897,7 @@ class Interp
     }
   }
 
-  public function setScriptClassStaticField(clsName:String, fieldName:String, value:Dynamic):Dynamic
+  public function setScriptClassStaticField(clsName:String, fieldName:String, value:Dynamic):Null<Dynamic>
   {
     var prefixedName = clsName + '#' + fieldName;
     var fieldDecl = getScriptClassStaticFieldDecl(clsName, fieldName);

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -225,7 +225,7 @@ class Parser
     return if (a.length == 1) a[0] else mk(EBlock(a), 0);
   }
 
-  function unexpected(tk):Dynamic
+  function unexpected(tk):Null<Dynamic>
   {
     error(EUnexpected(tokenString(tk)), tokenMin, tokenMax);
     return null;
@@ -302,7 +302,7 @@ class Parser
     #end
   }
 
-  inline function mk(e, ?pmin, ?pmax):Expr
+  inline function mk(e, ?pmin, ?pmax):Null<Expr>
   {
     #if hscriptPos
     if (e == null) return null;
@@ -1442,7 +1442,7 @@ class Parser
     return {};
   }
 
-  function parseModuleDecl():ModuleDecl
+  function parseModuleDecl():Null<ModuleDecl>
   {
     var meta = parseMetadata();
     var ident = getIdent();
@@ -1651,7 +1651,7 @@ class Parser
     return null;
   }
 
-  function parseField():FieldDecl
+  function parseField():Null<FieldDecl>
   {
     var meta = parseMetadata();
     var access = [];
@@ -1734,7 +1734,7 @@ class Parser
     return null;
   }
 
-  function parseInterfaceField():FieldDecl
+  function parseInterfaceField():Null<FieldDecl>
   {
     var meta = parseMetadata();
     var access = [];
@@ -1853,7 +1853,6 @@ class Parser
 
   function readString(until:Int):Const
   {
-    var c:Int = 0;
     var b:StringBuf = new StringBuf();
     var esc:Bool = false;
     var interps:Bool = false;
@@ -2541,7 +2540,6 @@ class Parser
   function tokenComment(op:String, char:Int)
   {
     var c = op.charCodeAt(1);
-    var s = input;
     if (c == '/'.code)
     { // comment
       while (char != '\r'.code && char != '\n'.code)

--- a/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodAbstractScriptClass.hx
@@ -169,7 +169,7 @@ abstract PolymodAbstractScriptClass(PolymodScriptClass) from PolymodScriptClass
     return false;
   }
 
-  @:op(a.b) public function fieldWrite(name:String, value:Dynamic):Dynamic
+  @:op(a.b) public function fieldWrite(name:String, value:Dynamic):Null<Dynamic>
   {
     if (this.findVar(name) != null)
     {

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -4,10 +4,8 @@ package polymod.hscript._internal;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
-#else
 #end
 import polymod.util.Util;
-import haxe.rtti.Meta;
 
 @:nullSafety
 class PolymodFinalMacro

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -584,7 +584,7 @@ class PolymodScriptClass
     Polymod.error(SCRIPT_RUNTIME_EXCEPTION, 'Error while executing function ${className}.${fnName}()#${errLine}: ' + '\n' + message, SCRIPT_RUNTIME);
   }
 
-  public function callFunction(fnName:String, ?args:Array<Dynamic>):Dynamic
+  public function callFunction(fnName:String, ?args:Array<Dynamic>):Null<Dynamic>
   {
     var field = findField(fnName);
     var fn = (field != null) ? findFunction(fnName, true) : null;

--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -177,7 +177,7 @@ class PolymodScriptClassMacro
 
           try
           {
-            var _ = Context.getType(polymodImplPath);
+            Context.getType(polymodImplPath);
             hasPolymodImpl = true;
           }
           catch (e) {}

--- a/polymod/hscript/_internal/PolymodStaticAbstractReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticAbstractReference.hx
@@ -1,8 +1,5 @@
 package polymod.hscript._internal;
 
-import polymod.hscript._internal.Expr.ClassDecl;
-import polymod.hscript._internal.Expr.FieldDecl;
-import polymod.hscript._internal.PolymodScriptClass;
 
 using StringTools;
 

--- a/polymod/hscript/_internal/PolymodStaticClassReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticClassReference.hx
@@ -1,7 +1,6 @@
 package polymod.hscript._internal;
 
-import polymod.hscript._internal.Expr.ClassDecl;
-import polymod.hscript._internal.Expr.FieldDecl;
+import polymod.hscript._internal.Expr;
 
 using StringTools;
 
@@ -43,7 +42,7 @@ class PolymodStaticClassReference
    * @param args The arguments to pass to the constructor
    * @return The resulting instance
    */
-  public function instantiate(?args:Array<Dynamic>):Dynamic
+  public function instantiate(?args:Array<Dynamic>):Null<Dynamic>
   {
     var asc:PolymodAbstractScriptClass = buildASC(args);
 

--- a/polymod/util/DependencyUtil.hx
+++ b/polymod/util/DependencyUtil.hx
@@ -1,7 +1,6 @@
 package polymod.util;
 
-import polymod.Polymod.ModDependencies;
-import polymod.Polymod.ModMetadata;
+import polymod.Polymod;
 import thx.semver.VersionRule;
 
 /**

--- a/polymod/util/InsensitiveMap.hx
+++ b/polymod/util/InsensitiveMap.hx
@@ -1,6 +1,5 @@
 package polymod.util;
 
-import haxe.ds.StringMap;
 import haxe.Constraints.IMap;
 
 /**

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -1,18 +1,12 @@
 package polymod.util;
 
-import haxe.Utf8;
 import haxe.io.Bytes;
 import haxe.io.Path;
-import polymod.Polymod.PolymodError;
-import polymod.Polymod.PolymodErrorType;
 import polymod.Polymod;
 import polymod.format.BaseParseFormat;
-import polymod.format.CSV;
-import polymod.format.ParseRules.CSVParseFormat;
-import polymod.format.ParseRules.TextFileFormat;
 import polymod.format.ParseRules;
 import polymod.fs.PolymodFileSystem.IFileSystem;
-import polymod.hscript._internal.Expr.ClassDecl;
+import polymod.hscript._internal.Expr;
 #if unifill
 import unifill.Unifill;
 #end
@@ -65,7 +59,7 @@ class Util
   }
 
   /**
-   * Filters a unicode string to only contain characters that are valid in a filename.
+   * Filters a Unicode string to only contain characters that are valid in a filename.
    */
   public static function filterASCII(str:String):String
   {
@@ -140,7 +134,6 @@ class Util
   public static function appendCSVOrTSV(baseText:String, appendText:String, id:String)
   {
     var lastChar = uCharAt(baseText, uLength(baseText) - 1);
-    var lastLastChar = uCharAt(baseText, uLength(baseText) - 1);
     var joiner = '';
     var endLine = "\n";
     var crIndex = uIndexOf(baseText, "\r");
@@ -370,7 +363,6 @@ class Util
     return '/';
   }
 
-  @:access(haxe.xml.Xml)
   public static inline function copyXml(data:Xml, parent:Xml = null):Xml
   {
     var c:Xml = null;
@@ -563,8 +555,6 @@ class Util
   public static function uTrimFinalEndlines(str:String):String
   {
     var done = false;
-    var fix = '';
-    var last = '';
     while (!done)
     {
       var fix = Util.uTrimFinalCharIf(str, "\n");
@@ -596,8 +586,6 @@ class Util
   public static function uTrimFirstEndlines(str:String):String
   {
     var done = false;
-    var fix = '';
-    var last = '';
     while (!done)
     {
       var fix = Util.uTrimFirstCharIf(str, "\n");

--- a/polymod/util/zip/ZipParser.hx
+++ b/polymod/util/zip/ZipParser.hx
@@ -86,7 +86,7 @@ class ZipParser
    * @param localFileName A filename relative to the root of the ZIP file.
    * @return A LocalFileHeader for the specified file, or null if the file was not found.
    */
-  public function getLocalFileHeaderOf(localFileName:String):LocalFileHeader
+  public function getLocalFileHeaderOf(localFileName:String):Null<LocalFileHeader>
   {
     fileHandle = File.read(this.fileName);
     var cdfh = centralDirectoryRecords.get(localFileName);


### PR DESCRIPTION
This PR does:
- optimize reports
- remove unused fields
- correct the return types from functions to use `Null<T>` instead for those that return `null`