### PR TITLE
HTML5 and Multithreading Fixes

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -370,20 +370,6 @@ class Polymod
     // Do scripted class initialization now that the assetLibrary is loaded.
     if (params.useScriptedClasses)
     {
-      Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes...');
-      Polymod.clearScripts();
-
-      // Add the loaded mods to the Parser's preprocessor values.
-      for (mod in prevModsLoaded)
-      {
-        Parser.preprocessorValues.remove(mod.id);
-      }
-
-      for (mod in sortedModsToLoad)
-      {
-        Parser.preprocessorValues.set(mod.id, mod.modVersion.toString());
-      }
-
       if (params.loadScriptsAsync)
       {
         #if lime
@@ -845,12 +831,31 @@ class Polymod
     polymod.hscript.HScriptable.ScriptRunner.clearScripts();
   }
 
+  static function prepareRegisterScriptedClasses():Void
+  {
+    Polymod.clearScripts();
+    Parser.resetPreprocessorValues();
+
+    // Add the loaded mods to the Parser's preprocessor values.
+    for (mod in prevModsLoaded)
+    {
+      Parser.preprocessorValues.set(mod.id, mod.modVersion.toString());
+    }
+  }
+
   /**
    * Get a list of all the available scripted classes (`.hxc` files), interpret them, and register any classes.
+   *
+   * @return A map of script class paths to whether they were successfully parsed and registered.
    */
-  public static function registerAllScriptClasses():Void
+  public static function registerAllScriptClasses():Map<String, Bool>
   {
+    Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes...');
+    prepareRegisterScriptedClasses();
+
     @:privateAccess {
+      var results:Map<String, Bool> = [];
+
       // Go through each script and parse any classes in them.
       var potentialScripts:Array<String> = Polymod.assetLibrary.list(TEXT);
       var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
@@ -870,10 +875,14 @@ class Polymod
                 break;
               }
             }
-            if (!Polymod.assetLibrary.exists(path)) throw 'Couldn\'t find file "$textPath"';
+            if (!Polymod.assetLibrary.exists(path)) {
+              Polymod.error(SCRIPT_NOT_FOUND, 'Could not find file "$textPath"');
+              results.set(path, false);
+            }
           }
           Polymod.debug('Registering scripted class "$path"');
-          polymod.hscript._internal.PolymodScriptClass.registerScriptClassByPath(path);
+          var result = polymod.hscript._internal.PolymodScriptClass.registerScriptClassByPath(path);
+          results.set(path, result);
         }
       }
 
@@ -882,18 +891,24 @@ class Polymod
       // but for now we just ignore the typed modules that are returned
       var _ = polymod.hscript._internal.PolymodTyperEx.typeAllModules();
       #end
-
       polymod.hscript._internal.Interp.validateImports();
+
+      return results;
     }
   }
 
+  #if lime
   /**
    * Get a list of all the available scripted classes (`.hxc` files), interpret them asynchronously, and register any classes.
    * Called on platforms that don't support synchronous file access.
+   *
+   * @return A list of futures for each script class being registered, providing `true` for success or an error if failed.
    */
-  #if lime
-  public static function registerAllScriptClassesAsync():Array<lime.app.Future<Bool>>
+  public static function registerAllScriptClassesAsync():lime.app.Future<Array<lime.app.Future<Bool>>>
   {
+    Polymod.info(SCRIPT_PARSE_START, 'Parsing script classes asynchronously...');
+    prepareRegisterScriptedClasses();
+
     // Go through each script and parse any classes in them.
     var potentialScripts:Array<String> = Polymod.assetLibrary.list(TEXT);
     var libraryIds:Array<String> = Polymod.assetLibrary.listLibraries();
@@ -916,15 +931,17 @@ class Polymod
           }
           if (!Polymod.assetLibrary.exists(path)) throw 'Couldn\'t find file "$textPath" (tried libraries ${libraryIds})';
         }
-        Polymod.debug('Fetching scripted class "$path"');
         var future = polymod.hscript._internal.PolymodScriptClass.registerScriptClassByPathAsync(path);
         if (future != null) futures.push(future);
       }
     }
 
-    polymod.hscript._internal.Interp.validateImports();
+    return lime.app.Promises.allSettled(futures).then((results) -> {
+      // Once all scripts have been registered, THEN validate the imports.
+      polymod.hscript._internal.Interp.validateImports();
 
-    return futures;
+      return lime.app.Future.withValue(results);
+    });
   }
   #end
 

--- a/polymod/backends/LimeBackend.hx
+++ b/polymod/backends/LimeBackend.hx
@@ -8,6 +8,7 @@ import polymod.PolymodAssets.PolymodAssetType;
 import polymod.fs.PolymodFileSystem;
 import polymod.Polymod;
 import polymod.util.Util;
+import polymod.util.ThreadSafety.SafeMap;
 
 using StringTools;
 
@@ -34,6 +35,7 @@ import lime.Assets.AssetType;
 import lime.audio.AudioBuffer;
 #end
 #end
+
 #if (!lime || nme)
 class LimeBackend extends StubBackend
 {
@@ -53,7 +55,8 @@ class LimeBackend extends StubBackend
 class LimeBackend implements IBackend
 {
   // STATIC:
-  private static var defaultAssetLibraries:Map<String, LimeAssetLibrary>;
+
+  static var defaultAssetLibraries:SafeMap<LimeAssetLibrary> = null;
 
   /**
    * Find all the registered access libraries and store keyed references to them
@@ -62,7 +65,7 @@ class LimeBackend implements IBackend
   {
     if (defaultAssetLibraries == null)
     {
-      defaultAssetLibraries = new Map<String, LimeAssetLibrary>();
+      defaultAssetLibraries = new SafeMap<LimeAssetLibrary>();
 
       // I don't like having to do this but there's no other way, hope the internals don't change!
       var libraries = @:privateAccess lime.utils.Assets.libraries;

--- a/polymod/backends/PolymodAssetLibrary.hx
+++ b/polymod/backends/PolymodAssetLibrary.hx
@@ -13,8 +13,11 @@ import firetongue.FireTongue;
 #if openfl
 import openfl.text.Font;
 #end
+import polymod.util.ThreadSafety.SafeMap;
 
 using StringTools;
+
+
 
 /**
  * Initialized when Polymod mods are loaded, and handles retrieving assets from currently loading mods.
@@ -39,17 +42,17 @@ class PolymodAssetLibrary
   var extensions:Map<String, PolymodAssetType>;
 
   // Cache for directory listings to avoid repeated file system scans
-  var dirCache:Map<String, Array<String>> = [];
+  var dirCache:SafeMap<Array<String>>;
   // Fast lookup for ignored files using Map instead of array searches
-  var ignoredFilesCache:Map<String, Bool> = [];
+  var ignoredFilesCache:SafeMap<Bool>;
   // Cache for file existence checks
-  var fileExistsCache:Map<String, Bool> = [];
+  var fileExistsCache:SafeMap<Bool>;
   // Cache for asset types to avoid repeated extension parsing
-  var assetTypeCache:Map<String, PolymodAssetType> = [];
+  var assetTypeCache:SafeMap<PolymodAssetType>;
   // Pre-built list of all available files across all mods
   var allFilesCache:Null<Array<String>> = null;
   // Cache for processed text files
-  var textCache:Map<String, String> = [];
+  var textCache:SafeMap<String>;
 
   #if firetongue
   private var tongue:FireTongue = null;
@@ -86,6 +89,12 @@ class PolymodAssetLibrary
     #end
     )
   {
+    dirCache = new SafeMap<Array<String>>();
+    ignoredFilesCache = new SafeMap<Bool>();
+    fileExistsCache = new SafeMap<Bool>();
+    assetTypeCache = new SafeMap<PolymodAssetType>();
+    textCache = new SafeMap<String>();
+
     this.backend = backend;
 
     this.fileSystem = fileSystem;
@@ -231,12 +240,12 @@ class PolymodAssetLibrary
 
   function clearCaches():Void
   {
-    dirCache = [];
-    ignoredFilesCache = [];
-    fileExistsCache = [];
-    assetTypeCache = [];
+    dirCache.clear();
+    ignoredFilesCache.clear();
+    fileExistsCache.clear();
+    assetTypeCache.clear();
     allFilesCache = null;
-    textCache = [];
+    textCache.clear();
   }
 
   /**

--- a/polymod/fs/MemoryFileSystem.hx
+++ b/polymod/fs/MemoryFileSystem.hx
@@ -28,6 +28,11 @@ class MemoryFileSystem implements IFileSystem
   var modRoot:String = '';
 
   /**
+   * A cache of the directories containing mod metadata, indexed by mod ID.
+   */
+  var modMetadataLocations:Map<String, String> = [];
+
+  /**
    * Receive parameters to instantiate the MemoryFileSystem.
    */
   public function new(params:PolymodFileSystemParams)
@@ -63,6 +68,82 @@ class MemoryFileSystem implements IFileSystem
   public function removeFile(path:String):Void
   {
     files.remove(path);
+  }
+
+  public function onLoadMod(modId:String):Void
+  {
+  }
+
+  public function onUnloadMod(modId:String):Void
+  {
+  }
+
+  public function readModDirectory(modDir:String, recursive:Bool = true):Array<String>
+  {
+    return recursive
+      ? readDirectoryRecursive(Util.pathJoin(modRoot, modDir))
+      : readDirectory(Util.pathJoin(modRoot, modDir));
+  }
+
+  /**
+   * Determines the mod directory associated with a given mod ID.
+   *
+   * @param modId The ID of the mod to look for.
+   * @param origin The context the error occurred in (while scanning for mods, while initializing mods, etc.).
+   *   Used for error reporting.
+   * @return The directory path where the mod was found, or `null` if not found.
+   */
+  public function scanModDirectoriesForId(modId:String, ?origin:PolymodErrorOrigin):Null<String>
+  {
+    // Get the directory that the mod metadata is in from cache.
+    var knownDirectory:Null<String> = modMetadataLocations.get(modId);
+    if (knownDirectory != null) return knownDirectory;
+
+    // Otherwise, scan all the directories in the mod root.
+    for (dir in readDirectory(modRoot))
+    {
+      var modPath = Util.pathJoin(modRoot, dir);
+      if (exists(modPath))
+      {
+        var meta:ModMetadata = null;
+
+        var metaFile = Util.pathJoin(modPath, PolymodConfig.modMetadataFile);
+        var iconFile = Util.pathJoin(modPath, PolymodConfig.modIconFile);
+
+        if (!exists(metaFile))
+        {
+          continue;
+        }
+        else
+        {
+          var metaText = getFileContent(metaFile);
+          meta = ModMetadata.fromJsonStr(metaText, origin);
+        }
+
+        if (meta == null) continue;
+
+        modMetadataLocations.set(meta.id, dir);
+
+        if (meta.id != modId && dir != modId) continue;
+        meta.dirName = dir;
+        meta.modPath = modPath;
+
+        if (!exists(iconFile))
+        {
+          Polymod.warning(MOD_MISSING_ICON, 'Could not find mod icon file: $iconFile', origin);
+        }
+        else
+        {
+          var iconBytes = getFileBytes(iconFile);
+          meta.icon = iconBytes;
+          meta.iconPath = iconFile;
+        }
+
+        return dir;
+      }
+    }
+    Polymod.error(MOD_MISSING_ID, 'Could not find mod with ID: $modId', origin);
+    return null;
   }
 
   /**
@@ -225,26 +306,92 @@ class MemoryFileSystem implements IFileSystem
   {
     if (apiVersionRule == null) apiVersionRule = VersionUtil.DEFAULT_VERSION_RULE;
 
-    var dirs = readDirectory(modRoot);
     var result:Array<ModMetadata> = [];
-    for (dir in dirs)
+
+    for (modId => modDir in modMetadataLocations)
     {
-      var testDir = Util.pathJoin(modRoot, dir);
+      if (!hasMetadataFile(modDir))
+      {
+        // Remove locations that no longer have metadata.
+        modMetadataLocations.remove(modId);
+        continue;
+      }
+            var meta:ModMetadata = this.getMetadataByModDir(modDir, PolymodErrorOrigin.SCAN);
+      if (meta == null)
+      {
+        // Remove locations whose metadata can no longer be parsed.
+        modMetadataLocations.remove(modId);
+        continue;
+      }
 
-      if (!exists(testDir)) continue;
+      if (!meta.isCompatible(apiVersionRule))
+      {
+        // Remove locations whose metadata is no longer compatible with the current API version.
+        Polymod.warning(MOD_API_VERSION_MISMATCH,
+          'Mod "${modDir}" is not compatible with API version "${apiVersionRule.toString()}", got "${meta.apiVersion.toString()}"',
+          SCAN);
+        modMetadataLocations.remove(modId);
+        continue;
+      }
 
-      if (!isDirectory(testDir)) continue;
+      // Leave the known metadata in place.
+      result.push(meta);
+    }
 
-      var meta:ModMetadata = getMetadataByModDir(dir, PolymodErrorOrigin.SCAN);
+    var knownDirectories:Array<String> = [for (key => value in modMetadataLocations) value];
+    var dirsInModRoot:Array<String> = readDirectory(modRoot);
+    for (modDir in dirsInModRoot)
+    {
+      if (knownDirectories.contains(modDir))
+      {
+        // We've already found mod metadata there.
+        continue;
+      }
 
-      if (meta == null) continue;
+      if (!hasMetadataFile(modDir))
+      {
+        // No mod metadata there.
+        continue;
+      }
 
-      if (!meta.isCompatible(apiVersionRule)) continue;
+      var meta:ModMetadata = this.getMetadataByModDir(modDir, PolymodErrorOrigin.SCAN);
+      if (meta == null)
+      {
+        // Unparsable mod metadata there.
+        continue;
+      }
 
+      if (!meta.isCompatible(apiVersionRule))
+      {
+        // Incompatible mod metadata there.
+        Polymod.warning(MOD_API_VERSION_MISMATCH,
+          'Mod "${modDir}" is not compatible with API version "${apiVersionRule.toString()}", got "${meta.apiVersion.toString()}"',
+          SCAN);
+        continue;
+      }
+
+      // Found a new mod!
+      modMetadataLocations.set(meta.id, modDir);
       result.push(meta);
     }
 
     return result;
+  }
+
+  /**
+   * Get the metadata for a given mod.
+   * This function is DEPRECATED, use `getMetadataByModDir` for the same result.
+   *
+   * @param dirName The directory name of the mod.
+   * @param origin The error reporting origin.
+   * @return The mod metadata, or `null` if not found.
+   */
+  function hasMetadataFile(dirName:String):Bool
+  {
+    var modPath = Util.pathJoin(modRoot, dirName);
+    if (!isDirectory(modPath)) return false;
+    var metaFile = Util.pathJoin(modPath, PolymodConfig.modMetadataFile);
+    return exists(metaFile);
   }
 
   /**

--- a/polymod/fs/SysFileSystem.hx
+++ b/polymod/fs/SysFileSystem.hx
@@ -590,12 +590,14 @@ class SysFileSystem implements IFileSystem
 #end
 
 #if !sys
+import polymod.fs.PolymodFileSystem.PolymodFileSystemParams;
+
 /**
- * Fallback used when the `sys` packages required by `SysZipFileSystem` are not available.
+ * Fallback used when the `sys` packages required by `SysFileSystem` are not available.
  */
-class SysZipFileSystem extends polymod.fs.StubFileSystem
+class SysFileSystem extends polymod.fs.StubFileSystem
 {
-  public function new(params:ZipFileSystemParams)
+  public function new(params:PolymodFileSystemParams)
   {
     super(params);
     Polymod.error(POLYMOD_FUNCTIONALITY_NOT_IMPLEMENTED, 'This file system not supported for this platform, and is only intended for use on sys targets', INIT);

--- a/polymod/hscript/_internal/HScriptedClassMacro.hx
+++ b/polymod/hscript/_internal/HScriptedClassMacro.hx
@@ -313,12 +313,12 @@ class HScriptedClassMacro
         kind: FFun(
           {
             args: [
-              {name: 'clsName', type: macro :String}, {name: 'funcName', type: macro :String},],
+              {name: 'clsName', type: macro :String}, {name: 'funcName', type: macro :String}, {name: 'args', type: macro :...Dynamic}],
             params: null,
             ret: macro :Dynamic,
             expr: macro
             {
-              return polymod.hscript._internal.PolymodScriptClass.callScriptClassStaticFunction(clsName, funcName);
+              return polymod.hscript._internal.PolymodScriptClass.callScriptClassStaticFunction(clsName, funcName, args);
             }
           })
       };
@@ -376,19 +376,42 @@ class HScriptedClassMacro
       {
         name: 'scriptStaticHas',
         doc: 'Determines if a static field of a scripted class exists or not.',
-        access: [APublic],
+        access: [APublic, AStatic],
         meta: null,
         pos: cls.pos,
         kind: FFun(
           {
             args: [
-              {name: 'fieldName', type: macro :String}],
+              {name: 'clsName', type: macro :String},
+              {name: 'fieldName', type: macro :String}
+            ],
             params: null,
             ret: macro :Bool,
             expr: macro
             {
-              @:privateAccess
-              return _asc._interp.getScriptClassStaticFieldDecl(_asc.fullyQualifiedName, fieldName) != null;
+              return polymod.hscript._internal.PolymodScriptClass.hasScriptClassStaticField(clsName, fieldName);
+            },
+          }),
+      };
+
+      var function_scriptStaticHasFunc:Field =
+      {
+        name: 'scriptStaticHasFunc',
+        doc: 'Determines if a static function of a scripted class exists or not.',
+        access: [APublic, AStatic],
+        meta: null,
+        pos: cls.pos,
+        kind: FFun(
+          {
+            args: [
+              {name: 'clsName', type: macro :String},
+              {name: 'fieldName', type: macro :String}
+            ],
+            params: null,
+            ret: macro :Bool,
+            expr: macro
+            {
+              return polymod.hscript._internal.PolymodScriptClass.hasScriptClassStaticFunction(clsName, fieldName);
             },
           }),
       };
@@ -404,7 +427,8 @@ class HScriptedClassMacro
       function_scriptStaticCall,
       function_scriptStaticGet,
       function_scriptStaticSet,
-      function_scriptStaticHas
+      function_scriptStaticHas,
+      function_scriptStaticHasFunc
     ];
   }
 

--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -2808,6 +2808,37 @@ class Interp
     });
   }
 
+  public function hasScriptClassStaticField(clsName:String, fieldName:String):Bool
+  {
+    // Every scripted class has these functions, so we force the check to return true.
+    if (['scriptInit', 'listScriptClasses'].contains(fieldName)) return true;
+
+    var imports:Map<String, ClassImport> = [];
+
+    var cls:Null<ClassDecl> = _scriptClassDescriptors.get(clsName);
+    if (cls != null)
+    {
+      imports = cls.imports;
+
+      // TODO: Optimize with a cache?
+      for (f in cls.staticFields)
+      {
+        if (f.name == fieldName)
+        {
+          // ALWAYS true regardless if it's a function.
+          return true;
+        }
+      }
+    }
+    else
+    {
+      Polymod.error(SCRIPTED_CLASS_NOT_REGISTERED, 'Scripted class $clsName has not been defined.', SCRIPT_RUNTIME);
+      return false;
+    }
+
+    return false;
+  }
+
   public function hasScriptClassStaticFunction(clsName:String, fnName:String):Bool
   {
     // Every scripted class has these functions, so we force the check to return true.

--- a/polymod/hscript/_internal/Parser.hx
+++ b/polymod/hscript/_internal/Parser.hx
@@ -2626,4 +2626,9 @@ class Parser
     if (preprocessorValues == null) preprocessorValues = DefineUtil.getDefines();
     return preprocessorValues;
   }
+
+  public static function resetPreprocessorValues():Void
+  {
+    preprocessorValues = null;
+  }
 }

--- a/polymod/hscript/_internal/PolymodFinalMacro.hx
+++ b/polymod/hscript/_internal/PolymodFinalMacro.hx
@@ -5,7 +5,6 @@ import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
 #end
-import polymod.util.Util;
 
 @:nullSafety
 class PolymodFinalMacro
@@ -15,6 +14,7 @@ class PolymodFinalMacro
    */
   static inline final METADATA_RESOURCE_NAME:String = 'PolymodFinalMacro_METADATA';
 
+  #if !macro
   public static inline function getFinals(fullPath:String):Array<String> {
     return getAllFinals().get(fullPath) ?? [];
   }
@@ -22,7 +22,7 @@ class PolymodFinalMacro
   public static inline function getFinalsOf(obj:Dynamic):Array<String> {
     while (Std.isOfType(obj, PolymodScriptClass)) obj = obj.superClass;
 
-    var typeName:String = Util.getTypeNameOf(obj);
+    var typeName:String = polymod.util.Util.getTypeNameOf(obj);
     var result = getFinals(typeName);
     return result;
   }
@@ -34,7 +34,7 @@ class PolymodFinalMacro
   public static inline function getPrivatePropertiesOf(obj:Dynamic):Array<String> {
     while (Std.isOfType(obj, PolymodScriptClass)) obj = obj.superClass;
 
-    var typeName:String = Util.getTypeNameOf(obj);
+    var typeName:String = polymod.util.Util.getTypeNameOf(obj);
     var result = getPrivateProperties(typeName);
     return result;
   }
@@ -54,6 +54,7 @@ class PolymodFinalMacro
     if (_allPrivates == null) _allPrivates = PolymodFinalMacro.fetchAllPrivateProperties();
     return _allPrivates;
   }
+  #end
 
   public static macro function locateAllFinals():Void
   {

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -384,6 +384,11 @@ class PolymodScriptClass
     return scriptInterp.callScriptClassStaticFunction(clsName, funcName, args);
   }
 
+  public static function hasScriptClassStaticField(clsName:String, funcName:String):Bool
+  {
+    return scriptInterp.hasScriptClassStaticField(clsName, funcName);
+  }
+
   public static function hasScriptClassStaticFunction(clsName:String, funcName:String):Bool
   {
     return scriptInterp.hasScriptClassStaticFunction(clsName, funcName);

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -147,22 +147,25 @@ class PolymodScriptClass
 
   /**
    * Register a scripted class by retrieving the script from the given path.
+   *
+   * @return `true` if the script was registered successfully, otherwise `false`.
    */
-  static function registerScriptClassByPath(path:String):Void
+  static function registerScriptClassByPath(path:String):Bool
   {
     var scriptBody = Polymod.assetLibrary.getText(path);
     if (scriptBody == null)
     {
       Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve script contents!', SCRIPT_RUNTIME);
-      return;
+      return false;
     }
     try
     {
       registerScriptClassByString(scriptBody, path);
+      return true;
     }
     catch (err:Expr.Error)
     {
-      var errLine:String = #if hscriptPos '${err.line}' #else "#???" #end;
+      var errLine:String = #if hscriptPos '${err.line}' #else '#???' #end;
       #if hscriptPos
       switch (err.e)
       #else
@@ -173,11 +176,14 @@ class PolymodScriptClass
           Polymod.error(SCRIPT_PARSE_FAILED,
             'Error while parsing function ${path}#${errLine}: EUnexpected' + '\n' + 'Unexpected token "${s}", is there invalid syntax on this line?',
             SCRIPT_RUNTIME);
+          return false;
         case EClassUnresolvedSuperclass(cls, reason):
           Polymod.error(SCRIPT_PARSE_FAILED,
             'Error while parsing class ${path}#${errLine}: EClassUnresolvedSuperclass' + '\n' + 'Unresolved superclass "${cls}", ${reason}', SCRIPT_RUNTIME);
+          return false;
         default:
           Polymod.error(SCRIPT_PARSE_FAILED, 'Error while parsing script ${path}#${errLine}: ' + '\n' + 'An unknown error occurred: ${err}', SCRIPT_RUNTIME);
+          return false;
       }
     }
   }
@@ -219,7 +225,7 @@ class PolymodScriptClass
         promise.error(err);
       }
     }).onError((err) -> {
-      if (err == "404")
+      if (err == '404')
       {
         Polymod.error(SCRIPT_PARSE_FAILED, 'Error while loading script "${path}", could not retrieve script contents (404 error)!', SCRIPT_RUNTIME);
       }

--- a/polymod/hscript/_internal/PolymodStaticClassReference.hx
+++ b/polymod/hscript/_internal/PolymodStaticClassReference.hx
@@ -1,6 +1,7 @@
 package polymod.hscript._internal;
 
 import polymod.hscript._internal.Expr;
+import polymod.util.Util;
 
 using StringTools;
 
@@ -118,11 +119,7 @@ class PolymodStaticClassReference
    */
   public function getFullyQualifiedName():String
   {
-    if (this.cls.pkg != null && this.cls.pkg.length > 0)
-    {
-      return this.cls.pkg.join(".") + "." + this.cls.name;
-    }
-    return this.cls.name;
+    return Util.getFullClassName(cls);
   }
 
   public function toString():String

--- a/polymod/util/ThreadSafety.hx
+++ b/polymod/util/ThreadSafety.hx
@@ -1,0 +1,20 @@
+package polymod.util;
+
+#if haxe_concurrent
+import hx.concurrent.collection.SynchronizedMap;
+
+// If available, make Polymod thread-safe.
+// Assumes String keys.
+@:forward
+abstract SafeMap<V>(SynchronizedMap<String, V>) to SynchronizedMap<String, V>
+{
+  // Add a no-arg constructor that builds a map with the appropriate type.
+  public function new() {
+    @:privateAccess
+    this = SynchronizedMap.newStringMap();
+  }
+}
+#else
+// If not available, use a standard Map.
+typedef SafeMap<V> = Map<String, V>;
+#end

--- a/polymod/util/Util.hx
+++ b/polymod/util/Util.hx
@@ -767,6 +767,10 @@ class Util
    */
   public static function getFullClassName(clsDecl:ClassDecl):String
   {
-    return (clsDecl.pkg != null ? (clsDecl.pkg.join(".") + ".") : "") + clsDecl.name;
+    if (clsDecl.pkg != null && clsDecl.pkg.length > 0)
+    {
+      return clsDecl.pkg.join('.') + '.' + clsDecl.name;
+    }
+    return clsDecl.name;
   }
 }


### PR DESCRIPTION
- Fix some build errors tied to HTML5 file systems not including required fields.
- Fix some build errors tied to attempting to access JavaScript code from a macro.
- Allow for arguments to be passed into `scriptStaticCall`, and make `scriptStaticHas` a static function (I guess I implemented these without actually trying to use them, LMAO!)
- If the `haxe-concurrent` library is installed, use the thread-safe SynchronizedMap to prevent access violations caused by multi-thread asset fetching.