### PR TITLE
[BUGFIX] Make async script loading framework-agnostic

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -8,6 +8,7 @@
   "releasenote": "Many improvements to HScripted classes, blacklisting, and error reporting",
   "contributors": ["MasterEric", "larsiusprime"],
   "dependencies": {
+    "tink_core": "",
     "thx.semver": "",
     "jsonpath": "",
     "jsonpatch": ""

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -266,7 +266,8 @@ class Polymod
     // Fetch mod metadata and exclude broken mods.
     var modsToLoad:Array<ModMetadata> = [];
 
-    if (params.modIds.length > 0) {
+    if (params.modIds.length > 0)
+    {
       for (i in 0...params.modIds.length)
       {
         var modId:Null<String> = params.modIds[i];
@@ -285,7 +286,9 @@ class Polymod
           modsToLoad.push(meta);
         }
       }
-    } else if (params.dirs.length > 0) {
+    }
+    else if (params.dirs.length > 0)
+    {
       for (i in 0...params.dirs.length)
       {
         var modDir:Null<String> = params.dirs[i];
@@ -763,7 +766,8 @@ class Polymod
    * @param strict If `true`, return `[]` if a required dependency is unmet.
    * @return The sorted list.
    */
-  public static function sortModsByDependencies(modMetadatas:Array<ModMetadata>, strict:Bool = false):Array<ModMetadata> {
+  public static function sortModsByDependencies(modMetadatas:Array<ModMetadata>, strict:Bool = false):Array<ModMetadata>
+  {
     return DependencyUtil.sortByDependencies(modMetadatas, !strict);
   }
 
@@ -773,7 +777,8 @@ class Polymod
    * @param modMetadatas The list of mods to validate.
    * @return Whether all required, non-optional dependencies are met.
    */
-  public static function validateModDependencies(modMetadatas:Array<ModMetadata>):Bool {
+  public static function validateModDependencies(modMetadatas:Array<ModMetadata>):Bool
+  {
     return DependencyUtil.validateDependencies(modMetadatas);
   }
 
@@ -853,13 +858,13 @@ class Polymod
    * Get a list of all the available scripted classes (`.hxc` files), interpret them asynchronously, and register any classes.
    * Called on platforms that don't support synchronous file access.
    */
-  public static function registerAllScriptClassesAsync():Array<lime.app.Future<Bool>>
+  public static function registerAllScriptClassesAsync():Array<tink.core.Future<Bool>>
   {
     // Go through each script and parse any classes in them.
     var potentialScripts:Array<String> = Polymod.assetLibrary.list(TEXT);
     var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
 
-    var futures:Array<lime.app.Future<Bool>> = [];
+    var futures:Array<tink.core.Future<Bool>> = [];
     for (textPath in potentialScripts)
     {
       if (PolymodConfig.scriptClassExt.exists(ext -> textPath.endsWith(ext)))
@@ -1256,7 +1261,8 @@ class ModMetadata
     return m;
   }
 
-  public function toString():String {
+  public function toString():String
+  {
     return 'ModMetadata($id:$modVersion)';
   }
 }

--- a/polymod/backends/IBackend.hx
+++ b/polymod/backends/IBackend.hx
@@ -17,10 +17,9 @@ interface IBackend
   public function exists(id:String):Bool;
   public function getBytes(id:String):Bytes;
   public function getText(id:String):String;
-  #if lime
-  public function loadBytes(id:String):#if !macro lime.app.Future<Bytes> #else Dynamic #end;
-  public function loadText(id:String):#if !macro lime.app.Future<String> #else Dynamic #end;
-  #end
+
+  public function loadBytes(id:String):#if !macro tink.core.Future<Bytes> #else Dynamic #end;
+  public function loadText(id:String):#if !macro tink.core.Future<String> #else Dynamic #end;
 
   public function getPath(id:String):String;
   public function list(type:PolymodAssetType = null):Array<String>;

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -273,24 +273,20 @@ class PolymodAssetLibrary
     return result;
   }
 
-  #if lime
-  public function loadText(id:String):lime.app.Future<String>
+  public function loadText(id:String):tink.core.Future<String>
   {
     return backend.loadText(id);
   }
-  #end
 
   public function getBytes(id:String):Bytes
   {
     return backend.getBytes(id);
   }
 
-  #if lime
-  public function loadBytes(id:String):lime.app.Future<Bytes>
+  public function loadBytes(id:String):tink.core.Future<Bytes>
   {
     return backend.loadBytes(id);
   }
-  #end
 
   public function getPath(id:String):String
   {

--- a/polymod/backends/StubBackend.hx
+++ b/polymod/backends/StubBackend.hx
@@ -35,17 +35,15 @@ class StubBackend implements IBackend
     return null;
   }
 
-  #if lime
-  public function loadBytes(id:String):lime.app.Future<Bytes>
+  public function loadBytes(id:String):tink.core.Future<Bytes>
   {
     return null;
   }
 
-  public function loadText(id:String):lime.app.Future<String>
+  public function loadText(id:String):tink.core.Future<String>
   {
     return null;
   }
-  #end
 
   public function getPath(id:String):Null<String>
   {

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -8,6 +8,8 @@ import polymod.hscript._internal.Expr.FunctionDecl;
 import polymod.hscript._internal.Expr.VarDecl;
 import polymod.hscript._internal.Printer;
 import polymod.util.Util;
+import tink.core.Outcome;
+import tink.core.Error;
 
 using StringTools;
 
@@ -171,7 +173,8 @@ class PolymodScriptClass
       {
         case EUnexpected(s):
           Polymod.error(SCRIPT_PARSE_FAILED,
-            'Error while parsing function ${path}#${errLine}: EUnexpected' + '\n' + 'Unexpected token "${s}", is there invalid syntax on this line?', SCRIPT_RUNTIME);
+            'Error while parsing function ${path}#${errLine}: EUnexpected' + '\n' + 'Unexpected token "${s}", is there invalid syntax on this line?',
+            SCRIPT_RUNTIME);
         case EClassUnresolvedSuperclass(cls, reason):
           Polymod.error(SCRIPT_PARSE_FAILED,
             'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}', SCRIPT_RUNTIME);
@@ -181,53 +184,59 @@ class PolymodScriptClass
     }
   }
 
-  static function registerScriptClassByPathAsync(path:String):lime.app.Future<Bool>
+  static function registerScriptClassByPathAsync(path:String):tink.core.Future<Bool>
   {
-    var promise = new lime.app.Promise<Bool>();
+    var trigger = tink.core.Future.trigger();
 
     if (!Polymod.assetLibrary.exists(path))
     {
       Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve contents of non-existent script!', SCRIPT_RUNTIME);
-      return null;
+
+      trigger.trigger(Failure(new Error(404, "Non-existent script")));
+
+      return trigger.asFuture();
     }
 
-    Polymod.assetLibrary.loadText(path).onComplete((text) -> {
-      try
+    Polymod.assetLibrary.loadText(path).handle(function(result) {
+      switch (result)
       {
-        registerScriptClassByString(text);
-        promise.complete(true);
-      }
-      catch (err:Expr.Error)
-      {
-        var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
-        #if hscriptPos
-        switch (err.e)
-        #else
-        switch (err)
-        #end
-        {
-          case EUnexpected(s):
-            Polymod.error(SCRIPT_PARSE_FAILED,
-              'Error while parsing script ${path}#${errLine}: EUnexpected' + '\n' +
-              'Unexpected error: Unexpected token "${s}", is there invalid syntax on this line?', SCRIPT_RUNTIME);
-          default:
-            Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
-        }
-        promise.error(err);
-      }
-    }).onError((err) -> {
-      if (err == "404")
-      {
-        Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve script contents (404 error)!', SCRIPT_RUNTIME);
-      }
-      else
-      {
-        Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
-        promise.error(err);
+        case Success(text):
+          try
+          {
+            registerScriptClassByString(text);
+            trigger.trigger(Success(true));
+          }
+          catch (err:Expr.Error)
+          {
+            var errLine:String = #if hscriptPos '${err.line}' #else '#???' #end;
+
+            #if hscriptPos
+            switch (err.e)
+            #else
+            switch (err)
+            #end
+            {
+              case EUnexpected(s):
+                Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}:\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
+              default:
+                Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}:\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
+            }
+            trigger.trigger(Failure(new Error(500, Std.string(err))));
+          }
+
+        case Failure(err):
+          if (err.message == "404")
+          {
+            Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script "${path}", could not retrieve script contents (404 error)!', SCRIPT_RUNTIME);
+          }
+          else
+          {
+            Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script "${path}": ' + '\n' + 'An unknown error occured: ${err}', SCRIPT_RUNTIME);
+            trigger.trigger(Failure(err));
+          }
       }
     });
-    // Await the promise
-    return promise.future;
+    return trigger.asFuture();
   }
 
   /**
@@ -362,7 +371,8 @@ class PolymodScriptClass
       {
         // The superclass is not a scripted class or native class. Probably doesn't exist, throw an error.
         var clsName = classDecl.pkg != null ? '${classDecl.pkg.join('.')}.${classDecl.name}' : classDecl.name;
-        Polymod.error(SCRIPT_PARSE_FAILED, 'Could not parse superclass "$fullSuperClsName" of scripted class "${clsName}". Did you forget to import it?', SCRIPT_RUNTIME);
+        Polymod.error(SCRIPT_PARSE_FAILED, 'Could not parse superclass "$fullSuperClsName" of scripted class "${clsName}". Did you forget to import it?',
+          SCRIPT_RUNTIME);
         return [];
       }
     }
@@ -415,7 +425,8 @@ class PolymodScriptClass
           {
             if (untyped !importedClass.cls._isHScriptedClass)
             {
-              Polymod.error(SCRIPT_PARSE_FAILED, 'Cannot extend non-scriptable class ("${Util.getFullClassName(c)}" tried extending "${pth.join('.')}").', SCRIPT_RUNTIME);
+              Polymod.error(SCRIPT_PARSE_FAILED, 'Cannot extend non-scriptable class ("${Util.getFullClassName(c)}" tried extending "${pth.join('.')}").',
+                SCRIPT_RUNTIME);
               return;
             }
             else
@@ -654,7 +665,8 @@ class PolymodScriptClass
       {
         Polymod.error(SCRIPT_RUNTIME_EXCEPTION,
           'Error while calling function ${fnName}(): EInvalidAccess' + '\n' +
-          'Script does not have function "${fnName}"! Define it or call the correct script function or superclass function.', SCRIPT_RUNTIME);
+          'Script does not have function "${fnName}"! Define it or call the correct script function or superclass function.',
+          SCRIPT_RUNTIME);
         return null;
       }
 


### PR DESCRIPTION
Prior to this PR, asynchronous script loading used lime.app.Future, a class that is specific to the lime library and overall flixel backend. This PR swaps those instances out for tink.core.Future, which is framework agnostic and works with any backend.