### PR TITLE
Allow `Std.isOfType/is` to properly check for scripted classes.

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -239,6 +239,12 @@ class Interp
    */
   function fcall(o:Dynamic, f:String, args:Array<Dynamic>):Dynamic
   {
+    // Override Std.isOfType to call our own function.
+    if (o != null && (o == 'Std' && f == 'isOfType'))
+    {
+      return PolymodScriptClass.isOfType(args[0], args[1]);
+    }
+
     // OVERRIDE CHANGE: Custom logic to handle super calls to prevent infinite recursion
     if (_proxy != null && o == _proxy.superClass && !Std.isOfType(o, PolymodScriptClass))
     {
@@ -651,7 +657,7 @@ class Interp
     binops.set("&&", function(e1, e2) return me.expr(e1) == true && me.expr(e2) == true);
     binops.set("=", assign);
     binops.set("...", function(e1, e2) return new IntIterator(me.expr(e1), me.expr(e2)));
-    binops.set("is", function(e1, e2) return #if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (me.expr(e1), me.expr(e2)));
+    binops.set("is", function(e1, e2) return PolymodScriptClass.isOfType(me.expr(e1), me.expr(e2))); // We use a special Std.isOfType to fix scripted classes.
     binops.set("??", function(e1, e2) return me.expr(e1) ?? me.expr(e2));
     assignOp("+=", function(v1:Dynamic, v2:Dynamic) return v1 + v2);
     assignOp("-=", function(v1:Float, v2:Float) return v1 - v2);

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -404,6 +404,64 @@ class PolymodScriptClass
     return scriptInterp.setScriptClassStaticField(clsName, fieldName, fieldValue);
   }
 
+  // Override version of Std.isOfType so we're able to test for scripted classes.
+  public static function isOfType(v:Dynamic, t:Dynamic):Bool
+  {
+    var typeClassDecl:ClassDecl = null;
+    var typeFullName:String = '';
+    if (t is PolymodStaticClassReference)
+    {
+      var o = cast(t, PolymodStaticClassReference);
+      typeClassDecl = o.cls;
+      typeFullName = Util.getFullClassName(typeClassDecl);
+    }
+    else
+    {
+      typeFullName = Util.getTypeNameOf(t);
+    }
+
+    // Check again for a class descriptor just in case.
+    // We check for the full package name in case the scripted class was packaged.
+    if (typeClassDecl == null)
+    {
+      var typeNameSplit:Array<String> = typeFullName.split('.');
+      var typeName:String = typeNameSplit.length < 1 ? typeFullName : typeNameSplit[typeNameSplit.length - 1];
+
+      typeClassDecl = Interp.findScriptClassDescriptor(typeFullName) ?? Interp.findScriptClassDescriptor(typeName) ?? null;
+      if (typeClassDecl != null)
+      {
+        // Re-assign full package.
+        typeFullName = Util.getFullClassName(typeClassDecl);
+      }
+    }
+
+    // `v` can be a PolymodScriptClass if you call `this` from a scripted class.
+    if (v is HScriptedClass || v is PolymodStaticClassReference || v is PolymodScriptClass)
+    {
+      var proxy:PolymodAbstractScriptClass = switch (v)
+      {
+        case (_ is HScriptedClass) => true: v._asc;
+        case (_ is PolymodStaticClassReference) => true: v.cls;
+        default: cast v;
+      }
+      var allPackages:Array<String> = [proxy.fullyQualifiedName].concat(getSuperClasses(proxy._c));
+
+      // Check whether the base class or any super classes are the same type as the type class.
+      return allPackages.indexOf(typeFullName) != -1;
+    }
+
+    // If we're on this line then it means `v` isn't a scripted class and `t` is instead.
+    // We can safely return false since source classes won't be able to extend scripted classes anyway.
+    if (typeClassDecl != null)
+    {
+      return false;
+    }
+
+    // Fallback to using the regular Std.isOfType
+    return #if (haxe_ver >= 4.2) Std.isOfType #else Std.is #end (v, t);
+  }
+
+
   /**
    * INSTANCE METHODS
    */


### PR DESCRIPTION
Idea comes from how in the contributors server we were talking about how to properly check for a scripted class you have to rely on the `toString()` function.

Anyways this PR overwrites `Std.isOfType` to allow for people to properly be able to check if an object is a scripted class using `Std.isOfType` or the `is` operator.