### PR TITLE
[FIX] Only create `toString` as override if it exists in super class

### DIFF
--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -481,10 +481,16 @@ class HScriptedClassMacro
 
   static function buildScriptedClass_toString(cls:ClassType):Field
   {
+    var access:Array<Access> = [APublic];
+    if (cls.findField('toString') != null)
+    {
+      access.push(AOverride);
+    }
+
     return {
       name: 'toString',
       doc: null,
-      access: [APublic, AOverride],
+      access: access,
       meta: null,
       pos: cls.pos,
       kind: FFun(


### PR DESCRIPTION
`HScriptedClassMacro` assumes the class being overriden will always have a `toString` function, which may not actually be the case.