### PR TITLE
Specify a dependency for the constructed abstract impl types

### DIFF
--- a/polymod/hscript/_internal/PolymodScriptClassMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptClassMacro.hx
@@ -75,7 +75,6 @@ class PolymodScriptClassMacro
 
   #if macro
   static var onGenerateCallbackRegistered:Bool = false;
-  @:persistent
   static var onAfterTypingCallbackRegistered:Bool = false;
 
   static function onGenerate(allTypes:Array<haxe.macro.Type>)
@@ -450,7 +449,7 @@ class PolymodScriptClassMacro
                 name: '${abstractType.name}_PolymodImpl_', // we need to give them a different name, because else types with an empty package will not work
                 kind: TDClass(null, [], false, false, false),
                 fields: fields
-              });
+              }, 'polymod.hscript._internal.PolymodScriptClassMacro');
 
             count++;
           }


### PR DESCRIPTION
Specifies the macro class itself as the dependency for the constructed types. I have no idea of what this does exactly, but it did seem to solve this issue where one of the generated types would become a dependency for a certain seemingly unrelated type, causing a bunch of unnecessary retyping.

That issue could be observed through the Haxe language server log
<img width="859" height="43" alt="image" src="https://github.com/user-attachments/assets/72a068a2-ea53-47cd-8980-1fcbb38b7a97" />
Also removes the `@:persistent` metadata because subsequent builds would actually end up not having the types, just like they did for the `onGenerate` callback.

Definitely needs testing, specifically to see if scripts can still access the generated types and if this improves code completion speed at all. At best, this did improve the starting memory usage from Haxe.