### PR TITLE
[BUGFIX] Fix intermittent read failures on certain ZIP files

### DIFF
--- a/polymod/fs/SysZipFileSystem.hx
+++ b/polymod/fs/SysZipFileSystem.hx
@@ -178,17 +178,18 @@ class SysZipFileSystem extends SysFileSystem
         return null;
       }
 
+      var fileBytes:Null<Bytes> = null;
       try
       {
-        var fileBytes = fileHeader.readData();
-        return fileBytes;
+        fileBytes = fileHeader.readData();
       }
       catch (e)
       {
         // An error occurred while reading the file from the ZIP.
         Polymod.error(MOD_ARCHIVE_READ_FAILED, 'Failed to read file bytes from archive, is it corrupt?\n$path\n${e}');
-        return null;
       }
+      fileHeader.cleanupFileHandle();
+      return fileBytes;
     }
   }
 

--- a/polymod/util/zip/ZipParser.hx
+++ b/polymod/util/zip/ZipParser.hx
@@ -120,8 +120,9 @@ class ZipParser
   }
 
   /**
-   * Read the centeral directory header for a specific file,
-   * and generate a LocalFileHeader.
+   * Read the central directory header for a specific file, and generate a LocalFileHeader.
+   * This opens a new file handle to the ZIP file independent of `persistFileHandle`,
+   * so make sure to close it with `LocalFileHeader.closeFileHandle()` when done using it.
    *
    * @param localFileName A filename relative to the root of the ZIP file.
    * @return A LocalFileHeader for the specified file, or `null` if the file was not found.
@@ -140,9 +141,19 @@ class ZipParser
       return null;
     }
 
-    fileHandle.seek(cdfh.localFileHeaderOffset, SeekBegin);
-    var lfh = new LocalFileHeader(fileHandle);
-    lfh.dataOffset = fileHandle.tell();
+    // This will always open a new handle, since it may be accessed in a different thread.
+    var localFileHandle:FileInput = File.read(this.fileName);
+    localFileHandle.seek(cdfh.localFileHeaderOffset, SeekBegin);
+    var lfh = new LocalFileHeader(localFileHandle);
+    if (!lfh.isValid())
+    {
+      Polymod.warning(ASSET_MISSING_FILE, 'Could not parse entry for $localFileName, it might be corrupted.');
+
+      cleanupFileHandle();
+      return null;
+    }
+
+    lfh.dataOffset = localFileHandle.tell();
 
     // Headers with this flag have its relevant data set to zero.
     // We populate it with the data from the central directory header instead.
@@ -307,7 +318,7 @@ class LocalFileHeader extends Header
   /**
    * Local file header signature = 0x04034b50 (PK♥♦ or "PK\3\4")
    */
-  public static final HEADER_SIGNATURE = 0x04034B50;
+  public static inline final HEADER_SIGNATURE:Int = 0x04034B50;
 
   /**
    * Version needed to extract (minimum)
@@ -423,10 +434,24 @@ class LocalFileHeader extends Header
         bytesRead += fileInput.readBytes(bytesToReturn, 0, compressedSize - bytesRead);
         bytesBuf.addBytes(bytesToReturn, 0, compressedSize - bytesRead);
       }
-      return (this.compressionMethod == DEFLATE) ? Util.unzipBytes(bytesBuf.getBytes()) : bytesBuf.getBytes();
+      bytesToReturn = bytesBuf.getBytes();
     }
 
     return (this.compressionMethod == DEFLATE) ? Util.unzipBytes(bytesToReturn) : bytesToReturn;
+  }
+
+  /**
+   * Closes the file handle for this header, if it exists.
+   * Note that this will render the header invalid for reading data,
+   * so it should only be called when it is no longer needed.
+   */
+  public function cleanupFileHandle()
+  {
+    if (fileInput != null)
+    {
+      fileInput.close();
+      fileInput = null;
+    }
   }
 
   /**
@@ -435,7 +460,7 @@ class LocalFileHeader extends Header
   public function isValid()
   {
     if (fileInput == null) return false;
-    if (compressedSize == 0) return false;
+    if (compressedSize + uncompressedSize == 0 && !generalPurposeBitFlag.has(DATA_DESCRIPTOR)) return false;
     if (signature.getInt32(0) != HEADER_SIGNATURE) return false;
 
     return true;
@@ -449,7 +474,7 @@ class LocalFileHeader extends Header
         general purpose bit flags: $generalPurposeBitFlag
         compression method: $compressionMethod
         last modified date: $lastModifiedDateTime
-        crc32: $crc32code
+        crc32: ${crc32code.toHex()}
         compressed size: $compressedSize
         uncompressed size: $uncompressedSize
         file name: $fileName
@@ -468,7 +493,7 @@ class CentralDirectoryFileHeader extends Header
   /**
    * Central directory file header signature = 0x02014b50
    */
-  public static final HEADER_SIGNATURE = 0x02014B50;
+  public static inline final HEADER_SIGNATURE:Int = 0x02014B50;
 
   /**
    * Version made by
@@ -651,7 +676,7 @@ class EndOfCentralDirectoryRecord extends Header
   /**
    * End of central directory signature = 0x06054b50
    */
-  public static final SIGNATURE = 0x06054B50;
+  public static inline final SIGNATURE:Int = 0x06054B50;
 
   /**
    * Number of this disk (or 0xffff for ZIP64)

--- a/polymod/util/zip/ZipParser.hx
+++ b/polymod/util/zip/ZipParser.hx
@@ -129,19 +129,16 @@ class ZipParser
    */
   public function getLocalFileHeaderOf(localFileName:String):Null<LocalFileHeader>
   {
-    buildFileHandle();
-    if (fileHandle == null) throw 'Failed to read ZIP file!';
+    if (!isValid()) throw 'Failed to read ZIP file!';
 
     var cdfh = centralDirectoryRecords.get(localFileName);
     if (cdfh == null)
     {
       Polymod.warning(ASSET_MISSING_FILE, 'The file $localFileName was not found in the zip: $fileName');
-
-      cleanupFileHandle();
       return null;
     }
 
-    // This will always open a new handle, since it may be accessed in a different thread.
+    // This will always open a new handle, since it may be accessed by a different thread.
     var localFileHandle:FileInput = File.read(this.fileName);
     localFileHandle.seek(cdfh.localFileHeaderOffset, SeekBegin);
     var lfh = new LocalFileHeader(localFileHandle);
@@ -149,7 +146,6 @@ class ZipParser
     {
       Polymod.warning(ASSET_MISSING_FILE, 'Could not parse entry for $localFileName, it might be corrupted.');
 
-      cleanupFileHandle();
       return null;
     }
 
@@ -165,7 +161,6 @@ class ZipParser
       lfh.uncompressedSize = cdfh.uncompressedSize;
     }
 
-    cleanupFileHandle();
     return lfh;
   }
 
@@ -175,10 +170,8 @@ class ZipParser
    *
    * @return Whether this Zip Parser is still valid.
    */
-  public function isValid():Bool {
-    if (!sys.FileSystem.exists(fileName)) return false;
-
-    return true;
+  public inline function isValid():Bool {
+    return sys.FileSystem.exists(fileName);
   }
 
   function buildFileHandle() {


### PR DESCRIPTION
This is a problem I've observed with QT-Rewired. Sometimes, when switching variations on Freeplay with a QT song selected there would be a random chance for the game to crash. The same could happen with stage assets, failing to load, if entering a song.

I believe the cause for this issue to be a race condition over the single FileInput handle in `ZipParser`. A handle has a pointer that dictates where it reads from, the problem is that a thread would move the pointer to a different spot while another thread was using it, causing the data to be corrupted, even though the archive itself is fine. You can imagine it as trying to mark a spot on a book then someone changing the page and causing you to mark somewhere else.

<figure>
<img width="1188" height="225" alt="Captura_de_tela_20260807_170007" src="https://github.com/user-attachments/assets/9ef1adab-647b-48c1-831c-735e60d01fff" />
<figcaption align="center"><sub>A local entry with a bogus file name due to the issue</sub></figcaption>

### The fix
I've decided to fix this by creating a file handle for each Local File Header instead of reusing one, which is disposed after used. I've also made sure to document it so that future code changes keep this promise. The one in `ZipParser` is still kept so that it can act as a lock. Now, you may question, why not use a mutex? A mutex would cause threads to wait for the handle to finish being used, causing parsing to be slow, since a thread would wait for the handle to be usable first. Creating a different file handle allows for concurrency without slowing things down.