### PR TITLE
[OPTIMIZATION] Remove unnecessary loop in `Interp#assignValue`

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -824,29 +824,27 @@ class Interp
             }
             else
             {
+              // Check if we are setting a final. If so, throw an error.
               @:privateAccess
+              if (_proxy != null && _proxy._c != null)
               {
-                // Check if we are setting a final. If so, throw an error.
-                if (_proxy != null && _proxy._c != null)
+                if (_proxy._c.imports.exists(id0))
                 {
-                  for (imp in _proxy._c.imports)
+                  var imp:ClassImport = _proxy._c.imports.get(id0);
+                  var finals:Array<String> = PolymodFinalMacro.getFinals(imp.fullPath);
+
+                  if (finals.contains(id))
                   {
-                    if (imp.name != id0) continue;
-                    var finals = PolymodFinalMacro.getFinals(imp.fullPath);
+                    error(EInvalidFinalSet(id));
+                    return null;
+                  }
 
-                    if (finals.contains(id))
-                    {
-                      error(EInvalidFinalSet(id));
-                      return null;
-                    }
+                  var privates:Array<String> = PolymodFinalMacro.getPrivateProperties(imp.fullPath);
 
-                    var privates = PolymodFinalMacro.getPrivateProperties(imp.fullPath);
-
-                    if (privates.contains(id))
-                    {
-                      error(EInvalidPropSet(id));
-                      return null;
-                    }
+                  if (privates.contains(id))
+                  {
+                    error(EInvalidPropSet(id));
+                    return null;
                   }
                 }
               }


### PR DESCRIPTION
Should close #337

Not sure why it's iterating through the imports to see if the class name matches the identifier in the context, considering the keys for the imports are already the names, which means we can just do a quick map lookup.

Tested with assigning to `Constants.TITLE` and it still errored, which means it should still work.