### PR TITLE
Fix crash when ignoredFiles is null

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -265,6 +265,7 @@ class Polymod
 
     params.modIds ??= [];
     params.dirs ??= [];
+    params.ignoredFiles ??= [];
 
     if (params.fileSystemParams == null) params.fileSystemParams = {modRoot: modRoot};
     if (params.fileSystemParams.modRoot == null) params.fileSystemParams.modRoot = modRoot;


### PR DESCRIPTION
Commit 928001c made changes that causes a crash to occur when `ignoredFiles` isn't specified for `Polymod.init()`.