### PR TITLE
Fix default Haxe types not being able to be constructed

### DIFF
--- a/polymod/hscript/_internal/Interp.hx
+++ b/polymod/hscript/_internal/Interp.hx
@@ -112,6 +112,11 @@ class Interp
 
   function cnew(cl:String, args:Array<Dynamic>):Dynamic
   {
+    if (defaultVariables.exists(cl))
+    {
+      return Type.createInstance(defaultVariables.get(cl), args);
+    }
+
     // Try to retrieve a scripted class with this name in the same package.
     if (getClassDecl().pkg != null && getClassDecl().pkg.length > 0)
     {


### PR DESCRIPTION
This PR fixes some Haxe types such as Array being unable to be initialized due to [this commit fixing security issues](https://github.com/FunkinCrew/polymod/commit/2e49c4975d155b1a78c8a1ad75c93fe8695f8143).

<img width="459" height="402" alt="image" src="https://github.com/user-attachments/assets/c9841eca-4d49-443f-87bf-e093754d2c8d" />
