### PR TITLE
[FIX] Use full class path in `using` to fix name collisions

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -2550,7 +2550,7 @@ class Interp
           // Polymod.debug('Imported class ${importedClass.name} from ${importedClass.fullPath}');
           imports.set(importedClass.name, importedClass);
         case DUsing(path):
-          var clsName = path[path.length - 1];
+          var clsName = path.join('.');
 
           if (usings.exists(clsName))
           {


### PR DESCRIPTION
## Description
This PR fixes a name collision and logic bug in the script parser/macro setup where static extensions `using` with identical class names but different package paths would conflict

## Example

### Before
If a script tried to use two different classes that shared the same name:
```haxe
using StringTools; 
using funkin.util.tools.StringTools; // This would be SKIPPED and trigger a warning!
```
## After
```haxe
using StringTools; // Registered as "StringTools"
using funkin.util.tools.StringTools; // Registered as "funkin.util.tools.StringTools"
```