### PR TITLE
[FEATURE + BUGFIX] HTML5 Modding

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -215,6 +215,15 @@ class Polymod
    */
   public static var onError:Null<PolymodError->Void> = null;
 
+  public static var onScriptsLoaded:Null<Void->Void> = null;
+
+  public static var modRoot(get, never):String;
+
+  static function get_modRoot():String
+  {
+    return assetLibrary?.fileSystem?.modRoot ?? "./mods";
+  }
+
   /**
    * The internal asset library used by Polymod.
    */
@@ -267,6 +276,7 @@ class Polymod
     params.dirs ??= [];
     params.ignoredFiles ??= [];
 
+    var shouldLoadMods:Bool = params.modIds.length == 0 && params.dirs.length == 0;
     if (params.fileSystemParams == null) params.fileSystemParams = {modRoot: modRoot};
     if (params.fileSystemParams.modRoot == null) params.fileSystemParams.modRoot = modRoot;
     if (params.apiVersionRule == null) params.apiVersionRule = VersionUtil.DEFAULT_VERSION_RULE;
@@ -893,6 +903,7 @@ class Polymod
       #end
       polymod.hscript._internal.Interp.validateImports();
 
+      if (Polymod.onScriptsLoaded != null) Polymod.onScriptsLoaded();
       return results;
     }
   }
@@ -939,6 +950,8 @@ class Polymod
     return lime.app.Promises.allSettled(futures).then((results) -> {
       // Once all scripts have been registered, THEN validate the imports.
       polymod.hscript._internal.Interp.validateImports();
+
+      if (Polymod.onScriptsLoaded != null) Polymod.onScriptsLoaded();
 
       return lime.app.Future.withValue(results);
     });

--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -6,7 +6,9 @@ import lime.system.ThreadPool;
 import polymod.backends.PolymodAssetLibrary;
 import polymod.PolymodAssets.PolymodAssetType;
 import polymod.fs.PolymodFileSystem;
+import polymod.fs.PolymodFileSystem.IFileSystem;
 import polymod.Polymod;
+import polymod.Polymod.FrameworkParams;
 import polymod.util.Util;
 import polymod.util.ThreadSafety.SafeMap;
 
@@ -46,6 +48,11 @@ class LimeBackend extends StubBackend
   }
 
   public function preloadImagesToCache():Void
+  {
+    Polymod.error(BACKEND_INIT_FAILED, "LimeBackend requires the lime library, did you forget to install it?", INIT);
+  }
+
+  public function preloadSoundsToCache():Void
   {
     Polymod.error(BACKEND_INIT_FAILED, "LimeBackend requires the lime library, did you forget to install it?", INIT);
   }
@@ -386,6 +393,15 @@ class LimeBackend implements IBackend
       modLibrary.preloadImagesToCache();
     }
   }
+
+  public function preloadSoundsToCache():Void
+  {
+    // On HTML5, we need to call `loadAudioBuffer()` on all sounds before they can be later loaded synchronously.
+    for (modLibrary in modLibraries)
+    {
+      modLibrary.preloadSoundsToCache();
+    }
+  }
 }
 
 @:nullSafety
@@ -452,6 +468,11 @@ class LimeModLibrary extends LimeAssetLibrary
    * This doesn't break mods.
    */
   var imageCache:Map<String, lime.graphics.Image>;
+
+  /**
+   * Preload sounds on HTML5 to allow sounds to be load synchronously.
+   */
+  var soundCache:Map<String, AudioBuffer>;
   #end
 
   public function new(backend:LimeBackend, fallback:LimeAssetLibrary, pathPrefix:String = '', libraryId:String = 'default')
@@ -461,11 +482,16 @@ class LimeModLibrary extends LimeAssetLibrary
     this.pathPrefix = pathPrefix;
     this.libraryId = libraryId;
     this.fallback = fallback;
+    super();
+
     #if html5
     imageCache = new Map<String, lime.graphics.Image>();
-    // preloadImagesToCache();
+    @:nullSafety(Off)
+    preloadImagesToCache();
+    soundCache = new Map<String, AudioBuffer>();
+    @:nullSafety(Off)
+    preloadSoundsToCache();
     #end
-    super();
   }
 
   @:nullSafety(Off)
@@ -505,6 +531,23 @@ class LimeModLibrary extends LimeAssetLibrary
     }
   }
 
+  public function preloadSoundsToCache():Void
+  {
+    // On HTML5, we need to call `loadImage()` on all sounds before they can be later loaded synchronously.
+
+    for (soundAsset in this.list(AssetType.SOUND))
+    {
+      var symbol = new IdAndLibrary(soundAsset, this);
+      var filePath = p.file(symbol.modId);
+
+      #if html5
+      if (soundCache.exists(filePath)) continue;
+      #end
+
+      loadAudioBuffer(soundAsset);
+    }
+  }
+
   public override function getAsset(id:String, assetType:String):Null<Dynamic>
   {
     if (assetType == TEXT) return getText(id);
@@ -536,7 +579,7 @@ class LimeModLibrary extends LimeAssetLibrary
 
   /**
    * Returns true if the asset of the given id and type exists.
-       * Takes into account mods and locales, if available.
+   * Takes into account mods and locales, if available.
    */
   public override function exists(id:String, assetType:String):Bool
   {
@@ -603,6 +646,13 @@ class LimeModLibrary extends LimeAssetLibrary
     var symbol = new IdAndLibrary(id, this);
     if (p.check(symbol.modId))
     {
+      var filePath = p.file(symbol.modId);
+      #if html5
+      if (soundCache.exists(filePath))
+      {
+        return soundCache.get(filePath);
+      }
+      #end
       var buffer:AudioBuffer = AudioBuffer.fromFile(p.file(symbol.modId));
 
       if (buffer == null)
@@ -923,15 +973,26 @@ class LimeModLibrary extends LimeAssetLibrary
     var symbol = new IdAndLibrary(id, this);
     if (p.check(symbol.modId))
     {
-      var path = pathGroups.get(p.file(symbol.modId));
-      if (path != null)
+      // We load the bytes, then load the file, rather than using AudioBuffer.loadFromFile,
+      // because URLs don't work with MemoryFileSystem.
+
+      var filePath = p.file(symbol.modId);
+      var soundFuture = LimeAsyncHandler.loadBytesFromFileSystem(filePath, p.fileSystem).then((bytes:Bytes) ->
       {
-        return AudioBuffer.loadFromFiles(path);
-      }
-      else
+        return Future.withValue(AudioBuffer.fromBytes(bytes));
+      });
+
+      #if html5
+      soundFuture.onComplete((result:AudioBuffer) ->
       {
-        return AudioBuffer.loadFromFile(getPath(p.file(symbol.modId)) ?? p.file(symbol.modId));
-      }
+        if (result != null)
+        {
+          soundCache.set(filePath, result);
+        }
+      });
+      #end
+
+      return soundFuture;
     }
     else if ((fallback != null))
     {
@@ -1122,7 +1183,6 @@ class LimeModLibrary extends LimeAssetLibrary
       #end
     }
 
-    items = Util.filterUnique(items);
     return items;
   }
 
@@ -1256,7 +1316,7 @@ class LimeCoreLibrary extends LimeAssetLibrary
   #if html5
   /**
    * Preload images on HTML5 to allow images to be loaded synchronously.
-   * This doesn't break mods because a new
+   * This doesn't break mods
    */
   var imageCache:Map<String, lime.graphics.Image>;
   #end
@@ -1359,7 +1419,6 @@ class LimeCoreLibrary extends LimeAssetLibrary
       {
         font = #if openfl OpenFLFont #else Font #end.fromBytes(polymodLibrary.fileSystem.getFileBytes(redirectId));
       }
-
       #if openfl
       @:privateAccess if (!OpenFLFont.__fontByName.exists(font.name)) OpenFLFont.registerFont(font);
       #end

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -1,5 +1,6 @@
 package polymod.backends;
 
+import haxe.io.Path;
 import haxe.io.Bytes;
 import polymod.Polymod.Framework as PolymodFramework;
 import polymod.PolymodAssets.PolymodAssetType;
@@ -594,7 +595,7 @@ class PolymodAssetLibrary
 
       if (type == null) return true;
 
-      var assetType = getAssetType(haxe.io.Path.extension(id));
+      var assetType = getAssetType(Path.extension(id));
       if (assetType != type) return false;
       return true;
     });
@@ -911,9 +912,7 @@ class PolymodAssetLibrary
 
     for (file in all)
     {
-      var doti = Util.uLastIndexOf(file, '.');
-      var ext:String = doti != -1 ? file.substring(doti + 1) : '';
-      ext = ext.toLowerCase();
+      var ext:String = Path.extension(file).toLowerCase();
       var assetType = getAssetType(ext);
       assetTypes.set(file, assetType);
 
@@ -1011,9 +1010,7 @@ class PolymodAssetLibrary
 
     for (f in all)
     {
-      var doti = Util.uLastIndexOf(f, '.');
-      var ext:String = doti != -1 ? f.substring(doti + 1) : '';
-      ext = ext.toLowerCase();
+      var ext:String = Path.extension(f).toLowerCase();
       var assetType = getAssetType(ext);
       assetTypes.set(f, assetType);
       if (!typeLibraries.exists(libraryId)) typeLibraries.set(libraryId, []);
@@ -1030,7 +1027,6 @@ class PolymodAssetLibrary
 
         if (font != null)
         {
-          // Check if font is already registered before registering
           @:privateAccess
           if (!Font.__fontByName.exists(font.fontName))
           {
@@ -1055,9 +1051,9 @@ class PolymodAssetLibrary
    */
   public function stripAssetsPrefix(id:String):String
   {
-    if (Util.uIndexOf(id, assetPrefix) == 0)
+    if (id.startsWith(assetPrefix))
     {
-      id = Util.uSubstring(id, assetPrefix.length);
+      return Util.uSubstr(id, assetPrefix.length);
     }
     return id;
   }
@@ -1071,7 +1067,7 @@ class PolymodAssetLibrary
    */
   public function prependAssetsPrefix(id:String):String
   {
-    if (Util.uIndexOf(id, assetPrefix) == 0)
+    if (id.startsWith(assetPrefix))
     {
       return id;
     }

--- a/polymod/fs/MemoryFileSystem.hx
+++ b/polymod/fs/MemoryFileSystem.hx
@@ -25,7 +25,7 @@ class MemoryFileSystem implements IFileSystem
 {
   var files:Map<String, Bytes> = new Map<String, Bytes>();
   var directories:Array<String> = [];
-  var modRoot:String = '';
+  public final modRoot:String = '';
 
   /**
    * A cache of the directories containing mod metadata, indexed by mod ID.

--- a/polymod/fs/MemoryZipFileSystem.hx
+++ b/polymod/fs/MemoryZipFileSystem.hx
@@ -100,7 +100,7 @@ class MemoryZipFileSystem extends MemoryFileSystem
   {
     var compressedBytes = super.getFileBytes(path);
 
-    if (pathIsCompressed.get(path) != null && pathIsCompressed.get(path)) return Util.unzipBytes(compressedBytes);
+    if (pathIsCompressed.exists(path) && pathIsCompressed.get(path)) return Util.unzipBytes(compressedBytes);
 
     return compressedBytes; // if it wasn't actually compressed
   }

--- a/polymod/fs/PolymodFileSystem.hx
+++ b/polymod/fs/PolymodFileSystem.hx
@@ -50,9 +50,11 @@ class PolymodFileSystem
     #elseif nodefs
     // Node file system.
     return new polymod.fs.NodeFileSystem(params);
+    #elseif html5
+    // If you're on HTML5, you should use MemoryFileSystem or MemoryZipFileSystem.
+    return new polymod.fs.MemoryFileSystem(params);
     #else
     // No compatible file system.
-    // If you're on HTML5, you should use MemoryFileSystem or ZipFileSystem.
     return new polymod.fs.StubFileSystem(params);
     #end
   }
@@ -75,6 +77,7 @@ typedef PolymodFileSystemParams =
  */
 interface IFileSystem
 {
+  public final modRoot:String;
   /**
    * Returns whether the file or directory at the given path exists.
    *

--- a/polymod/fs/StubFileSystem.hx
+++ b/polymod/fs/StubFileSystem.hx
@@ -16,6 +16,7 @@ import polymod.fs.PolymodFileSystem.PolymodFileSystemParams;
 @SuppressWarnings('checkstyle:FieldDocComment')
 class StubFileSystem implements IFileSystem
 {
+  public final modRoot:String;
   public function new(params:PolymodFileSystemParams) {}
 
   public inline function exists(path:String):Bool

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -202,7 +202,7 @@ class PolymodScriptClass
     Polymod.assetLibrary.loadText(path).onComplete((text) -> {
       try
       {
-        registerScriptClassByString(text);
+        registerScriptClassByString(text, path);
         promise.complete(true);
       }
       catch (err:Expr.Error)

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -11,6 +11,8 @@ import polymod.hscript._internal.Expr;
 import unifill.Unifill;
 #end
 
+using StringTools;
+
 class Util
 {
   /**
@@ -93,12 +95,7 @@ class Util
     id = stripPrefix(id);
     var mergeFile = PolymodConfig.mergeFolder + sl() + id;
     // try the path first
-    var format:BaseParseFormat = parseRules.get(id);
-    if (format == null)
-    {
-      // try the extension then
-      format = parseRules.get(extension);
-    }
+    var format:BaseParseFormat = parseRules.get(id) ?? parseRules.get(extension);
     if (format != null)
     {
       var mergeText = getModText(mergeFile, modId);
@@ -117,12 +114,7 @@ class Util
     var extension = uExtension(id, true);
     id = stripPrefix(id);
     // try the path first
-    var format:BaseParseFormat = parseRules.get(id);
-    if (format == null)
-    {
-      // try the extension then
-      format = parseRules.get(extension);
-    }
+    var format:BaseParseFormat = parseRules.get(id) ?? parseRules.get(extension);
     if (format != null)
     {
       var appendText = getModText(Util.pathJoin(PolymodConfig.appendFolder, id), modId);
@@ -294,21 +286,30 @@ class Util
 
   public static inline function pathMerge(id:String, theDir:String = ''):String
   {
-    return pathSpecial(id, PolymodConfig.mergeFolder, theDir);
+    return appendPrefix(pathSpecial(id, PolymodConfig.mergeFolder, theDir), withTrailingSlash(Path.normalize(Polymod.modRoot)));
   }
 
   private static inline function pathAppend(id:String, theDir:String = ''):String
   {
-    return pathSpecial(id, PolymodConfig.appendFolder, theDir);
+    return appendPrefix(pathSpecial(id, PolymodConfig.appendFolder, theDir), withTrailingSlash(Path.normalize(Polymod.modRoot)));
   }
 
   public static inline function stripPrefix(id:String, prefix:String = 'assets/'):String
   {
-    if (uIndexOf(id, prefix) == 0)
+    if (id.startsWith(prefix))
     {
-      id = uSubstring(id, 7);
+      return uSubstr(id, prefix.length);
     }
     return id;
+  }
+
+  public static inline function appendPrefix(id:String, prefix:String = 'assets/'):String
+  {
+    if (id.startsWith(prefix))
+    {
+      return id;
+    }
+    return prefix + id;
   }
 
   public static function pathSpecial(id:String, special:String = '', theDir:String = ''):String
@@ -363,6 +364,7 @@ class Util
     return '/';
   }
 
+  @:access(haxe.xml.Xml)
   public static inline function copyXml(data:Xml, parent:Xml = null):Xml
   {
     var c:Xml = null;
@@ -491,8 +493,7 @@ class Util
 
   public static function uExtension(str:String, lowerCase:Bool = false):String
   {
-    var i = uLastIndexOf(str, '.');
-    var extension = uSubstr(str, i + 1, uLength(str) - (i + 1));
+    var extension = Path.extension(str);
     if (lowerCase)
     {
       extension = extension.toLowerCase();


### PR DESCRIPTION
This pull requests fixes various issues with `polymod` on html5/web such as:
- Scripts now indentify themselves as `hscriptClass({filePath}` instead of `hscriptClass` for async scripts
- `LimeModLibrary` now correctly precaches all images and now sounds to ensure mods on web can have content ready as soon as possible
- Fixes various problems with getting the file extension in the library while using `MemoryFileSystem` or `MemoryZipFileSystem` by using the `haxe.io.Path::extension` function

This also merges `html5-fixes` to `develop`