### PR TITLE
[BUGFIX] Fix null access when stringifying function argument

### DIFF
--- a/polymod/hscript/_internal/Printer.hx
+++ b/polymod/hscript/_internal/Printer.hx
@@ -642,7 +642,8 @@ class Printer
           {
             var arg:Argument = f.args[i];
             if (arg.opt ?? false) output += "?";
-            output += arg.name + ":" + this.typeToString(arg.t);
+            output += arg.name;
+            if (arg.t != null) output += ":" + this.typeToString(arg.t);
             if (arg.value != null) output += " = " + this.exprToString(arg.value);
 
             if (i < f.args.length - 1) output += ", ";


### PR DESCRIPTION
Addresses the crash in https://github.com/FunkinCrew/Funkin/issues/7649

Functions can have arguments that have no types specified, and `Printer` didn't take that into account.