### PR TITLE
Use `PromiseUtil` instead of Funkin Lime's `lime.app.Promises`

### DIFF
--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -18,7 +18,9 @@ import thx.semver.VersionRule;
 
 using Lambda;
 using StringTools;
+#if lime
 using polymod.util.PromiseUtil;
+#end
 
 #if firetongue
 import firetongue.FireTongue;

--- a/polymod/Polymod.hx
+++ b/polymod/Polymod.hx
@@ -18,6 +18,7 @@ import thx.semver.VersionRule;
 
 using Lambda;
 using StringTools;
+using polymod.util.PromiseUtil;
 
 #if firetongue
 import firetongue.FireTongue;
@@ -947,7 +948,7 @@ class Polymod
       }
     }
 
-    return lime.app.Promises.allSettled(futures).then((results) -> {
+    return lime.app.Promise.allSettled(futures).then((results) -> {
       // Once all scripts have been registered, THEN validate the imports.
       polymod.hscript._internal.Interp.validateImports();
 

--- a/polymod/util/PromiseUtil.hx
+++ b/polymod/util/PromiseUtil.hx
@@ -1,0 +1,134 @@
+package polymod.util;
+
+import lime.app.Promise;
+import lime.app.Future;
+
+/**
+ * A set of static utility functions for working with Promises.
+ * This includes functions which resolve groups of Futures.
+ */
+class PromiseUtil
+{
+  /**
+   * Creates a promise which fulfills when all the input promises resolve successfully,
+   * with an array of the result values.
+   * Rejects when any of the input promises reject, with the first rejection reason.
+   * @param futures A list of Futures to resolve.
+   * @return A Future for a list of result values.
+   */
+  public static function all<T>(cls:Class<Promise<T>>, futures:Array<Future<T>>):Future<Array<T>>
+  {
+    var promise:Promise<Array<T>> = new Promise<Array<T>>();
+    var results:Array<T> = [];
+
+    for (future in futures)
+    {
+      future.onComplete(function(result)
+      {
+        results.push(result);
+        promise.progress(results.length, futures.length);
+        if (results.length == futures.length)
+        {
+          promise.complete(results);
+        }
+      });
+      future.onError(function(error)
+      {
+        promise.error(error);
+      });
+    }
+
+    return promise.future;
+  }
+
+  /**
+   * Creates a promise which fulfills when all the input promises settle (whether success or failure).
+   * Returns an array of objects that describe the outcome of each promise.
+   * @param futures A list of Futures to resolve.
+   * @return A Future for a list of result values.
+   */
+  public static function allSettled<T>(cls:Class<Promise<T>>, futures:Array<Future<T>>):Future<Array<Future<T>>>
+  {
+    var promise:Promise<Array<Future<T>>> = new Promise<Array<Future<T>>>();
+
+    var resolved:Int = 0;
+
+    for (future in futures)
+    {
+      future.onComplete(function(value)
+      {
+        resolved += 1;
+        promise.progress(resolved, futures.length);
+        if (resolved == futures.length)
+        {
+          promise.complete(futures);
+        }
+      });
+      future.onError(function(error)
+      {
+        resolved += 1;
+        promise.progress(resolved, futures.length);
+        if (resolved == futures.length)
+        {
+          promise.complete(futures);
+        }
+      });
+    }
+
+    return promise.future;
+  }
+
+  /**
+   * Creates a promise which fulfills when any of the input promises resolve successfully.
+   * Returns the first fulfilled promise. If all promises reject, the promise will be rejected with the list of rejection reasons.
+   * @param futures A list of Futures to resolve.
+   * @return A Future for a result value.
+   */
+  public static function any<T>(cls:Class<Promise<T>>, futures:Array<Future<T>>):Future<T>
+  {
+    var promise:Promise<T> = new Promise<T>();
+    var errors:Array<Dynamic> = [];
+
+    for (future in futures)
+    {
+      future.onComplete(function(value)
+      {
+        promise.complete(value);
+      });
+      future.onError(function(error)
+      {
+        errors.push(error);
+        promise.progress(errors.length, futures.length);
+        if (errors.length == futures.length)
+        {
+          promise.error(errors);
+        }
+      });
+    }
+
+    return promise.future;
+  }
+
+  /**
+   * Creates a promise which fulfills when any of the input promises settle.
+   * Returns an object that describes the outcome of the first settled promise (whether success or failure).
+   * @param futures A list of Futures to resolve.
+   * @return A Future for a result value.
+   */
+  public static function race<T>(cls:Class<Promise<T>>, futures:Array<Future<T>>):Future<T>
+  {
+    var promise:Promise<T> = new Promise<T>();
+    for (future in futures)
+    {
+      future.onComplete(function(value)
+      {
+        promise.complete(value);
+      });
+      future.onError(function(error)
+      {
+        promise.error(error);
+      });
+    }
+    return promise.future;
+  }
+}

--- a/polymod/util/PromiseUtil.hx
+++ b/polymod/util/PromiseUtil.hx
@@ -1,5 +1,6 @@
 package polymod.util;
 
+#if lime
 import lime.app.Promise;
 import lime.app.Future;
 
@@ -132,3 +133,4 @@ class PromiseUtil
     return promise.future;
   }
 }
+#end


### PR DESCRIPTION
Fixes [this issue](https://github.com/FunkinCrew/polymod/issues/457)

This PR brings Funkin Lime's `Promises.hx` into the library through `PromiseUtil.hx` and uses that instead, helping to make the library not dependent on using Funkin Lime.